### PR TITLE
docs: three broken links, two stale claims, and a check that could not see them

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -5,8 +5,9 @@ description: How to cut an OpenAether release — what has to be proven first, t
 
 # Cutting a release
 
-The authority is [`docs/release-checklist.md`](../../../docs/release-checklist.md):
-run it, do not summarise it. This is only what the checklist cannot tell you.
+The authority is `docs/release-checklist.md` in OpenAether-infra — run it, do
+not summarise it. It is not linked relatively here because this skill is shared
+with OpenAether-apps, which has no such file. This is only what the checklist cannot tell you.
 
 ## A version number is a claim
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -21,12 +21,19 @@ from a green pipeline: a reboot renamed nodes on every provider (the images are
 `metal` builds, the names came from DHCP); a routine apply after an upgrade
 proposed replacing all three control planes at once; `task test` deleted the
 operator's kubeconfig; OVH was never idempotent; a worker could never be upgraded
-in place; no node could be fully drained; and a tfvars backup was not gitignored.
+in place; a node could not be fully drained; and a tfvars backup was not
+gitignored.
 The upgrade path itself is the headline — 1.0.0 shipped it unverified.
 
-Still open and deliberately not fixed for 1.0.0: the PodDisruptionBudgets that
-make a node undrainable (OpenAether-apps), the two applies a version bump needs,
-and the Outscale image lane that cannot replace an image. All below.
+Since then, on the same day: a node CAN be fully drained. istiod ran a single
+replica under a budget requiring one, which is what pinned it; with two, a worker
+drained clean — exit 0, zero non-DaemonSet pods left, about a minute while
+OpenBao's raft quorum settled. The six other zero-disruption budgets are correct
+and transient.
+
+Still open: the two applies a version bump needs, and the Outscale image lane,
+which cannot replace an image for a reason now measured rather than guessed —
+`create_before_destroy` was tried and reverted. Both below.
 
 Alerting exists and is proven end to end: 19 rules, a real alert delivered to
 Slack from a Scaleway cluster, and a `Watchdog` whose silence is the signal.

--- a/docs/deployment-test-matrix.md
+++ b/docs/deployment-test-matrix.md
@@ -8,7 +8,7 @@
 > of the file.
 >
 > ✅ apply-tested · 🎭 emulated (Feint: real provider, real HTTP, no account) ·
-> 🧪 unit-tested only (mocked) · ⬜ untested. Reviewed 2026-07-28.
+> 🧪 unit-tested only (mocked) · ⬜ untested. Reviewed 2026-08-13.
 
 ## Mental model
 
@@ -96,7 +96,7 @@ Two orthogonal layers of knobs:
 
 | ID | Role | CP/W | k8s_lb_mode | Uniquely exercises | Status |
 |---|---|---|---|---|---|
-| `OSC-mgmt-ha` | mgmt | 3+2 | managed | LB returns a **DNS name**, not an IP; outscale SSH user. | ✅ |
+| `OSC-mgmt-ha` | mgmt | 3+1 | managed | LB returns a **DNS name**, not an IP; outscale SSH user. 3+3 does not fit the 40 GB RAM quota, so HA here means the control plane only. | ✅ *(2026-08-13, incl. Kubernetes and Talos upgrades in place)* |
 | `OSC-work-ha` | workload | 3+3 | managed | Workload role; BSU volumes if paired with storage. | ⬜ |
 | `OSC-vip-reject` | — | any | vip | Negative test: validation must reject `vip`. | 🧪 |
 

--- a/infrastructure/opentofu/cluster/README.md
+++ b/infrastructure/opentofu/cluster/README.md
@@ -33,7 +33,7 @@ tofu apply -var-file=envs/<cluster>.tfvars
 ### Provider Contract
 
 Every provider module in `modules/providers/<name>/` must implement the
-[provider contract](modules/providers/provider-contract.md). The root module's
+[provider contract](../modules/providers/provider-contract.md). The root module's
 junction point uses `coalesce()` to select the active provider's outputs.
 
 **Adding a new provider = implementing the contract interface.** The Talos module
@@ -140,7 +140,7 @@ Only the `*.tfvars.example` templates are versioned. Copy an example to its real
 credentials never get committed.
 
 > Local Docker testing (3 CP + 2 workers) is **not** an env file here — it lives in
-> [`../opentofu-local`](../opentofu-local) (its own root, `TF_VAR_`-driven).
+> [`../../opentofu-local`](../../opentofu-local) (its own root, `TF_VAR_`-driven).
 
 ## Workflow
 

--- a/scripts/dev/check-skill-parity.sh
+++ b/scripts/dev/check-skill-parity.sh
@@ -48,6 +48,23 @@ if ! diff -q "$MANIFEST" "$SIBLING/.claude/skills/SHARED" >/dev/null 2>&1; then
   echo "  ✗ the SHARED manifests themselves differ"; drift=1
 fi
 
+# A shared skill must also be VALID where it is copied: a relative link to a file
+# only one repository has passes a byte-for-byte comparison and is still broken on
+# the other side. That happened to docs/release-checklist.md.
+while IFS= read -r name; do
+  [[ -n "$name" && "$name" != \#* ]] || continue
+  for side in "$HERE" "$SIBLING"; do
+    f="$side/.claude/skills/$name/SKILL.md"
+    [[ -f "$f" ]] || continue
+    while read -r target; do
+      [[ -n "$target" ]] || continue
+      [[ -e "$(dirname "$f")/${target%%#*}" ]] || {
+        echo "  ✗ $name links $target, which does not exist in $(basename "$side")"; drift=1; }
+    done < <(grep -oE '\]\([^)#][^)]*\)' "$f" | sed -E 's/^\]\(//; s/\)$//' \
+             | grep -vE '^(https?:|mailto:)')
+  done
+done < "$MANIFEST"
+
 if [[ $drift -eq 1 ]]; then
   echo "✗ skills have drifted. They are duplicated on purpose — change both." >&2
   exit 1


### PR DESCRIPTION
Auditing the markdown rather than trusting it, after a session that changed a lot
of what the repository asserts.

## Three relative links pointed at nothing

`cluster/README.md` linked the provider contract and `opentofu-local` from the
wrong depth — both predate today. The third was introduced with the skills: the
`release` skill linked `docs/release-checklist.md` relatively, which resolves
here and **not** in OpenAether-apps, where the same skill is duplicated. It names
the file now instead of linking it, and says why.

## The parity check could not have caught that

It compared the two copies to each other, so a link valid on one side and broken
on the other passed byte for byte — a check that could not fail for the case it
most needed to. It now resolves every relative link in a shared skill against
**both** repositories.

Seen red by reinstating the exact link just removed:

```
✗ release links ../../../docs/release-checklist.md, which does not exist in OpenAether-apps
✗ skills have drifted. They are duplicated on purpose — change both.
```

green after restoring it.

## Two claims had gone stale, one of them hours old

- `docs/backlog.md` "Where we stand" still said no node could be fully drained
  and listed the PodDisruptionBudgets as open, after that entry was closed by
  measurement the same afternoon — the summary contradicting its own body.
- `docs/deployment-test-matrix.md` still read "Reviewed 2026-07-28", with
  `OSC-mgmt-ha` at 3+2 when Outscale runs 3+1 (3+3 does not fit its 40 GB RAM
  quota), and without the Kubernetes and Talos upgrades it has since had.

## Checked across both repositories

No French outside `*.fr.md`; every translated pair cross-links; every skill's
frontmatter names its own directory; no broken relative link anywhere.

Pairs with dis-bzh/OpenAether-apps#30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM