### PR TITLE
docs: no real environment data in this public repo

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,11 +1,13 @@
-# The commit this key lived in (91bd7b53) is no longer part of main's
-# history (see "archive: Pulumi-era prototype (squashed)") but stays
-# reachable via pre-existing tags (0.1.0-0.4.0, archive/pre-cleanup-*) — a
-# full clone still fetches those, so gitleaks still finds it. See the repo's
-# own discussion for whether/how those tags get cleaned up separately.
-91bd7b53e81aa694f9c671c43219ea7e3ead3728:apps/base/linkerd/linkerd-control-plane.yaml:kubernetes-secret-yaml:1945
-91bd7b53e81aa694f9c671c43219ea7e3ead3728:apps/base/linkerd/linkerd-control-plane.yaml:private-key:127
-91bd7b53e81aa694f9c671c43219ea7e3ead3728:apps/base/linkerd/linkerd-control-plane.yaml:private-key:172
-91bd7b53e81aa694f9c671c43219ea7e3ead3728:apps/base/linkerd/linkerd-control-plane.yaml:private-key:466
-91bd7b53e81aa694f9c671c43219ea7e3ead3728:apps/base/linkerd/linkerd-control-plane.yaml:private-key:781
-91bd7b53e81aa694f9c671c43219ea7e3ead3728:apps/base/linkerd/linkerd-control-plane.yaml:private-key:1946
+# Self-signed, CLI-generated Linkerd identity/webhook certs from an
+# abandoned prototype — never a real secret, never live (apps/base/linkerd/
+# is absent from current HEAD; only reachable via old tags 0.1.0-0.4.0 /
+# archive/pre-cleanup-*, which a full clone still fetches, so gitleaks still
+# finds it). Commit hash updated 2026-07-31 after a git-filter-repo history
+# rewrite (unrelated leak, real IPs — see CHANGELOG/backlog); content and
+# line numbers are unchanged, only the commit hash moved (91bd7b53 -> 00a81a49).
+00a81a496120ab4627b02f481b5d9a8da46f1a1b:apps/base/linkerd/linkerd-control-plane.yaml:kubernetes-secret-yaml:1945
+00a81a496120ab4627b02f481b5d9a8da46f1a1b:apps/base/linkerd/linkerd-control-plane.yaml:private-key:127
+00a81a496120ab4627b02f481b5d9a8da46f1a1b:apps/base/linkerd/linkerd-control-plane.yaml:private-key:172
+00a81a496120ab4627b02f481b5d9a8da46f1a1b:apps/base/linkerd/linkerd-control-plane.yaml:private-key:466
+00a81a496120ab4627b02f481b5d9a8da46f1a1b:apps/base/linkerd/linkerd-control-plane.yaml:private-key:781
+00a81a496120ab4627b02f481b5d9a8da46f1a1b:apps/base/linkerd/linkerd-control-plane.yaml:private-key:1946

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,17 @@ Provisioning bare-metal / cloud + Talos (OpenTofu). Les manifests communs et le
 wiring Flux vivent dans `OpenAether-apps` ; les manifests **métier** dans chaque
 repo applicatif.
 
+## Dépôt public — aucune donnée réelle
+
+Ce dépôt est **public**. N'y committer que du code et des exemples — jamais une
+IP, un ID de compte cloud, ou toute autre donnée propre à un environnement ou un
+test réels. Pattern déjà en place : `envs/*.tfvars` (réel) est gitignore, seul
+`*.tfvars.example` (placeholders `YOUR_IP`, etc.) est public. Incident du
+2026-07-31 : des IP réelles (FIP OVH, egress management, IP admin) avaient fui
+dans `OpenAether-apps` et ont nécessité une purge d'historique (`git
+filter-repo`, `--replace-text` ET `--replace-message` — les messages de commit
+ne sont PAS couverts par le premier seul).
+
 ## Objectif produit — socle Talos modulaire, management CAPI optionnel
 
 OpenAether déploie **un cluster Talos** sur **n'importe quel provider** (Proxmox ou


### PR DESCRIPTION
## Summary
Codifies the 2026-07-31 incident as a standing CLAUDE.md rule: real IPs (OVH floating IPs, management NAT egress, an admin CIDR) and a real Outscale account ID had leaked into `OpenAether-apps`' `apps/clusters/edge-{2,3}.yaml` and both repos' git history. Fixed (moved to a kubectl Secret + `substituteFrom`) and history purged (`git filter-repo`, both `--replace-text` and `--replace-message` — commit messages aren't covered by the first alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)