### PR TITLE
fix: task up idempotency + real teardown verification

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -201,7 +201,20 @@ tasks:
     cmds:
       - ../../../scripts/internal/ensure-buckets.sh envs/{{.ROLE}}-{{.PROVIDER}}.tfvars
       - tofu init -reconfigure $(../../../scripts/internal/tf-backend.sh envs/{{.ROLE}}-{{.PROVIDER}}.tfvars)
-      - tofu apply -var-file="envs/{{.ROLE}}-{{.PROVIDER}}.tfvars" -var talos_bootstrap=false
+      - |
+        # Idempotency guard: control_plane_count/worker_count (cluster/main.tf) are
+        # gated by talos_bootstrap, so forcing =false here on an ALREADY-bootstrapped
+        # cluster zeroes them and drops talos_machine_bootstrap et al. from state —
+        # bootstrap-phase2 then recreates them, re-sending the bootstrap RPC against
+        # a live etcd, which Talos correctly refuses (AlreadyExists) and which also
+        # invalidates the kubeconfig output. Found live 2026-07-30 re-running `task
+        # up` for an idempotency test. Only a truly fresh cluster gets false.
+        if tofu state list 2>/dev/null | grep -q 'module.talos.talos_machine_bootstrap'; then
+          TB=true
+        else
+          TB=false
+        fi
+        tofu apply -var-file="envs/{{.ROLE}}-{{.PROVIDER}}.tfvars" -var talos_bootstrap=$TB
       - task: _backup-state
         vars: {PROVIDER: "{{.PROVIDER}}"}
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -24,6 +24,24 @@ and a full `task fleet-down` teardown. CI hardened (SHA-pinned actions/hooks,
 branch rulesets, object-collision gate) on both repos. Fleet is torn down;
 the `1.0.0` tag itself is deliberately deferred to a later session.
 
+2026-07-31: the two gaps the 2026-07-30 teardown had exposed are fixed and
+validated live, not just reasoned about — `task infra` no longer forces
+`talos_bootstrap=false` on an already-bootstrapped cluster (re-ran `task up`
+twice on a fresh Scaleway management: 0 changes on the second pass, node ages
+unchanged, kubeconfig intact), and `edge-down.sh` now re-checks the provider
+directly after the Kubernetes-level cascade instead of trusting it (new
+`scripts/ops/verify-provider-clean.py`). Proving that second fix live
+surfaced a THIRD real bug on the first try: an Octavia load balancer orphaned
+by the 2026-07-30 OVH teardown was silently reused by CAPO on the next
+`edge-2` deploy and broke it (stale VIP port, 404). Fixed live (scoped delete,
+`scripts/ops/delete-openstack-resource.py`) and now a permanent check in
+`verify-provider-clean.py`. Both fixes then proved on a full real cycle: fresh
+management → real OVH edge-2 deploy → `edge-down.sh` teardown (provider
+verified clean on the first pass) → full `fleet-down` (edge-3, never
+provisioned — blocked cleanly on missing Outscale credentials, no spend) →
+all 3 providers independently re-verified clean. Fleet is torn down again;
+`1.0.0` tag still pending.
+
 **Idempotency bilan (Phase 4, 2026-07-30):** CAPI provisioning, gitception
 injection and each child's own Flux reconciliation are genuinely automatic —
 no operator step once credentials exist. What is NOT: per-provider CAPI
@@ -31,45 +49,10 @@ credentials/keypairs (`kubectl create secret`, by hand, no `task` target);
 OVH's floating IP (scripted allocation, but the address is hand-copied into
 git); and OpenBao seeding (`bao kv put`, entirely manual per cluster, by
 design — secrets don't belong in git — but with real room for the ordering
-bug below). `task up`/`bootstrap-phase2` itself is NOT safely re-runnable
-against an already-bootstrapped cluster (see Open below).
+bug below). `task up`/`bootstrap-phase2` re-run safety against an
+already-bootstrapped cluster is fixed as of 2026-07-31, see above.
 
 ## Open — work we can do
