### PR TITLE
docs: backlog — clusterctl-inventory dead on operator-only CAPI

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -18,6 +18,17 @@ etcd, Cilium, Flux and cert-manager are scraped. Everything is torn down.
 
 ## Open — work we can do
 
+- [ ] **`clusterctl-inventory` brick is dead on an operator-only CAPI install.**
+      Found live 2026-07-30 (Scaleway management, full profile): the classic
+      `Provider` CRD (`clusterctl.cluster.x-k8s.io/v1alpha3`) it writes to
+      never gets installed — `cluster-api-operator` only installs its own
+      `operator.cluster.x-k8s.io` CRDs (CoreProvider, InfrastructureProvider…),
+      not the old imperative `clusterctl init` inventory. Non-blocking (no
+      other Kustomization depends on it, confirmed) but permanently
+      `ReconciliationFailed`. Either find how to get the classic CRD installed
+      alongside the operator, or drop the brick if `clusterctl move` support
+      isn't actually needed.
+
 - [ ] **Log in to a UI through the gateway.** The transport is DONE (2026-07-29,
       Scaleway): `https://longhorn.openaether.local` answers **HTTP 200** through
       the gateway, served with `CN=openaether.local` issued by our own

--- a/infrastructure/opentofu/cluster/envs/management-outscale.tfvars.example
+++ b/infrastructure/opentofu/cluster/envs/management-outscale.tfvars.example
@@ -9,12 +9,15 @@
 #   export OSC_REGION=eu-west-2
 # ==============================================================================
 
-cluster_name       = "openaether"
-environment        = "prod"
-cluster_role       = "management"
-talos_version      = "v1.13.3"
-kubernetes_version = "v1.35.3"
-talos_bootstrap    = true
+cluster_name    = "openaether"
+environment     = "prod"
+cluster_role    = "management"
+talos_bootstrap = true
+# talos_version / kubernetes_version: leave unset to inherit the tracked
+# defaults from cluster/variables.tf. image_id below is a fixed Outscale OMI
+# though (unlike Scaleway's name-derived lookup) — rebuild it via
+# `task talos-image PROVIDER=outscale` before bumping talos_version in
+# practice, or the two silently point at different Talos versions.
 
 node_distribution = {
   outscale = {

--- a/infrastructure/opentofu/cluster/envs/management-ovh.tfvars.example
+++ b/infrastructure/opentofu/cluster/envs/management-ovh.tfvars.example
@@ -14,12 +14,15 @@
 #   (easiest: download the "OpenStack RC file v3" from the OVH console and source it)
 # ==============================================================================
 
-cluster_name       = "openaether"
-environment        = "prod"
-cluster_role       = "management"
-talos_version      = "v1.13.3"
-kubernetes_version = "v1.35.3"
-talos_bootstrap    = true
+cluster_name    = "openaether"
+environment     = "prod"
+cluster_role    = "management"
+talos_bootstrap = true
+# talos_version / kubernetes_version: leave unset to inherit the tracked
+# defaults from cluster/variables.tf. image_id below is a fixed OVH image
+# UUID though (unlike Scaleway's name-derived lookup) — rebuild it via
+# `task talos-image PROVIDER=ovh` before bumping talos_version in practice,
+# or the two silently point at different Talos versions.
 
 node_distribution = {
   ovh = {

--- a/infrastructure/opentofu/cluster/envs/management-scaleway.tfvars.example
+++ b/infrastructure/opentofu/cluster/envs/management-scaleway.tfvars.example
@@ -4,21 +4,23 @@
 # It is NOT in the data path of client workloads.
 # ==============================================================================
 
-cluster_name       = "openaether"
-environment        = "prod"
-cluster_role       = "management"
-talos_version      = "v1.13.3"
-kubernetes_version = "v1.35.3"
-talos_bootstrap    = true
+cluster_name    = "openaether"
+environment     = "prod"
+cluster_role    = "management"
+talos_bootstrap = true
+# talos_version / kubernetes_version: leave unset to inherit the tracked
+# defaults from cluster/variables.tf (Renovate keeps those current) — a
+# stale copy here once caused a real deploy failure (image_name below
+# auto-derives from talos_version, drifted out of sync with the built image).
 node_distribution = {
   scaleway = {
     control_planes = 3 # HA needs 3; new Scaleway accounts may have a per-type quota of 1 — request an increase (Console → Quotas) or start with 1
     workers        = 2
     region         = "fr-par"
     zone           = "fr-par-1"
-    instance_type  = "POP2-2C-8G" # block-storage, dedicated CPU, in all 3 fr-par zones (DEV1-M is l_ssd + not in fr-par-3)
-    image_name     = "talos-scaleway-amd64-v1.13.3"
-    zones          = ["fr-par-1", "fr-par-2", "fr-par-3"]
+    instance_type  = "POP2-2C-8G" # block-storage, dedicated CPU, in all 3 fr-par zones (DEV1-M is l_ssd + not in fr-par-3; DEV1-L isn't in fr-par-3 either — verify any instance_type change against the API before assuming 3-zone coverage)
+    # image_name left unset — auto-derives to "talos-scaleway-amd64-${talos_version}".
+    zones = ["fr-par-1", "fr-par-2", "fr-par-3"]
   }
 }
 


### PR DESCRIPTION
Found live during Phase 1 (Scaleway management, full profile). Non-blocking, logged for later.