### PR TITLE
docs: add missing grafana/db, zitadel/db, restic, longhorn seed paths

### DIFF
--- a/docs/admin-access.md
+++ b/docs/admin-access.md
@@ -44,6 +44,17 @@ bao kv put secret/observability/alertmanager-slack webhook-url=https://hooks.sla
 # Alertmanager will not start without it either. Slack-only? Then drop the
 # Watchdog route from vm-customresources/vmalert.yaml, deliberately.
 bao kv put secret/observability/alertmanager-deadmansswitch url=https://hc-ping.com/<uuid>
+# Also required (missed on a first pass, found live 2026-07-30): the CNPG app
+# DB passwords and Longhorn's volume-encryption passphrase. Without these the
+# grafana-db/zitadel-db Cluster still becomes Ready (bootstrap generates ITS
+# OWN placeholder if the secret is absent at initdb time) but the app can't
+# actually connect — auth fails silently until this is seeded AND the
+# Postgres role is aligned (ALTER ROLE ... WITH PASSWORD, once, if initdb
+# already ran with a different placeholder).
+bao kv put secret/grafana/db password=$(openssl rand -base64 24 | tr -d '=+/')
+bao kv put secret/zitadel/db username=zitadel password=$(openssl rand -base64 24 | tr -d '=+/')
+bao kv put secret/backup/restic password=$(openssl rand -base64 36 | tr -d '=+/')
+bao kv put secret/longhorn/encryption passphrase=$(openssl rand -base64 48 | tr -d '=+/')
 ```
 
 `s3-primary` feeds three mechanisms at once: restic, CNPG PITR and Longhorn


### PR DESCRIPTION
## Summary
The Day-1 OpenBao seeding runbook (`docs/admin-access.md`) only listed backup/observability paths. Found live seeding edge-3 (Outscale) 2026-07-30: the CNPG app DB passwords (`grafana/db`, `zitadel/db`) and Longhorn's encryption passphrase (`longhorn/encryption`) are ALSO required, plus the restic escrow password (`backup/restic`) was already required but not spelled out alongside the others.

Without them the Cluster still goes Ready (CNPG's bootstrap self-generates a placeholder value at initdb time if the secret is absent), but the app can't actually connect until the secret is seeded — and if initdb already ran, the already-initialized Postgres role also needs `ALTER ROLE ... WITH PASSWORD` to realign with the newly-seeded value.

## Test plan
- [x] `task lint` clean