-
-- [ ] **`edge-down.sh`'s CAPI cascade doesn't verify the infra provider actually
-      cleaned up its OWN network resources.** Found live 2026-07-30 on the
-      `task fleet-down` teardown: after `edge-down edge-2` reported success (0
-      machines left) and the management was destroyed, an independent check
-      against OVH found the `OpenStackCluster`'s network, subnet, router
-      (with a still-attached interface) and both security groups still
-      existed — CAPO's own controller apparently doesn't always finish
-      tearing these down within the script's wait window, and nothing
-      re-checks. Not billed on OVH, but real cruft that collides with a
-      future edge-2 redeploy. Cleaned up manually this session (remove the
-      router interface, delete router, network, security groups — see the
-      Neutron API calls in the session, or re-derive from `ensure-capo-fip.py`'s
-      auth pattern). Outscale showed a similar gap (one orphaned, BILLED
-      Elastic IP survived edge-3's teardown). `edge-down.sh` should verify
-      (not just wait-and-trust) that the provider's network objects are
-      actually gone before declaring success — same discipline as
-      `fleet-down.sh`'s own `FAILED` flag for the management destroy.
-
-- [ ] **`bootstrap-phase2` is not idempotent against an already-bootstrapped
-      cluster.** Found live 2026-07-30 re-running `task up` on the management
-      cluster to test idempotency: `talos_machine_bootstrap.this[0]` always
-      re-attempts the bootstrap RPC on `tofu apply -var talos_bootstrap=true`,
-      and Talos correctly refuses with `AlreadyExists: etcd data directory is
-      not empty` — but OpenTofu treats that as a resource error, failing the
-      whole apply. `task up`'s own description claims "every step above is
-      idempotent" — true for `infra`, false for `bootstrap-phase2`. Either
-      skip the resource when etcd is already healthy, or have the task target
-      tolerate this specific error as success.
-      ⚠️ Side effect, not just a clean failure: the failed apply also
-      invalidates the `kubeconfig` output/local file (empty after re-running
-      `tofu output -raw kubeconfig`) even though the cluster itself is
-      untouched (etcd/nodes verified healthy immediately after). Recovery
-      without re-running the broken apply: `talosctl -n <ip> -e <ip>
-      kubeconfig ./kubeconfig --force` against a live control-plane node.
 
 - [ ] **`clusterctl-inventory` brick is dead on an operator-only CAPI install.**
       Found live 2026-07-30 (Scaleway management, full profile): the classic
@@ -183,6 +166,20 @@ One line each; the detail lives in the referenced file.
   notices; a replica JOIN calling `restore_command` blocks forever instead of
   erroring — found live on edge-3 2026-07-30, apps repo
   `cnpg/networkpolicy-db-restricted.yaml`.
+- **A resource-count driven by a phase variable is not idempotent** — gating
+  `module.talos`'s `control_plane_count`/`worker_count` on `var.talos_bootstrap`
+  meant every re-run of `task infra` (talos_bootstrap=false, part of `task up`)
+  zeroed them and dropped `talos_machine_bootstrap` from state, which then got
+  RECREATED by `bootstrap-phase2` — re-sending the bootstrap RPC to a live
+  etcd. Fixed by reading `tofu state list` first (`Taskfile.yml`'s `infra`
+  task) instead of always forcing the phase-1 value.
+- **CAPO reuses an Octavia LB by NAME on the next deploy — a leftover isn't
+  just cruft, it silently breaks the redeploy.** A `kubeapi` LB orphaned by a
+  prior `edge-down` (its VIP port's network long gone) got picked up by CAPO
+  on the next `edge-2` apply instead of a fresh one being created; the FIP↔port
+  association then 404s forever with no error surfaced to Flux. `edge-down.sh`
+  now re-verifies the provider directly after the Kubernetes-level cascade
+  (`verify-provider-clean.py`, checks LBs too) instead of trusting it blindly.
 - **Seed OpenBao app-DB secrets BEFORE the CNPG cluster's first `initdb`** —
   seeding late doesn't stop the Cluster going Ready (bootstrap self-generates
   a placeholder), it just leaves the live Postgres role's password out of

--- a/scripts/ops/delete-openstack-resource.py
+++ b/scripts/ops/delete-openstack-resource.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Delete ONE OpenStack/OVH resource by its exact ID — the scoped alternative
+to purge-orphans/ovh.py (whole account, no filtering) for when a SPECIFIC
+leftover is already identified (e.g. via verify-provider-clean.py) and other
+resources on the account must NOT be touched (a live redeploy in progress).
+
+Usage:
+    source .env.sh
+    python3 scripts/ops/delete-openstack-resource.py loadbalancer <id>
+    python3 scripts/ops/delete-openstack-resource.py router|network|security-group|port|floatingip <id>
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+RESOURCE_PATHS = {
+    "loadbalancer": ("load-balancer", "/v2.0/lbaas/loadbalancers/{id}?cascade=true"),
+    "router": ("network", "/v2.0/routers/{id}"),
+    "network": ("network", "/v2.0/networks/{id}"),
+    "security-group": ("network", "/v2.0/security-groups/{id}"),
+    "port": ("network", "/v2.0/ports/{id}"),
+    "floatingip": ("network", "/v2.0/floatingips/{id}"),
+}
+
+
+def keystone_token() -> tuple[str, list]:
+    base = os.environ["OS_AUTH_URL"].rstrip("/")
+    url = base + ("/auth/tokens" if base.endswith("/v3") else "/v3/auth/tokens")
+    auth = {
+        "auth": {
+            "identity": {
+                "methods": ["password"],
+                "password": {
+                    "user": {
+                        "name": os.environ["OS_USERNAME"],
+                        "password": os.environ["OS_PASSWORD"],
+                        "domain": {"name": os.environ.get("OS_USER_DOMAIN_NAME", "Default")},
+                    }
+                },
+            },
+            "scope": {"project": {"id": os.environ["OS_PROJECT_ID"]}},
+        }
+    }
+    req = urllib.request.Request(
+        url, data=json.dumps(auth).encode(), headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.headers["X-Subject-Token"], json.load(resp)["token"]["catalog"]
+
+
+def main() -> int:
+    if len(sys.argv) != 3 or sys.argv[1] not in RESOURCE_PATHS:
+        print(f"usage: delete-openstack-resource.py {{{'|'.join(RESOURCE_PATHS)}}} <id>", file=sys.stderr)
+        return 2
+    kind, rid = sys.argv[1], sys.argv[2]
+    service_type, path_tpl = RESOURCE_PATHS[kind]
+
+    token, catalog = keystone_token()
+    region = os.environ["OS_REGION_NAME"].lower()
+    endpoint = next(
+        e["url"]
+        for s in catalog
+        if s["type"] == service_type
+        for e in s["endpoints"]
+        if e["interface"] == "public" and e["region"].lower() == region
+    ).rstrip("/")
+
+    req = urllib.request.Request(
+        endpoint + path_tpl.format(id=rid),
+        headers={"X-Auth-Token": token},
+        method="DELETE",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=90)
+    except urllib.error.HTTPError as e:
+        print(f"✗ delete failed: {e.code} {e.read().decode()[:200]}", file=sys.stderr)
+        return 1
+    print(f"✓ deleted {kind} {rid}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/edge-down.sh
+++ b/scripts/ops/edge-down.sh
@@ -37,6 +37,8 @@ warn() { printf '⚠ %s\n' "$*" >&2; }
 # ⚠️ Always qualify `clusters.cluster.x-k8s.io`: the `Cluster` kind is also
 # CNPG's (postgresql.cnpg.io). Without the CAPI CRDs installed, an unqualified
 # `kubectl delete cluster <name>` would target a DATABASE.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
 command -v kubectl >/dev/null 2>&1 || { echo "✗ kubectl required" >&2; exit 1; }
 kubectl cluster-info >/dev/null 2>&1 || { echo "✗ KUBECONFIG points at no reachable cluster" >&2; exit 1; }
 
@@ -49,6 +51,18 @@ fi
 mapfile -t MACHINES < <(kubectl get machines -n "$NS" \
   -l "cluster.x-k8s.io/cluster-name=$CLUSTER" -o name 2>/dev/null)
 info "Cluster '$CLUSTER' (ns $NS): ${#MACHINES[@]} machine(s) to destroy"
+
+# Which infra provider this cluster is on — needed AFTER deletion (step 4) to
+# know which API to re-check, so it must be captured now, before the objects
+# that reveal it disappear.
+PROVIDER=""
+for kp in "openstackcluster:openstack" "osccluster:outscale" "scalewaycluster:scaleway"; do
+  kind="${kp%%:*}"; prov="${kp##*:}"
+  if kubectl get "$kind" -n "$NS" -o name 2>/dev/null | grep -q -- "$CLUSTER"; then
+    PROVIDER="$prov"
+    break
+  fi
+done
 
 if [ "$ASSUME_YES" -eq 0 ]; then
   read -rp "Permanently destroy '$CLUSTER' and its VMs? [y/N] " a
@@ -87,6 +101,43 @@ while (( SECONDS < deadline )); do
   mach=$(kubectl get machines -n "$NS" -l "cluster.x-k8s.io/cluster-name=$CLUSTER" \
            --no-headers 2>/dev/null | wc -l)
   if [ "$left" = 0 ] && [ "$mach" = 0 ]; then
+    ok "cluster '$CLUSTER' Kubernetes objects gone"
+
+    # 4. The Kubernetes-level signal above is NOT proof the provider finished:
+    # CAPO/CAPOSC's own network cleanup can lag past the object's own deletion
+    # (found live 2026-07-30 — OVH network/router/SGs and a billed Outscale EIP
+    # both survived a "fully deleted" report). Re-check the provider directly;
+    # retry a few times before failing, since this is a real async cascade, not
+    # necessarily a stuck one.
+    VERIFY="$ROOT/scripts/ops/verify-provider-clean.py"
+    if [ -n "$PROVIDER" ] && [ -f "$VERIFY" ]; then
+      info "Vérification côté provider ($PROVIDER)…"
+      for attempt in 1 2 3 4; do
+        OUT="$(python3 "$VERIFY" "$CLUSTER" "$PROVIDER" 2>&1)"; rc=$?
+        case $rc in
+          0) ok "cluster '$CLUSTER' fully deleted (provider verified clean)"; exit 0 ;;
+          2) warn "provider verification skipped: $OUT"
+             ok "cluster '$CLUSTER' Kubernetes objects gone (provider NOT re-checked)"
+             exit 0 ;;
+        esac
+        warn "attempt $attempt/4: $PROVIDER still has resources for '$CLUSTER', retrying in 20s…"
+        sleep 20
+      done
+      printf '%s\n' "$OUT" >&2
+      cat >&2 <<EOT
+
+✗ the Kubernetes-level cascade finished but $PROVIDER still has resources
+  tagged '$CLUSTER' (listed above) after 4 checks (~80s) — CAPO/CAPOSC's own
+  cleanup did not finish. Purge by hand, ONE resource at a time (a leftover
+  Octavia LB alone breaks the NEXT redeploy — found live 2026-07-31):
+    python3 scripts/ops/delete-openstack-resource.py <kind> <id>
+  scripts/ops/purge-orphans/ also works but is WHOLE-ACCOUNT (no name
+  filtering) — never run it while another cluster is live on the same
+  provider. Then re-run: this script is idempotent and will report clean
+  once they are gone.
+EOT
+      exit 1
+    fi
     ok "cluster '$CLUSTER' fully deleted"
     exit 0
   fi

--- a/scripts/ops/purge-orphans/README.md
+++ b/scripts/ops/purge-orphans/README.md
@@ -7,7 +7,10 @@ edge-down` / `task destroy`, which delete cleanly **and** update the state.
 
 These scripts talk to the provider API directly: they ignore the OpenTofu state
 and do not update it. They target the WHOLE project, not one cluster — only run
-them on an account whose expected contents you know.
+them on an account whose expected contents you know. If another cluster is
+live on the same provider, or you already know the exact resource(s) to
+remove (e.g. from `verify-provider-clean.py`'s output), use the scoped
+`../delete-openstack-resource.py <kind> <id>` instead — it touches nothing else.
 
 ```bash
 source .env.sh

--- a/scripts/ops/purge-orphans/ovh.py
+++ b/scripts/ops/purge-orphans/ovh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Purges the OVH resources left behind by an orphaned CAPI cluster.
-Targets everything carrying the given prefix (default: k8s-clusterapi / edge-).
+"""Purges ALL OVH project resources (servers, LBs, FIPs, routers, networks,
+security groups) — whole-account, no name filtering. See README.md.
 Usage: purge-orphans-ovh.py [--apply]   (dry-run by default)"""
 import os, sys, json, urllib.request
 

--- a/scripts/ops/verify-provider-clean.py
+++ b/scripts/ops/verify-provider-clean.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Read-only check: does the provider still have resources for a CAPI child
+cluster after edge-down.sh's Kubernetes-level cascade reports the Cluster and
+its Machines gone?
+
+That Kubernetes-level signal is NOT sufficient — found live 2026-07-30 on a
+real `task fleet-down`: after edge-down reported edge-2 fully deleted, OVH
+still had the cluster's network/subnet/router/security-groups, and Outscale
+had left one billed, unassociated Elastic IP from edge-3. CAPO/CAPOSC's own
+controller does not always finish its provider-side cleanup within the
+Kubernetes object's finalizer window. This script re-checks the provider
+directly instead of trusting that silence means clean.
+
+Never deletes anything — see scripts/ops/purge-orphans/ for that (whole
+account, deliberately manual, not safe to call unattended from here).
+
+Exit codes: 0 clean, 1 leftovers found (printed to stdout), 2 could not verify
+(missing credentials / unsupported provider — printed to stderr).
+
+Usage:
+    source .env.sh
+    python3 scripts/ops/verify-provider-clean.py <cluster> openstack|outscale|scaleway
+"""
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def openstack_leftovers(cluster: str) -> list[str]:
+    base = os.environ["OS_AUTH_URL"].rstrip("/")
+    url = base + ("/auth/tokens" if base.endswith("/v3") else "/v3/auth/tokens")
+    auth = {
+        "auth": {
+            "identity": {
+                "methods": ["password"],
+                "password": {
+                    "user": {
+                        "name": os.environ["OS_USERNAME"],
+                        "password": os.environ["OS_PASSWORD"],
+                        "domain": {"name": os.environ.get("OS_USER_DOMAIN_NAME", "Default")},
+                    }
+                },
+            },
+            "scope": {"project": {"id": os.environ["OS_PROJECT_ID"]}},
+        }
+    }
+    req = urllib.request.Request(
+        url, data=json.dumps(auth).encode(), headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        token, catalog = resp.headers["X-Subject-Token"], json.load(resp)["token"]["catalog"]
+    region = os.environ["OS_REGION_NAME"].lower()
+    headers = {"X-Auth-Token": token}
+
+    def ep(service_type: str) -> str:
+        return next(
+            e["url"]
+            for s in catalog
+            if s["type"] == service_type
+            for e in s["endpoints"]
+            if e["interface"] == "public" and e["region"].lower() == region
+        ).rstrip("/")
+
+    def get(path: str):
+        return json.load(urllib.request.urlopen(urllib.request.Request(path, headers=headers), timeout=60))
+
+    net, comp = ep("network"), ep("compute")
+    leftovers = []
+    for s in get(comp + "/servers")["servers"]:
+        if cluster in s["name"]:
+            leftovers.append(f"server {s['name']}")
+    # Found live 2026-07-31: an Octavia LB from a PRIOR teardown survived, its
+    # apiserver kubeapi LB referencing a since-deleted network's VIP port. CAPO
+    # reuses an existing LB by NAME on the next deploy rather than recreating
+    # it, so the leak isn't just cruft — it silently breaks the next redeploy
+    # (FIP-to-port association 404s forever, no CAPO error surfaced to Flux).
+    try:
+        lb_ep = ep("load-balancer")
+        for lb in get(lb_ep + "/v2.0/lbaas/loadbalancers")["loadbalancers"]:
+            if cluster in lb["name"]:
+                leftovers.append(f"load-balancer {lb['name']}")
+    except StopIteration:
+        pass
+    for n in get(net + "/v2.0/networks")["networks"]:
+        if cluster in n["name"]:
+            leftovers.append(f"network {n['name']}")
+    for r in get(net + "/v2.0/routers")["routers"]:
+        if cluster in r["name"]:
+            leftovers.append(f"router {r['name']}")
+    for g in get(net + "/v2.0/security-groups")["security_groups"]:
+        if cluster in g["name"]:
+            leftovers.append(f"security-group {g['name']}")
+    return leftovers
+
+
+def outscale_leftovers(cluster: str) -> list[str]:
+    ak, sk = os.environ["OUTSCALE_ACCESS_KEY_ID"], os.environ["OUTSCALE_SECRET_KEY"]
+    region = os.environ.get("OSC_REGION", os.environ.get("OUTSCALE_REGION", "eu-west-2"))
+    host = f"api.{region}.outscale.com"
+
+    def call(action: str, payload: dict | None = None) -> dict:
+        body = json.dumps(payload or {})
+        t = datetime.datetime.now(datetime.timezone.utc)
+        amzdate, datestamp = t.strftime("%Y%m%dT%H%M%SZ"), t.strftime("%Y%m%d")
+        canonical = (
+            f"POST\n/api/v1/{action}\n\ncontent-type:application/json\nhost:{host}\n"
+            f"x-amz-date:{amzdate}\n\ncontent-type;host;x-amz-date\n"
+            + hashlib.sha256(body.encode()).hexdigest()
+        )
+        scope = f"{datestamp}/{region}/api/aws4_request"
+        to_sign = f"AWS4-HMAC-SHA256\n{amzdate}\n{scope}\n" + hashlib.sha256(canonical.encode()).hexdigest()
+        k = f"AWS4{sk}".encode()
+        for part in (datestamp, region, "api", "aws4_request"):
+            k = hmac.new(k, part.encode(), hashlib.sha256).digest()
+        sig = hmac.new(k, to_sign.encode(), hashlib.sha256).hexdigest()
+        req = urllib.request.Request(
+            f"https://{host}/api/v1/{action}",
+            data=body.encode(),
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-Amz-Date": amzdate,
+                "Authorization": (
+                    f"AWS4-HMAC-SHA256 Credential={ak}/{scope}, "
+                    "SignedHeaders=content-type;host;x-amz-date, "
+                    f"Signature={sig}"
+                ),
+            },
+        )
+        return json.load(urllib.request.urlopen(req, timeout=60))
+
+    leftovers = []
+    for vm in call("ReadVms").get("Vms", []):
+        if vm.get("State") != "terminated":
+            name = next((t["Value"] for t in vm.get("Tags", []) if t["Key"] == "Name"), "")
+            leftovers.append(f"vm {vm.get('VmId')} ({name or 'untagged'}, {vm.get('State')})")
+    # No reliable cluster-name tag survives on a leaked EIP (that's how one leaked
+    # live on 2026-07-30) — this account carries a single Outscale cluster, so ANY
+    # unassociated EIP is a leftover. Revisit this check if a second Outscale
+    # cluster is ever added (would need per-cluster tagging upstream first).
+    for ip in call("ReadPublicIps").get("PublicIps", []):
+        if not ip.get("VmId") and not ip.get("LinkPublicIpId"):
+            leftovers.append(f"unassociated EIP {ip.get('PublicIp')}")
+    return leftovers
+
+
+CHECKS = {"openstack": openstack_leftovers, "outscale": outscale_leftovers}
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: verify-provider-clean.py <cluster> openstack|outscale|scaleway", file=sys.stderr)
+        return 2
+    cluster, provider = sys.argv[1], sys.argv[2]
+
+    check = CHECKS.get(provider)
+    if check is None:
+        print(f"no provider-side check implemented for '{provider}'", file=sys.stderr)
+        return 2
+
+    try:
+        leftovers = check(cluster)
+    except KeyError as e:
+        print(f"missing credential {e} — source .env.sh first", file=sys.stderr)
+        return 2
+    except (urllib.error.URLError, urllib.error.HTTPError) as e:
+        print(f"could not reach the {provider} API: {e}", file=sys.stderr)
+        return 2
+
+    if not leftovers:
+        return 0
+    for item in leftovers:
+        print(item)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `task infra` no longer forces `talos_bootstrap=false` unconditionally — only on a genuinely fresh cluster (checked via `tofu state list`). Fixes a real bug where every `task up` re-run zeroed the Talos module's node counts, dropped `talos_machine_bootstrap` from state, and got it recreated — re-sending the bootstrap RPC against a live etcd (rejected) and invalidating the local kubeconfig.
- `edge-down.sh` now verifies directly against the provider (new `scripts/ops/verify-provider-clean.py`, with retries) that OVH/Outscale actually finished their own cleanup, instead of trusting the Kubernetes-level cascade alone.
- New scoped `scripts/ops/delete-openstack-resource.py` (single resource by ID) as the safe alternative to the whole-account `purge-orphans/` scripts when another cluster is live on the same provider.
- `docs/backlog.md` updated: closed the two now-fixed Open items, documented the new findings.

## Validated live (2026-07-30/31, real cloud)
- Fresh Scaleway management deploy, then `task up` re-run twice: second run is a clean no-op (`No changes` on both `tofu apply`s), node ages unchanged, kubeconfig intact.
- `verify-provider-clean.py` tested against real OVH/Outscale in both states: clean (exit 0) and with real leftovers correctly listed (exit 1).
- Real OVH edge-2 deploy → `edge-down.sh` teardown → provider verified clean on the first pass, independently re-confirmed.
- While validating, found and fixed a third real bug live: an Octavia LB orphaned by a prior teardown was silently reused by CAPO on the next deploy and broke it (stale VIP port, 404 on FIP association) — now a permanent check in `verify-provider-clean.py`.
- Full `fleet-down` afterward: edge-3 (never provisioned, missing Outscale creds — no spend) + management, all 3 providers independently re-verified clean.

## Test plan
- [x] Fresh management deploy + idempotent re-run (real Scaleway)
- [x] Real OVH edge-2 deploy + edge-down.sh teardown with provider verification
- [x] Full fleet-down + independent 3-provider clean check
- [x] pre-commit hooks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)