### PR TITLE
feat(ci): an unattended lane that can actually start, and covers what it claims

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -4,8 +4,8 @@
 # Claude Code on the web sessions.
 #
 # Requires the environment's network policy to allow outbound access to the
-# tool download domains (get.opentofu.org, talos.dev, dl.k8s.io, taskfile.dev,
-# github.com, pypi.org, ...). If egress is blocked, the installs below fail.
+# tool download domains (get.opentofu.org, talos.dev, dl.k8s.io, github.com,
+# pypi.org, ...). If egress is blocked, the installs below fail.
 set -euo pipefail
 
 # root in the remote environment, sudo elsewhere.
@@ -24,25 +24,7 @@ cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 #    non-interactively.
 printf 'y\n' | ./scripts/setup.sh
 
-# 2. tflint — used by `task lint` but not covered by setup.sh. Idempotent.
-if ! command -v tflint >/dev/null 2>&1; then
-  echo "Installing tflint..."
-  tmp="$(mktemp)"
-  trap 'rm -f "$tmp"' RETURN
-  # Pinned + checksum-verified, like every other download in this repository.
-  # This used to fetch install_linux.sh from `master` and run it: a moving remote
-  # script, executed at session start, in the environment that holds the
-  # credentials. CI pins the action by SHA; the tool it installs was `latest`.
-  # renovate: datasource=github-releases depName=terraform-linters/tflint
-  TFLINT_VERSION="v0.64.0"
-  base="https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}"
-  d="$(mktemp -d)"
-  curl -fsSL -o "$d/tflint_linux_amd64.zip" "$base/tflint_linux_amd64.zip"
-  curl -fsSL -o "$d/checksums.txt"          "$base/checksums.txt"
-  ( cd "$d" && grep ' tflint_linux_amd64.zip$' checksums.txt | sha256sum -c - )
-  unzip -q -o "$d/tflint_linux_amd64.zip" -d "$d"
-  $SUDO_CMD install -m 0755 "$d/tflint" /usr/local/bin/tflint
-  rm -rf "$d"
-fi
+# 2. tflint — setup.sh installs it now, through the same pinned installer CI
+# uses. This copy was the third place the same download was written out by hand.
 
 echo "✅ Toolchain ready (tofu, talosctl, kubectl, yamllint, tflint, task, flux)."

--- a/.claude/skills/cluster-upgrade/SKILL.md
+++ b/.claude/skills/cluster-upgrade/SKILL.md
@@ -5,7 +5,9 @@ description: Upgrading Kubernetes and Talos on a live OpenAether cluster without
 
 # Upgrading a live cluster
 
-`docs/release-checklist.md` §7 is the procedure. This is the reasoning behind it.
+`docs/upgrade.md` is the procedure, and `scripts/dev/staging-upgrade.sh` is that
+same procedure unattended — if the two disagree, the script wins, it is the one
+that runs. This is the reasoning behind both.
 
 ## Upgrade in place; do not replace the node
 
@@ -23,12 +25,20 @@ intermediate state, because one moves before the other. `versions-guard.tf`
 refuses an unsupported pair and refuses a Talos minor it has never heard of —
 extend its map from the upstream matrix rather than widening it.
 
-## Expect two applies
+## Expect two applies, and know why
 
 Bumping `talos_version` and applying puts the new installer into the machine
 configs; nothing reboots yet. That first apply fails once with "Provider produced
-inconsistent final plan" on OVH and Outscale. Run it again. It is a known open
-item, not a sign you did something wrong.
+inconsistent final plan" on OVH and Outscale. Run it again.
+
+Not a sign you did something wrong, and no longer a mystery: upstream
+`siderolabs/terraform-provider-talos` #352. When `machine_configuration_input` is
+unknown at plan time, the provider keeps the old `machine_configuration_hash` in
+the plan and recomputes it at apply. The second run works because the first
+resolved whatever was unknown. Fixed upstream in the 0.12.0 pre-release line
+only — we pin 0.11.0, the newest stable. **Do not "fix" it locally without
+proving the fix on a real cloud**, and do not add a retry: `staging-upgrade.sh`
+deliberately has none, because a retry turns the defect green.
 
 ## What to watch, beyond "it came back"
 
@@ -44,10 +54,16 @@ item, not a sign you did something wrong.
   and the running version have disagreed, and that plan would take the cluster
   down.
 
-## The drain does not finish, and that is known
+## A stuck drain is one budget's fault, not the stack's
 
-Several PodDisruptionBudgets permit no eviction — CNPG guards each cluster's
-primary until a switchover, Longhorn blocks while volumes are attached. The
-script reports the stuck drain, waits out its timeout and continues, so the node
-reboots with those pods aboard. Nothing observable has broken, but "drained
-before reboot" is not a property this project can claim yet. See the backlog.
+A worker drains clean — measured 2026-08-13, exit 0, zero non-DaemonSet pods
+left. It did not before, and the cause was singular: `istiod` ran one replica
+under a budget requiring one available, so it could never be evicted. It runs two
+now.
+
+The remaining zero-disruption budgets are correct and transient — CNPG guards
+each cluster's primary until a switchover, Longhorn blocks while volumes are
+attached, OpenBao wants 2 of 3 raft replicas. If a drain hangs, look for a
+single-replica workload under a `minAvailable: 1` before concluding the stack
+cannot be drained. That wrong conclusion was written into a release note and had
+to be corrected in public.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,21 @@ jobs:
           # renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
           tofu_version: "1.12.5"
 
+      # Same installer as setup.sh and the session-start hook, for the same reason
+      # as Task below: one pinned version, verified against the project's own
+      # checksums, and no third-party action between us and the binary.
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a  # v6
-        with:
-          # renovate: datasource=github-releases depName=terraform-linters/tflint
-          tflint_version: v0.64.0
+        run: ./scripts/internal/install-tflint.sh
 
+      # Not `arduino/setup-task`: that action asks the releases API for the
+      # version, UNAUTHENTICATED, from a runner IP shared with every other GitHub
+      # customer — which is what took `main` red on 2026-08-13 with nothing wrong
+      # in the code. Passing it a token would have hidden the second half: this
+      # repository pins and checksums helm, gitleaks, feint and tflint, and Task
+      # was the one tool coming from a third party by name. Same installer as
+      # `scripts/setup.sh`, so a runner and a workstation cannot disagree.
       - name: Setup Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        run: ./scripts/internal/install-task.sh
 
       - name: Install yamllint
         run: pip install yamllint
@@ -150,7 +157,7 @@ jobs:
           rm -rf "${asset}" linux-amd64
 
       - name: Setup Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        run: ./scripts/internal/install-task.sh
 
       - name: task render-check
         run: task render-check
@@ -174,7 +181,7 @@ jobs:
           tofu_version: "1.12.5"
 
       - name: Setup Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        run: ./scripts/internal/install-task.sh
 
       - name: task validate
         run: task validate ROOT=${{ matrix.root }}
@@ -199,7 +206,7 @@ jobs:
           tofu_version: "1.12.5"
 
       - name: Setup Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        run: ./scripts/internal/install-task.sh
 
       - name: task test
         run: task test
@@ -231,7 +238,7 @@ jobs:
           tofu_version: "1.12.5"
 
       - name: Setup Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
+        run: ./scripts/internal/install-task.sh
 
       - name: Install Feint (pinned + checksum-verified)
         run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,6 +26,11 @@ on:
         description: Leave the cluster up after the run (for manual inspection)
         type: boolean
         default: false
+      stages:
+        description: How far to go — deploy only, or also prove it can be kept
+        type: choice
+        options: [deploy, deploy+idempotency, full]
+        default: full
   schedule:
     # Weekly, Monday 03:17 UTC. Off the hour so it does not pile up with
     # everything else the runners fire at :00.
@@ -42,18 +47,59 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-    name: "Deploy, verify, destroy (${{ inputs.provider || 'scaleway' }})"
+  # A dispatch exercises the one provider a maintainer picked; the weekly run
+  # exercises all three. Without this the cron fell through to `inputs.provider
+  # || 'scaleway'` and OVH and Outscale had no unattended coverage at all — the
+  # two providers where the known upgrade defect actually reproduces.
+  scope:
+    name: What this run covers
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-    # The Environment is what holds the secrets, and what lets you require an
-    # approval before the job starts. Configure `staging` with required
-    # reviewers in Settings → Environments; without that, a scheduled run can
-    # spend money with nobody looking.
+    timeout-minutes: 5
+    outputs:
+      providers: ${{ steps.pick.outputs.providers }}
+      stages: ${{ steps.pick.outputs.stages }}
+    steps:
+      - id: pick
+        env:
+          EVENT: ${{ github.event_name }}
+          PROVIDER: ${{ inputs.provider }}
+          STAGES: ${{ inputs.stages }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "schedule" ]; then
+            echo 'providers=["scaleway","ovh","outscale"]' >> "$GITHUB_OUTPUT"
+            echo 'stages=full' >> "$GITHUB_OUTPUT"
+          else
+            echo "providers=[\"${PROVIDER}\"]" >> "$GITHUB_OUTPUT"
+            echo "stages=${STAGES}" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    name: "Deploy, prove, destroy (${{ matrix.provider }})"
+    needs: scope
+    runs-on: ubuntu-latest
+    # Deploy is ~25 min; idempotency adds a second bring-up; the upgrade adds an
+    # image build, two applies and one reboot per node. 90 was sized for the
+    # first of the three.
+    timeout-minutes: 210
+    strategy:
+      # Never fail-fast: a provider dying must not cancel the others mid-apply,
+      # which is precisely how billed resources get orphaned.
+      fail-fast: false
+      matrix:
+        provider: ${{ fromJSON(needs.scope.outputs.providers) }}
+    # The Environment holds the secrets and gates who can reach them. It exists,
+    # and its deployment branch policy is `main` only — no other branch can get
+    # the cloud credentials, which is the protection that matters in a public
+    # repository. Deliberately NO required reviewer: an approval gate would block
+    # the weekly run, and an unattended lane nobody approves is a lane that never
+    # runs. What keeps the spend bounded instead is the `if: always()` teardown
+    # below and the `reap` job, which runs even when this job never got there.
     environment: staging
     env:
-      PROVIDER: ${{ inputs.provider || 'scaleway' }}
+      PROVIDER: ${{ matrix.provider }}
       ROLE: ${{ inputs.role || 'management' }}
+      STAGES: ${{ needs.scope.outputs.stages }}
       TF_IN_AUTOMATION: "1"
       TF_INPUT: "0"
       # `task infra` and `bootstrap-phase2` apply WITHOUT -auto-approve, on
@@ -70,9 +116,9 @@ jobs:
           # renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
           tofu_version: "1.12.5"
 
-      - name: Setup Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52  # v3.0.0
-
+      # No separate Task step here: setup.sh installs it, through the same pinned
+      # installer CI uses. There used to be one, and it ran an unauthenticated
+      # releases-API call before the step that would have installed Task anyway.
       - name: Setup toolchain
         run: ./scripts/setup.sh
 
@@ -110,15 +156,39 @@ jobs:
           } >> "$GITHUB_ENV"
 
       # The tfvars is environment data and stays out of git — the whole point of
-      # the split. It is a base64 blob in the Environment, one secret per
-      # provider, built from the matching envs/*.tfvars.example.
+      # the split. One base64 secret PER PROVIDER, built from the matching
+      # envs/*.tfvars.example: a single shared blob would write Scaleway's
+      # addresses into OVH's env file the moment this ran as a matrix.
+      #
+      # Each one is expected to pin talos_version / kubernetes_version one patch
+      # BELOW cluster/variables.tf, which is what gives the upgrade stage
+      # something real to move. See scripts/dev/staging-upgrade.sh.
       - name: Materialise the tfvars
         env:
-          TFVARS_B64: ${{ secrets.STAGING_TFVARS_B64 }}
+          TFVARS_B64_SCALEWAY: ${{ secrets.STAGING_TFVARS_B64_SCALEWAY }}
+          TFVARS_B64_OVH: ${{ secrets.STAGING_TFVARS_B64_OVH }}
+          TFVARS_B64_OUTSCALE: ${{ secrets.STAGING_TFVARS_B64_OUTSCALE }}
         run: |
-          test -n "$TFVARS_B64" || { echo "::error::STAGING_TFVARS_B64 is empty"; exit 1; }
-          printf '%s' "$TFVARS_B64" | base64 -d \
+          set -euo pipefail
+          var="TFVARS_B64_$(echo "$PROVIDER" | tr '[:lower:]' '[:upper:]')"
+          blob="${!var:-}"
+          test -n "$blob" || { echo "::error::secret STAGING_${var} is empty"; exit 1; }
+          printf '%s' "$blob" | base64 -d \
             > "infrastructure/opentofu/cluster/envs/${ROLE}-${PROVIDER}.tfvars"
+
+      # `task up` refuses before it bills if the key is missing, and every later
+      # stage needs it too (bootstrap-phase2, the tunnels, rolling-replace). Its
+      # public half belongs in the tfvars above, or the bastion will not take it.
+      - name: Install the bastion SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY" || { echo "::error::STAGING_SSH_PRIVATE_KEY is empty"; exit 1; }
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keygen -y -f ~/.ssh/id_ed25519 > /dev/null
 
       - name: Preflight quotas
         continue-on-error: true
@@ -130,6 +200,16 @@ jobs:
 
       - name: Verify
         run: ./scripts/dev/staging-verify.sh "$PROVIDER" "$ROLE"
+
+      # Building a cluster and keeping one are different claims. These two
+      # stages are the second; 1.0.0 shipped having proven only the first.
+      - name: Idempotency — a second bring-up must change nothing
+        if: env.STAGES != 'deploy'
+        run: ./scripts/dev/staging-idempotency.sh "$PROVIDER" "$ROLE"
+
+      - name: Upgrade — Kubernetes then Talos, in place, with a probe running
+        if: env.STAGES == 'full'
+        run: ./scripts/dev/staging-upgrade.sh "$PROVIDER" "$ROLE"
 
       # `if: always()` is the load-bearing line in this file. A failed apply is
       # precisely the case that leaves billed resources standing, so the teardown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The credentialed lane now covers what it claims, and can actually start.**
+  `staging.yml` was merged with no `staging` environment and none of its secrets,
+  so it had never executed once — indistinguishable, from the outside, from a
+  lane that passes. It also only ever exercised Scaleway (the cron passed no
+  input and fell through to the default) and stopped at deploy → verify →
+  destroy, which is the half 1.0.0 had already proven. It now picks all three
+  providers on the schedule and one on dispatch, takes one tfvars secret **per
+  provider** instead of writing the same blob into every provider's env file,
+  installs the bastion key `task up` refuses to start without, and runs two new
+  stages: `staging-idempotency.sh` (a second bring-up must leave an empty plan,
+  the same nodes with the same creation timestamps, and a working kubeconfig)
+  and `staging-upgrade.sh` (Kubernetes then Talos in place, a 1s readyz probe
+  throughout, and **no retry** of the apply known to fail — a retry would turn
+  that defect green). `check-staging-secrets.sh` reads the required names out of
+  the workflow rather than restating them, and names what is missing.
+- **`docs/upgrade.md`** (+ `.fr.md`), the runbook this repository did not have.
+  The procedure existed in a file called "release checklist 1.0.1" and in
+  `.claude/skills/` — readable by a release manager and by an assistant, not by
+  an operator upgrading on a Tuesday. §7 of the checklist now points at it and
+  keeps only what a release adds.
+- **`task plan ... STRICT=1`** — `-detailed-exitcode`, so "the configuration
+  converged" is an assertion instead of something read off a screen.
+
+### Changed
+
+- **Feint 0.7.3.** Both issues this repository filed are served: `CreateTags`
+  answering that a resource the emulator had just created did not exist (#99,
+  fixed 0.7.1) and a whole Scaleway product falling through to net/http's
+  plain-text 404, which the SDK discarded for its content type (#74, fixed
+  0.7.3 — `/lb/v1/` and `/vpc-gw/v2/` answer `501` in Scaleway's own dialect
+  now). The emulated fixture puts the tags back on six kinds rather than the
+  three it had removed, because a table that fell behind once deserves more than
+  the row that caught it. `task feint-test` green, both providers, both lanes;
+  `task feint-record` re-measured and unchanged in substance — the same three
+  operations nobody serves.
+
 ### Fixed
 
+- **Task was the one tool nobody pinned, and it took `main` red.** CI installed
+  it with `arduino/setup-task`, which asks the releases API for the version
+  **unauthenticated**, from a runner IP shared with every other GitHub customer:
+  on 2026-08-13 that failed with "API rate limit exceeded" and nothing was wrong
+  in the code. Handing the action a token would have fixed the symptom and left
+  the rest — this repository pins and checksum-verifies helm, gitleaks, feint and
+  tflint, while `setup.sh` piped an unpinned `https://taskfile.dev/install.sh`
+  into `sh`. Both are gone, replaced by `scripts/internal/install-task.sh`: one
+  pinned version, the project's own checksums file, no third party, and the same
+  installer on a runner and on a workstation. `staging.yml` lost the step
+  entirely — `setup.sh` was installing Task on the next line anyway.
+- **`task setup` still did not leave a machine able to run `task lint` or
+  `task security`.** Re-measured in a bare `ubuntu:24.04` while validating the
+  change above, which is the only reason it was found: **tflint** was never
+  installed by `setup.sh` at all, though `task lint` calls it — so the first
+  command a contributor runs failed on a machine this script had just called
+  ready. And **checkov** was installed and unreachable: pipx puts it in
+  `~/.local/bin`, which is not on PATH on a fresh Ubuntu, so `task security` died
+  with "executable file not found" about a tool that was present. pipx warns
+  about this; nothing acted on it. tflint now comes from
+  `scripts/internal/install-tflint.sh` — pinned, checksum-verified, and the same
+  file the CI job and the session-start hook use instead of the three separate
+  hand-written copies they had. The checkov path now runs `pipx ensurepath`,
+  exports the directory for the rest of the script, and prints the one line the
+  reader needs. Re-measured in the same bare container: exit 0, **eleven tools
+  out of eleven** reachable, `tflint 0.64.0` and `checkov 3.3.11` among them.
+  What that run does *not* prove is which shell profile `ensurepath` lands in on
+  a given distribution — hence the printed line, which does not depend on it.
+- **Three stale claims, one of them published.** `release-checklist.md` said
+  nothing enforced the Talos↔Kubernetes pair, months after `versions-guard.tf`
+  did; the backlog still listed it as open; and the guard's own error message
+  sent the reader to `modules/talos/versions-guard.tf`, a path that does not
+  exist. The published 1.0.0 release note claimed a node could not be drained
+  because of "seven PodDisruptionBudgets" — one, and fixed; corrected in place
+  with the correction marked rather than quietly rewritten.
+- **The first apply after a version bump has a name now.** Not "most likely the
+  port-ready guards" — it is upstream `siderolabs/terraform-provider-talos` #352
+  on `.machine_configuration_hash`, and the fix ships only in the 0.12.0
+  pre-release line. Which also explains why running it twice works. Still open,
+  with the decision written down instead of a guess.
 - **A node could not be fully drained, and one replica was the reason.** 1.0.0
   admits that a rolling upgrade reboots nodes with pods still aboard. The cause
   was ours and singular: `istiod` ran one replica under a PodDisruptionBudget

--- a/README.fr.md
+++ b/README.fr.md
@@ -200,6 +200,7 @@ task security            # contrôles de durcissement
 | [docs/capi-bootstrap.fr.md](docs/capi-bootstrap.fr.md) | Amorcer un management par CAPI et le rendre autogéré |
 | [docs/deployment-test-matrix.fr.md](docs/deployment-test-matrix.fr.md) | Ce qui est validé, où, et comment |
 | [docs/emulated-cloud.fr.md](docs/emulated-cloud.fr.md) | Tester Scaleway/Outscale contre un émulateur local — et les limites de l'exercice |
+| [docs/upgrade.fr.md](docs/upgrade.fr.md) | Faire bouger Kubernetes et Talos sur un cluster qui doit rester debout |
 | [docs/release-checklist.md](docs/release-checklist.md) | Ce qu'il faut lancer avant de taguer, dans l'ordre qui échoue le moins cher |
 | [docs/backlog.md](docs/backlog.md) | **Source de vérité** : état courant, dette, améliorations (anglais seulement) |
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ task security            # hardening checks
 | [docs/capi-bootstrap.md](docs/capi-bootstrap.md) | Bootstrap a management via CAPI and make it self-managed |
 | [docs/deployment-test-matrix.md](docs/deployment-test-matrix.md) | What is validated, where, and how |
 | [docs/emulated-cloud.md](docs/emulated-cloud.md) | Testing Scaleway/Outscale against a local emulator — and the limits of that |
+| [docs/upgrade.md](docs/upgrade.md) | Moving Kubernetes and Talos on a cluster that has to stay up |
 | [docs/release-checklist.md](docs/release-checklist.md) | What to run before tagging a release, in the order that fails cheapest |
 | [docs/backlog.md](docs/backlog.md) | **Source of truth**: current state, debt, improvements (English only — living working document) |
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -311,6 +311,32 @@ tasks:
       - task: _backup-state
         vars: {PROVIDER: "{{.PROVIDER}}"}
 
+  plan:
+    desc: >-
+      Plan a cluster root without applying. STRICT=1 makes a non-empty plan an ERROR (exit 2) — that is the
+      "converged" assertion an idempotency or post-upgrade check needs. Usage: task plan
+      ROLE=management|workload [PROVIDER=scaleway|ovh|outscale|proxmox] [STRICT=1]
+    dir: infrastructure/opentofu/cluster
+    vars:
+      ROLE: '{{.ROLE | default "management"}}'
+      PROVIDER: '{{.PROVIDER | default "scaleway"}}'
+    env: *provider-env
+    cmds:
+      - tofu init -reconfigure $(../../../scripts/internal/tf-backend.sh envs/{{.ROLE}}-{{.PROVIDER}}.tfvars)
+      - |
+        # Same talos_bootstrap resolution as `infra`: passing the phase-1 value to
+        # an already-bootstrapped cluster zeroes the node counts and the plan then
+        # describes a teardown nobody asked for.
+        if tofu state list 2>/dev/null | grep -q 'module.talos.talos_machine_bootstrap'; then
+          TB=true
+        else
+          TB=false
+        fi
+        # -detailed-exitcode: 0 = no changes, 2 = changes, 1 = error. Task fails on
+        # any non-zero, which is what turns "the plan is empty" into an assertion.
+        tofu plan {{if eq .STRICT "1"}}-detailed-exitcode{{end}} \
+          -var-file="envs/{{.ROLE}}-{{.PROVIDER}}.tfvars" -var talos_bootstrap=$TB
+
   bootstrap-phase2:
     desc: >-
       Phase 2: open SSH tunnels (from state) + bootstrap Talos. Usage: task bootstrap-phase2

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -12,6 +12,25 @@ explanation belongs in the commit that ruled it out.
 
 ## Where we stand
 
+2026-08-14: **everything below was proven by a human running commands. Nothing
+re-proves it.** `.github/workflows/staging.yml` is the answer to that and it has
+never executed: it was merged 2026-08-13 with no `staging` environment and none
+of its 17 secrets set, so its first scheduled fire would have died on an empty
+blob — and a workflow that has never run looks exactly like one that passes.
+Fixed today, except the part only a human can do: the environment exists
+(deployment branch policy `main` only, no approval gate, so the weekly run is
+not blocked), the lane now covers all three providers on the cron instead of
+Scaleway alone, and it gained an idempotency stage and an upgrade stage that
+does not retry the known failing apply. `scripts/dev/check-staging-secrets.sh`
+names what is still missing; until someone runs those `gh secret set` commands,
+the unattended lane is code, not coverage.
+
+Also today: the first-apply-after-a-version-bump failure is no longer a
+hypothesis. It is upstream #352 on `.machine_configuration_hash`, fixed in the
+0.12.0 pre-release line only — see the entry below. Feint moved to 0.7.3, which
+served both issues we filed (#74, #99); the emulated fixture tags six kinds now
+and `task feint-test` is green on both providers, both lanes.
+
 2026-08-13: **the three clouds each ran deploy → idempotency → Kubernetes upgrade
 → Talos upgrade, and all three passed.** Scaleway 3+3, OVH 3+3, Outscale 3+1;
 every node upgraded in place with `rolling-replace --upgrade` rather than
@@ -85,17 +104,40 @@ is an entry that gets picked up and put back down. **Decide:** replaces
 **Closes:** when a question has to be settled first — a task-shaped entry
 invites someone to build what nobody decided.
 
-- [ ] **The first apply after a `talos_version` bump always fails.** Reproduced
-      on OVH and Outscale, identically: the plan proposes a couple of
-      adds/destroys alongside the config changes, then apply reports "Provider
-      produced inconsistent final plan" once per machine config. Re-running
-      succeeds and the second plan is smaller, so the current instruction is
-      "run it twice" — which is the kind of advice that hides a bug rather than
-      naming it. Most likely the port-ready `terraform_data` guards replace in
-      the same graph walk that re-renders the machine configs, so the value
-      applied differs from the one planned.
+- [ ] **The unattended lane has no credentials, so it proves nothing yet.**
+      `scripts/dev/check-staging-secrets.sh` prints the 17 `gh secret set`
+      commands. The three `STAGING_TFVARS_B64_*` must each pin `talos_version`
+      and `kubernetes_version` **one patch below** `cluster/variables.tf` — that
+      gap is the only thing the upgrade stage has to move, and it refuses to run
+      rather than pass on an empty one.
+      **Closes:** `check-staging-secrets.sh` green, then one `workflow_dispatch`
+      per provider, green, `stages=full`. Rung: real cloud — that is the point
+      of the lane.
+
+- [ ] **The first apply after a `talos_version` bump always fails, and it is an
+      upstream bug we cannot take the fix for.** Reproduced on OVH and Outscale:
+      apply reports "Provider produced inconsistent final plan" once per machine
+      config, and re-running succeeds. Identified 2026-08-14 — it is
+      `siderolabs/terraform-provider-talos` **#352**, on
+      `.machine_configuration_hash`: when `machine_configuration_input` is
+      unknown at plan time (the data source reads "during apply"), the provider
+      keeps the OLD hash in the plan and recomputes it at apply, and OpenTofu
+      rejects the change. That also explains why the second run works — the first
+      apply resolves whatever was unknown, so the data source becomes readable at
+      plan time and nothing is deferred.
+      Fixed upstream by PR #359 (commit `024ce5a`, 2026-06-04), which ships in
+      **0.12.0-alpha.3 and later only**. 0.11.0 is still the newest stable and is
+      what `cluster/versions.tf` pins, so there is no patch to move to — the same
+      0.12 dependency as the declarative-upgrade entry below.
+      **Decide:** wait for 0.12 stable, or force a replace instead of an update
+      (`replace_triggered_by` on a `terraform_data` carrying the version pair —
+      a create plans the hash as unknown, so there is no prior value to be
+      inconsistent with). The second is untested and must not be committed as a
+      fix before it is.
       **Closes:** one apply after a version bump, exit 0, no retry. Rung: real
-      cloud (it does not reproduce against mocks).
+      cloud — it needs the data source to be deferred, which neither mocks nor
+      the container lane can produce. `staging.yml`'s upgrade stage is where it
+      will show, and it does not retry, on purpose.
 
 - [ ] **Report boot-image drift, now that nothing else will.** Node resources
       ignore their image attribute, because otherwise a `talosctl upgrade` leaves
@@ -128,17 +170,6 @@ invites someone to build what nobody decided.
       control plane components and the kubelets behind health checks. Our run
       lost 3 probe seconds while an apiserver restarted; that is the gap
       `upgrade-k8s` exists to close.
-
-- [ ] **Nothing checks that talos_version and kubernetes_version are a supported
-      pair.** Talos supports a window of Kubernetes releases — 1.13 covers 1.31
-      to 1.36 ([support matrix](https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix))
-      — and the two variables are bumped INDEPENDENTLY by Renovate. The day
-      Kubernetes 1.37 lands while talos_version is still on 1.13, the plan will
-      be perfectly valid and the cluster will not come up, with nothing pointing
-      at the pair. Encode the window (a map from Talos minor to the Kubernetes
-      minors it accepts) and fail at plan time, or check it in preflight-quotas
-      where the other before-you-spend checks live. Cheap, and it closes a gap
-      that only shows itself on a real cluster.
 
 - [ ] **The Outscale image lane cannot replace an image, and it is not an
       ordering problem.** Rebuilding fails with "409 ResourceConflict — Unable to
@@ -292,21 +323,9 @@ invites someone to build what nobody decided.
       scrapes. Any cluster running Flux 2.8 does — the local Docker root
       qualifies, no cloud needed.
 
-- [ ] **`CreateTags` says a resource the emulator just created does not exist.**
-      `taggable` (`internal/providers/outscale/tags.go`) knows four prefixes —
-      `vpc-`, `subnet-`, `i-`, `key-` — against sixteen the pack mints, so ten
-      taggable kinds answer `5063 InvalidResource` on ids it returns from its own
-      `Read*`. Not cosmetic: the provider fails the apply (`Unable to create
-      tags`), the resource is tainted, and the next apply fails identically — the
-      configuration cannot converge. Reproduced on 0.7.0 with a two-resource
-      OpenTofu config. Our fixture works around it by leaving the internet
-      service and route tables untagged. Reported as `stephrobert/feint#99`.
-      **Closes:** that issue served, then `task feint-apply PROVIDER=outscale`
-      green with the tags put back on the fixture. Emulated.
-
 - [ ] **A full emulated apply of the cluster root needs two routes, and two
-      decisions reversed.** Measured on 0.6.0 and again on 0.7.0, identical both
-      times (`task feint-record`). Genuinely missing: Scaleway LB (SW-5 `#17`)
+      decisions reversed.** Measured on 0.6.0, 0.7.0 and 0.7.3, identical all
+      three times (`task feint-record`). Genuinely missing: Scaleway LB (SW-5 `#17`)
       and public gateway (SW-6 `#18`). Declined *with a stated reason*, which is
       a different conversation: `ipam BookIP` (SW-4 `#11`) because addresses come
       from the subnet plan rather than a client reservation, and Outscale

--- a/docs/emulated-cloud.fr.md
+++ b/docs/emulated-cloud.fr.md
@@ -65,12 +65,16 @@ actuel, reproductible avec les commandes ci-dessus :
 | Provider | Appelé, servi par personne | Appels | Manquant, ou décliné ? |
 |---|---|---|---|
 | Scaleway | `POST /ipam/v1/regions/fr-par/ips` (501) | 2 | Décliné — le `GET` sur le même chemin répond 200 |
-| Scaleway | `/lb/v1/zones/fr-par-1/ips` (404) | 2 | Manquant |
-| Scaleway | `/vpc-gw/v2/zones/fr-par-1/ips` (404) | 1 | Manquant |
+| Scaleway | `/lb/v1/zones/fr-par-1/ips` (501) | 2 | Manquant |
+| Scaleway | `/vpc-gw/v2/zones/fr-par-1/ips` (501) | 1 | Manquant |
 | Outscale | `/api/v1/CreateLoadBalancer` (404) | 2 | Décliné |
 
-Identique en 0.6.0 et 0.7.0 : aucune des deux n'a bougé quoi que ce soit
-qu'appellent nos modules. La distinction de la dernière colonne est tout
+Les mêmes trois opérations en 0.6.0, 0.7.0 et 0.7.3 : aucune version n'a bougé
+quoi que ce soit qu'appellent nos modules. Ce qui a bougé, c'est la *forme* du
+refus — les deux manques Scaleway répondaient un `404` en texte brut jusqu'à la
+0.7.3, que le SDK jetait pour son content type, si bien que l'appelant voyait
+`404 Not Found` et pas de corps. Ils répondent maintenant `501` dans le dialecte
+de Scaleway (notre issue #74). La distinction de la dernière colonne est tout
 l'intérêt de rejouer la mesure — une route manquante est un trou que quelqu'un
 peut combler, un decline est une réponse.
 
@@ -112,20 +116,25 @@ régressions de câblage avant de dépenser.
 
 ## Manques connus
 
-Épinglé sur **Feint 0.7.0** (`scripts/dev/feint.sh`). Ce que cette voie ne peut
+Épinglé sur **Feint 0.7.3** (`scripts/dev/feint.sh`). Ce que cette voie ne peut
 toujours pas porter, tout consigné dans [`backlog.md`](backlog.md) :
 
 | Non exercé | Pourquoi |
 |---|---|
 | Load balancers Outscale | `CreateLoadBalancer` est **décliné volontairement**, pas manquant : un load balancer est un plan de données que l'émulateur n'a pas, en créer un rendrait un nom DNS ne résolvant nulle part. `ReadLoadBalancers` répond une liste vide. Celui-là ne bougera pas. |
 | Réservations IPAM Scaleway | Décliné aussi, avec une raison : les adresses viennent du plan de sous-réseau où le NIC est placé, donc `BookIP` distribuerait une adresse qu'aucun runtime ne configure. `scaleway_ipam_ip` est donc hors de portée ici. |
-| LB et public gateway Scaleway | Réellement absents — ni servis ni déclinés. Les deux vrais manques que nos modules rencontrent. |
+| LB et public gateway Scaleway | Réellement absents. Les deux vrais manques que nos modules rencontrent. Depuis la 0.7.3 ils refusent au moins lisiblement — `501` dans le dialecte du SDK au lieu du `404` en texte brut de net/http, que le SDK Scaleway jetait pour son content type (notre issue #74). |
 | Type de volume racine Scaleway | Aucun `root_volume { volume_type }` n'est écrivable : le provider 2.79+ refuse `b_ssd`, et `sbs_volume` planifie éternellement car l'émulateur l'écrase. L'honorer enverrait le provider sur `block/v1`, non monté. Mesuré ici, c'est devenu la limite documentée en amont et son issue #8. |
 | Résolution d'image par nom | Le catalogue est fixe, et la 0.7.0 applique le filtre `image_names` : un nom publié par un pipeline de build ne correspond à rien — des deux côtés. Les tfvars Scaleway épinglent `image_id` ; ceux d'Outscale pointent `image_name` sur une entrée du catalogue, ce qui exerce la recherche sans prétendre résoudre notre propre image. |
-| Tags sur route tables et internet services | `CreateTags` ne connaît que quatre préfixes d'identifiant (`vpc-`, `subnet-`, `i-`, `key-`) : taguer un `igw-` ou un `rtb-` est refusé sur une ressource qu'il vient de créer. Le module de production tague les deux. |
 
-Deux choses ont quitté cette liste. `outscale_volume_link` en 0.6.0, qui a monté
-le filtre `LinkVolumeVmIds` dont dépend son attente. Et `data.outscale_images`
-en 0.7.0, qui ne fait plus segfaulter le provider — la voie Outscale résout donc
-son image par la data source plutôt que par un id épinglé, ce qui exerce la
-forme `images[0]` que le module portait comme une hypothèse non vérifiée.
+Trois choses ont quitté cette liste. `outscale_volume_link` en 0.6.0, qui a monté
+le filtre `LinkVolumeVmIds` dont dépend son attente. `data.outscale_images` en
+0.7.0, qui ne fait plus segfaulter le provider — la voie Outscale résout donc son
+image par la data source plutôt que par un id épinglé, ce qui exerce la forme
+`images[0]` que le module portait comme une hypothèse non vérifiée. Et
+`CreateTags` en 0.7.1 (notre issue #99) : la table de préfixes en tenait quatre
+contre seize que le pack frappait, si bien que taguer un `igw-` ou un `rtb-`
+était refusé sur une ressource que l'émulateur venait de créer. La fixture tague
+maintenant six types plutôt que de remettre les trois qu'elle avait retirés — une
+table qui a pris du retard une fois mérite d'être exercée sur plus que la ligne
+qui l'a attrapée.

--- a/docs/emulated-cloud.md
+++ b/docs/emulated-cloud.md
@@ -63,13 +63,17 @@ output, reproducible with the commands above:
 | Provider | Called, served by nobody | Calls | Missing, or declined? |
 |---|---|---|---|
 | Scaleway | `POST /ipam/v1/regions/fr-par/ips` (501) | 2 | Declined — `GET` on the same path answers 200 |
-| Scaleway | `/lb/v1/zones/fr-par-1/ips` (404) | 2 | Missing |
-| Scaleway | `/vpc-gw/v2/zones/fr-par-1/ips` (404) | 1 | Missing |
+| Scaleway | `/lb/v1/zones/fr-par-1/ips` (501) | 2 | Missing |
+| Scaleway | `/vpc-gw/v2/zones/fr-par-1/ips` (501) | 1 | Missing |
 | Outscale | `/api/v1/CreateLoadBalancer` (404) | 2 | Declined |
 
-Identical on 0.6.0 and 0.7.0: neither release moved anything our modules call.
-The distinction in the last column is the whole value of re-running this — a
-missing route is a gap someone may fill, a decline is an answer.
+The same three operations on 0.6.0, 0.7.0 and 0.7.3: no release has moved
+anything our modules call. What did move is the *shape* of the refusal — the two
+Scaleway gaps answered a plain-text `404` until 0.7.3, which the SDK discarded
+for its content type, so the caller saw `404 Not Found` and no body. They answer
+`501` in Scaleway's own dialect now (our issue #74). The distinction in the last
+column is the whole value of re-running this — a missing route is a gap someone
+may fill, a decline is an answer.
 
 Upstream here is the emulator, not the cloud. A client that signs the host it
 was configured with — the Terraform provider does — cannot be recorded against a
@@ -107,20 +111,24 @@ the only proof of a deployment; this catches wiring regressions before spending.
 
 ## Known gaps
 
-Pinned to **Feint 0.7.0** (`scripts/dev/feint.sh`). What this lane still cannot
+Pinned to **Feint 0.7.3** (`scripts/dev/feint.sh`). What this lane still cannot
 carry, all recorded in [`backlog.md`](backlog.md):
 
 | Not exercised | Why |
 |---|---|
 | Outscale load balancers | `CreateLoadBalancer` is **declined on purpose**, not missing: a load balancer is a data plane the emulator does not have, so creating one would return a DNS name resolving nowhere. `ReadLoadBalancers` answers an empty list. This one will not move. |
 | Scaleway IPAM reservations | Also a decline with a reason: addresses come from the subnet plan a NIC is placed in, so `BookIP` would hand out an address no runtime configures. `scaleway_ipam_ip` is therefore out of reach here. |
-| Scaleway LB and public gateway | Genuinely absent — neither served nor declined. The two remaining gaps our modules hit. |
+| Scaleway LB and public gateway | Genuinely absent. The two remaining gaps our modules hit. Since 0.7.3 they at least refuse legibly — `501` in the SDK's own dialect instead of net/http's plain-text `404`, which the Scaleway SDK dropped on the floor for having the wrong content type (our issue #74). |
 | Scaleway root volume type | No `root_volume { volume_type }` is writable: provider 2.79+ refuses `b_ssd`, and `sbs_volume` plans for ever because the emulator overrides it. Honouring it would send the provider to `block/v1`, unmounted. Measured here, now upstream's stated limit and its issue #8. |
 | Image name resolution | The catalogue is fixed, and 0.7.0 applies the `image_names` filter, so a name a build pipeline published matches nothing — on either provider. The Scaleway tfvars pin `image_id`; the Outscale ones point `image_name` at a catalogue entry instead, which exercises the lookup without pretending to resolve our own image. |
-| Tags on route tables and internet services | `CreateTags` knows four identifier prefixes (`vpc-`, `subnet-`, `i-`, `key-`), so tagging an `igw-` or an `rtb-` is refused on a resource it has just created. The production module tags both. |
 
-Two things left this list. `outscale_volume_link` in 0.6.0, which mounted the
-`LinkVolumeVmIds` filter its wait depends on. And `data.outscale_images` in
-0.7.0, which stopped segfaulting the provider — so the Outscale lane now
-resolves its image through the data source rather than a pinned id, exercising
-the `images[0]` shape the module had carried as an unverified assumption.
+Three things left this list. `outscale_volume_link` in 0.6.0, which mounted the
+`LinkVolumeVmIds` filter its wait depends on. `data.outscale_images` in 0.7.0,
+which stopped segfaulting the provider — so the Outscale lane now resolves its
+image through the data source rather than a pinned id, exercising the
+`images[0]` shape the module had carried as an unverified assumption. And
+`CreateTags` in 0.7.1 (our issue #99): the prefix table held four kinds against
+sixteen the pack minted, so tagging an `igw-` or an `rtb-` was refused on a
+resource the emulator had just created. The fixture tags six kinds now rather
+than putting back the three it had removed — a table that fell behind once
+should be exercised on more than the row that caught it.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -263,48 +263,24 @@ task up ROLE=management PROVIDER=outscale
 ## 7. Upgrades — Kubernetes and Talos, on a cluster that has to stay up
 
 §§1-6 prove a cluster can be built. They prove nothing about keeping one, which
-is the half 1.0.0 shipped unverified. Run this on the reference provider at
-minimum, on an HA topology, with a one-second probe so "no interruption" is a
-number rather than an impression:
+is the half 1.0.0 shipped unverified.
 
-```bash
-while :; do kubectl get --raw=/readyz --request-timeout=2s >/dev/null 2>&1 \
-  && echo ok || echo FAIL; sleep 1; done | tee probe.log
-```
+The procedure itself is [`upgrade.md`](upgrade.md) — it is not release-specific
+and does not belong here twice. What a *release* adds to it:
 
-Point it at the endpoint in the kubeconfig, not at a tunnel to one node — a
-tunnel measures that node, and the node you are upgrading is expected to go away.
+- [ ] run it on an **HA** topology, on the reference provider at minimum, with
+      the one-second probe up throughout — "no interruption" has to be a number
+- [ ] run it on **OVH or Outscale** too, not only Scaleway: the known first-apply
+      failure (upstream #352) reproduces there and nowhere else
+- [ ] every node upgraded **in place**, none replaced, every one back under its
+      own name
+- [ ] `task plan ... STRICT=1` exits 0 afterwards
+- [ ] whatever it shook out is in `backlog.md` before the tag, including what you
+      chose not to fix
 
-**Check the version pair before moving either.** Talos supports a range of
-Kubernetes versions, not all of them (1.13 covers 1.31-1.36). The starting pair,
-the ending pair, and the intermediate state all have to sit inside it, because
-one moves before the other. Nothing enforces this yet — see the backlog.
-
-**Expect to apply twice.** Bumping `talos_version` and applying puts the new
-installer in the machine configs — nothing reboots yet. That first apply fails on
-both OVH and Outscale with "Provider produced inconsistent final plan", once per
-machine config; running it again succeeds. It is in the backlog, not fixed.
-
-**Talos, in place.** `rolling-replace.sh --upgrade` calls `talosctl upgrade`,
-which keeps the node's disk, identity and etcd membership, drains it itself, and
-refuses a control-plane upgrade that would cost etcd its quorum. One node at a
-time, health-gated between each. Re-runnable: a node already on the target
-version is skipped.
-
-```bash
-task rolling-replace PROVIDER=scaleway KEY=~/.ssh/<key> -- --cp-only --upgrade
-task rolling-replace PROVIDER=scaleway KEY=~/.ssh/<key> -- --workers-only --upgrade
-```
-
-**What to watch, beyond "it came back".** After each node: its name is unchanged
-(`kubectl get nodes` — a `talos-xxxxx` entry means the hostname did not hold and
-the next reboot will orphan another node object), the node count has not grown,
-etcd still reports every member, and the probe's FAIL count has not moved much.
-
-**Then plan again.** A clean upgrade leaves `tofu plan` at zero destroys. If it
-wants to replace nodes, the boot image and the running version have disagreed —
-that plan would take the cluster down, so stop and read
-`modules/providers/provider-contract.md` § "Node image drift".
+`scripts/dev/staging-upgrade.sh` does all of the above unattended and does not
+retry the failing apply, on purpose. If the weekly `staging` run is green on the
+three providers, this section is already answered — say so and move on.
 
 ## 8. Cross-repo and CAPI, if you are exercising the optional layer
 

--- a/docs/upgrade.fr.md
+++ b/docs/upgrade.fr.md
@@ -1,0 +1,108 @@
+# Mettre à niveau un cluster vivant — Kubernetes et Talos
+
+🇬🇧 [English version](upgrade.md)
+
+> Construire un cluster et en garder un sont deux affirmations différentes. Voici
+> la seconde. Prouvée à la main sur Scaleway, OVH et Outscale le 2026-08-13, en
+> topologie HA, chaque nœud mis à niveau **sur place** plutôt que remplacé.
+>
+> La version non assistée de cette même procédure est
+> [`scripts/dev/staging-upgrade.sh`](../scripts/dev/staging-upgrade.sh), jouée
+> chaque semaine par `.github/workflows/staging.yml`. Si les deux divergent, c'est
+> le script qui fait foi — c'est lui qui tourne.
+
+## Les deux faits dont découle tout le reste
+
+**L'image de boot d'un nœud n'est que le médium depuis lequel il a été installé.**
+Après un `talosctl upgrade`, l'instance rapporte toujours l'ancien id d'image,
+par construction. Les ressources de nœud portent donc `ignore_changes` dessus —
+voir
+[`provider-contract.md` § Node image drift](../infrastructure/opentofu/modules/providers/provider-contract.md).
+Sans cela, bumper `talos_version` ferait remplacer les trois control planes en
+même temps par un apply de routine, et etcd perdrait son quorum.
+
+**Talos ne supporte qu'une fenêtre de versions Kubernetes.**
+`cluster/versions-guard.tf` refuse une paire non supportée dès le plan, et refuse
+aussi une mineure Talos que personne n'a saisie dans sa table plutôt que de la
+laisser passer en silence. La paire de départ, celle d'arrivée **et** l'état
+intermédiaire doivent tenir dans la fenêtre, puisque les deux bougent l'une après
+l'autre.
+
+## Mesurer l'interruption
+
+À lancer avant tout le reste, contre l'endpoint du kubeconfig — jamais contre un
+tunnel vers un nœud, puisque c'est ce nœud-là qu'on s'apprête à retirer.
+
+```bash
+while :; do kubectl get --raw=/readyz --request-timeout=2s >/dev/null 2>&1 \
+  && echo ok || echo FAIL; sleep 1; done | tee probe.log
+```
+
+Une exécution propre perd quelques secondes le temps qu'un apiserver redémarre.
+Celle du 2026-08-13 en a perdu trois.
+
+## Kubernetes d'abord
+
+Elle ne redémarre rien, ce qui isole le roulement du control plane de celui des
+nœuds.
+
+```bash
+# modifier kubernetes_version dans envs/<role>-<provider>.tfvars, puis
+task infra ROLE=management PROVIDER=<p>
+```
+
+Talos réconcilie les static pods et les kubelets ; attendre que chaque nœud
+rapporte la nouvelle version avant de continuer. À noter : ce chemin contourne
+`talosctl upgrade-k8s`, qui séquence ces composants derrière des health checks —
+voir `backlog.md`.
+
+## Puis Talos, sur place
+
+Bumper `talos_version`, construire l'image de la nouvelle version (les ressources
+de nœud ignorent l'image, mais la *data source*, elle, doit résoudre), appliquer,
+puis dérouler.
+
+```bash
+task talos-image PROVIDER=<p> VERSION=<new> ENSURE=1
+# modifier talos_version dans le tfvars, puis
+task infra ROLE=management PROVIDER=<p>
+task rolling-replace PROVIDER=<p> KEY=~/.ssh/<clé> -- --cp-only --upgrade
+task rolling-replace PROVIDER=<p> KEY=~/.ssh/<clé> -- --workers-only --upgrade
+```
+
+`--upgrade` appelle `talosctl upgrade`, qui conserve le disque, l'identité et
+l'appartenance etcd du nœud, le drain lui-même, et refuse une mise à niveau de
+control plane qui coûterait son quorum à etcd. Un nœud à la fois, avec une porte
+de santé entre chacun, et rejouable : un nœud déjà sur la version cible est
+sauté. Les control planes d'abord — un worker a besoin d'un control plane sain
+pour se drainer.
+
+⚠️ **Le premier apply après un bump de `talos_version` échoue sur OVH et
+Outscale** avec « Provider produced inconsistent final plan », une fois par
+machine config. Rien n'est laissé à moitié appliqué ; relancer. C'est l'issue
+amont `siderolabs/terraform-provider-talos` #352, corrigée seulement dans la
+ligne 0.12.0 en pré-version — détails et décision encore ouverte dans
+`backlog.md`.
+
+## Ce qu'il faut vérifier, au-delà de « c'est revenu »
+
+Après chaque nœud, puis à la fin :
+
+- **son nom n'a pas changé** — une entrée `talos-xxxxx` signifie que le hostname
+  n'a pas tenu, et le prochain reboot orphelinera un autre objet node
+- le nombre de nœuds n'a pas augmenté, et etcd rapporte toujours tous ses membres
+- le compteur de FAIL de la sonde n'a presque pas bougé
+- **`tofu plan` est vide.** S'il veut remplacer des nœuds, l'image de boot et la
+  version qui tourne ont divergé — ce plan-là coucherait le cluster. S'arrêter et
+  lire § Node image drift avant de lancer quoi que ce soit d'autre.
+
+```bash
+task plan ROLE=management PROVIDER=<p> STRICT=1   # sortie 2 = non convergé
+```
+
+## Remplacer un nœud plutôt que le mettre à niveau
+
+`--upgrade` ne peut pas porter un changement d'`instance_type`, de disque ou de
+zone, ni un nouveau schematic d'image : ceux-là exigent une nouvelle VM. Même
+script, sans `--upgrade` : il draine, applique un `-replace` ciblé et attend, un
+nœud à la fois. Ce chemin-là, lui, exige que la nouvelle image cloud existe.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,0 +1,101 @@
+# Upgrading a live cluster — Kubernetes and Talos
+
+🇫🇷 [Version française](upgrade.fr.md)
+
+> Building a cluster and keeping one are different claims. This is the second.
+> Proven by hand on Scaleway, OVH and Outscale on 2026-08-13, HA topologies, every
+> node upgraded **in place** rather than replaced.
+>
+> The unattended version of this same procedure is
+> [`scripts/dev/staging-upgrade.sh`](../scripts/dev/staging-upgrade.sh), run
+> weekly by `.github/workflows/staging.yml`. If the two ever disagree, the script
+> is the one that gets run.
+
+## The two facts everything here follows from
+
+**A node's boot image is only the medium it was installed from.** After
+`talosctl upgrade` the instance still reports the old image id, by design. Node
+resources therefore carry `ignore_changes` on it — see
+[`provider-contract.md` § Node image drift](../infrastructure/opentofu/modules/providers/provider-contract.md).
+Without that, bumping `talos_version` would make a routine apply replace every
+control plane at once and etcd would lose quorum.
+
+**Talos supports a window of Kubernetes releases, not all of them.**
+`cluster/versions-guard.tf` refuses an unsupported pair at plan time, and refuses
+a Talos minor nobody has entered in its map rather than passing it silently. The
+starting pair, the ending pair *and* the intermediate state all have to sit
+inside the window, because the two move one at a time.
+
+## Measure the interruption
+
+Start this before anything, against the endpoint in the kubeconfig — never a
+tunnel to one node, because that node is the one you are about to take away.
+
+```bash
+while :; do kubectl get --raw=/readyz --request-timeout=2s >/dev/null 2>&1 \
+  && echo ok || echo FAIL; sleep 1; done | tee probe.log
+```
+
+A clean run loses a few seconds while an apiserver restarts. The hand-run on
+2026-08-13 lost three.
+
+## Kubernetes first
+
+It reboots nothing, so it isolates the control-plane roll from the node roll.
+
+```bash
+# edit kubernetes_version in envs/<role>-<provider>.tfvars, then
+task infra ROLE=management PROVIDER=<p>
+```
+
+Talos reconciles the static pods and the kubelets; wait for every node to report
+the new version before moving on. Note that this bypasses `talosctl upgrade-k8s`,
+which sequences those components behind health checks — see `backlog.md`.
+
+## Then Talos, in place
+
+Bump `talos_version`, build the image for the new version (the node resources
+ignore the image, but the *data source* still has to resolve), apply, then roll.
+
+```bash
+task talos-image PROVIDER=<p> VERSION=<new> ENSURE=1
+# edit talos_version in the tfvars, then
+task infra ROLE=management PROVIDER=<p>
+task rolling-replace PROVIDER=<p> KEY=~/.ssh/<key> -- --cp-only --upgrade
+task rolling-replace PROVIDER=<p> KEY=~/.ssh/<key> -- --workers-only --upgrade
+```
+
+`--upgrade` calls `talosctl upgrade`, which keeps the node's disk, identity and
+etcd membership, drains it itself, and refuses a control-plane upgrade that would
+cost etcd its quorum. One node at a time, health-gated between each, and
+re-runnable: a node already on the target version is skipped. Control planes
+first — a worker needs a healthy control plane to drain against.
+
+⚠️ **The first apply after a `talos_version` bump fails on OVH and Outscale**
+with "Provider produced inconsistent final plan", once per machine config.
+Nothing is left half-applied; re-run it. This is upstream
+`siderolabs/terraform-provider-talos` #352, fixed only in the 0.12.0 pre-release
+line — details and the decision still open in `backlog.md`.
+
+## What to check, beyond "it came back"
+
+After each node, and again at the end:
+
+- **its name is unchanged** — a `talos-xxxxx` entry means the hostname did not
+  hold, and the next reboot will orphan another node object
+- the node count has not grown, and etcd still reports every member
+- the probe's FAIL count has barely moved
+- **`tofu plan` is empty.** If it wants to replace nodes, the boot image and the
+  running version have disagreed — that plan would take the cluster down. Stop
+  and read § Node image drift before running anything else.
+
+```bash
+task plan ROLE=management PROVIDER=<p> STRICT=1   # exit 2 = not converged
+```
+
+## Replacing a node rather than upgrading it
+
+`--upgrade` cannot carry an `instance_type`, disk or zone change, nor a new image
+schematic — those need a new VM. Same script, without `--upgrade`: it drains,
+applies a targeted `-replace`, and waits, one node at a time. That path *does*
+need the new cloud image to exist.

--- a/infrastructure/opentofu-feint/outscale.tf
+++ b/infrastructure/opentofu-feint/outscale.tf
@@ -51,12 +51,18 @@ resource "outscale_subnet" "public" {
 
 # --- Egress: internet service for the public subnet, NAT for the private one ---
 
-# No tags block, and it is not a modelling choice: the emulator's CreateTags
-# knows four identifier prefixes — vpc-, subnet-, i-, key- — so tagging an
-# igw- or an rtb- is refused with "the resource does not exist" on a resource
-# it has just created. The production module does tag these; see the backlog.
+# Tagged on purpose, and on more kinds than the module strictly needs: Feint's
+# CreateTags knew four identifier prefixes against sixteen it minted, so ten
+# taggable kinds answered "the resource does not exist" about resources it had
+# just created (stephrobert/feint#99, fixed in 0.7.1). These blocks are what
+# keeps that regression visible here rather than on a real account.
 resource "outscale_internet_service" "this" {
   count = local.outscale_active
+
+  tags {
+    key   = "Name"
+    value = "${var.cluster_name}-igw"
+  }
 }
 
 resource "outscale_internet_service_link" "this" {
@@ -67,6 +73,11 @@ resource "outscale_internet_service_link" "this" {
 
 resource "outscale_public_ip" "nat" {
   count = local.outscale_active
+
+  tags {
+    key   = "Name"
+    value = "${var.cluster_name}-nat-ip"
+  }
 }
 
 # A bare internet service only NATs a machine that owns a public IP, so the
@@ -78,12 +89,21 @@ resource "outscale_nat_service" "this" {
   public_ip_id = outscale_public_ip.nat[0].public_ip_id
 
   depends_on = [outscale_internet_service_link.this, outscale_route_table_link.public]
+
+  tags {
+    key   = "Name"
+    value = "${var.cluster_name}-nat"
+  }
 }
 
 resource "outscale_route_table" "public" {
   count  = local.outscale_active
   net_id = outscale_net.this[0].net_id
-  # Untagged for the same reason as the internet service above.
+
+  tags {
+    key   = "Name"
+    value = "${var.cluster_name}-public-rt"
+  }
 }
 
 resource "outscale_route" "public_internet" {
@@ -102,7 +122,11 @@ resource "outscale_route_table_link" "public" {
 resource "outscale_route_table" "private" {
   count  = local.outscale_active
   net_id = outscale_net.this[0].net_id
-  # Untagged for the same reason as the internet service above.
+
+  tags {
+    key   = "Name"
+    value = "${var.cluster_name}-private-rt"
+  }
 }
 
 resource "outscale_route" "private_nat" {
@@ -125,6 +149,11 @@ resource "outscale_security_group" "this" {
   description         = "OpenAether cluster nodes - least-privilege inbound"
   security_group_name = "${var.cluster_name}-cluster-sg"
   net_id              = outscale_net.this[0].net_id
+
+  tags {
+    key   = "Name"
+    value = "${var.cluster_name}-cluster-sg"
+  }
 }
 
 resource "outscale_security_group_rule" "k8s_api" {
@@ -163,6 +192,11 @@ resource "outscale_security_group" "bastion" {
   description         = "OpenAether bastion - SSH from admin only"
   security_group_name = "${var.cluster_name}-bastion-sg"
   net_id              = outscale_net.this[0].net_id
+
+  tags {
+    key   = "Name"
+    value = "${var.cluster_name}-bastion-sg"
+  }
 }
 
 resource "outscale_security_group_rule" "bastion_ssh" {
@@ -189,6 +223,11 @@ resource "outscale_volume" "worker_data" {
   count          = local.outscale_active
   subregion_name = "eu-west-2a"
   size           = 10
+
+  tags {
+    key   = "Name"
+    value = "${var.cluster_name}-worker-data"
+  }
 }
 
 resource "outscale_vm" "control_plane" {

--- a/infrastructure/opentofu/cluster/versions-guard.tf
+++ b/infrastructure/opentofu/cluster/versions-guard.tf
@@ -31,7 +31,7 @@ resource "terraform_data" "version_pair_guard" {
         local.k8s_minor_num >= local.k8s_supported.min &&
         local.k8s_minor_num <= local.k8s_supported.max
       )
-      error_message = "talos_version ${var.talos_version} and kubernetes_version ${var.kubernetes_version} are not a supported pair. Talos ${local.talos_minor_key} either supports a different Kubernetes range, or is not in modules/talos/versions-guard.tf yet — check https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix and extend the map rather than widening it blindly."
+      error_message = "talos_version ${var.talos_version} and kubernetes_version ${var.kubernetes_version} are not a supported pair. Talos ${local.talos_minor_key} either supports a different Kubernetes range, or is not in cluster/versions-guard.tf yet — check https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix and extend the map rather than widening it blindly."
     }
   }
 }

--- a/scripts/dev/check-staging-secrets.sh
+++ b/scripts/dev/check-staging-secrets.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Say whether the credentialed lane can actually run, and name what is missing.
+#
+# `.github/workflows/staging.yml` was merged with none of its secrets configured
+# and no `staging` environment at all, so its first scheduled fire would have
+# died on an empty blob. Nothing said so — a workflow that has never run looks
+# exactly like one that passes. This turns that into a command.
+#
+# Reads names only. It never prints a value, and GitHub would not return one.
+#
+# Usage: check-staging-secrets.sh [environment]     (default: staging)
+set -euo pipefail
+
+ENVIRONMENT="${1:-staging}"
+WORKFLOW="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.github/workflows/staging.yml"
+
+command -v gh >/dev/null || { echo "✗ gh is not installed" >&2; exit 1; }
+
+# The required set is READ FROM THE WORKFLOW, not restated here: a hardcoded list
+# would drift the first time someone adds a secret, and pass while the lane broke.
+mapfile -t REQUIRED < <(
+  grep -oE 'secrets\.[A-Z0-9_]+' "$WORKFLOW" | cut -d. -f2 | grep -v '^GITHUB_TOKEN$' | sort -u
+)
+[ "${#REQUIRED[@]}" -gt 0 ] || { echo "✗ read no secret names from $WORKFLOW" >&2; exit 1; }
+
+if ! gh api "repos/:owner/:repo/environments/${ENVIRONMENT}" >/dev/null 2>&1; then
+  echo "✗ no '${ENVIRONMENT}' environment on this repository."
+  echo "  gh api -X PUT repos/:owner/:repo/environments/${ENVIRONMENT}"
+  exit 1
+fi
+
+mapfile -t PRESENT < <(gh secret list --env "$ENVIRONMENT" --json name -q '.[].name' 2>/dev/null | sort)
+
+MISSING=()
+for name in "${REQUIRED[@]}"; do
+  printf '%s\n' "${PRESENT[@]}" | grep -qx "$name" || MISSING+=("$name")
+done
+
+if [ "${#MISSING[@]}" -eq 0 ]; then
+  echo "✓ ${ENVIRONMENT}: all ${#REQUIRED[@]} secrets set"
+  exit 0
+fi
+
+echo "✗ ${ENVIRONMENT}: ${#MISSING[@]} of ${#REQUIRED[@]} secrets missing — the lane cannot run."
+echo
+for name in "${MISSING[@]}"; do
+  echo "  gh secret set ${name} --env ${ENVIRONMENT}"
+done
+echo
+echo "The three STAGING_TFVARS_B64_* are one base64 blob per provider, each built"
+echo "from the matching envs/<role>-<provider>.tfvars.example and each pinning"
+echo "talos_version / kubernetes_version ONE PATCH BELOW cluster/variables.tf —"
+echo "that gap is what the upgrade stage moves. Build one with:"
+echo "  base64 -w0 < infrastructure/opentofu/cluster/envs/management-scaleway.tfvars"
+exit 1

--- a/scripts/dev/feint.sh
+++ b/scripts/dev/feint.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # renovate: datasource=github-releases depName=stephrobert/feint extractVersion=^v(?<version>.*)$
-FEINT_VERSION="0.7.0"
+FEINT_VERSION="0.7.3"
 FEINT_ENDPOINT="${FEINT_ENDPOINT:-http://127.0.0.1:4599}"
 BIN_DIR="${FEINT_BIN_DIR:-$HOME/.local/bin}"
 

--- a/scripts/dev/staging-idempotency.sh
+++ b/scripts/dev/staging-idempotency.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Re-run the bring-up on a cluster that is already up, and assert nothing moved.
+#
+# `task up` is documented as idempotent and was proven so by hand on 2026-07-30,
+# after a re-run had silently re-sent the bootstrap RPC to a live etcd and
+# invalidated the operator's kubeconfig. Nothing has re-proven it since, on any
+# provider — which is the gap this closes.
+#
+# Three assertions, because "the second apply succeeded" is not one of them:
+#   1. the plan afterwards is EMPTY  — the configuration converged
+#   2. every node is the same node   — same names, same creationTimestamps
+#   3. the kubeconfig still works    — the output was not invalidated
+#
+# Usage: staging-idempotency.sh <provider> <role> [ssh-key]
+set -euo pipefail
+
+PROVIDER="${1:?usage: staging-idempotency.sh <provider> <role> [ssh-key]}"
+ROLE="${2:?usage: staging-idempotency.sh <provider> <role> [ssh-key]}"
+KEY="${3:-$HOME/.ssh/id_ed25519}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export KUBECONFIG="$ROOT/infrastructure/opentofu/cluster/kubeconfig"
+
+fail() { echo "✗ $*" >&2; exit 1; }
+ok() { echo "✓ $*"; }
+
+# Name plus creationTimestamp: a replaced node keeps its name and gets a new
+# timestamp, so comparing names alone would call a full rebuild idempotent.
+node_identities() {
+  kubectl get nodes \
+    -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.creationTimestamp}{"\n"}{end}' |
+    sort
+}
+
+BEFORE="$(node_identities)"
+[ -n "$BEFORE" ] || fail "no nodes before the re-run — this check needs a live cluster"
+echo "$BEFORE" | sed 's/^/  /'
+
+echo "--- second bring-up ---"
+task up ROLE="$ROLE" PROVIDER="$PROVIDER" KEY="$KEY"
+
+# STRICT=1 turns a non-empty plan into exit 2. This is the assertion; the apply
+# above merely has to not fail.
+echo "--- the plan after it must be empty ---"
+task plan ROLE="$ROLE" PROVIDER="$PROVIDER" STRICT=1 ||
+  fail "the plan is not empty after a second bring-up — the configuration does not converge"
+ok "plan empty: the second bring-up changed nothing"
+
+# Re-fetched rather than reused: the 2026-07-30 defect invalidated this very
+# output, so reading the file we already had would hide exactly what we test.
+task kubeconfig ROLE="$ROLE" PROVIDER="$PROVIDER"
+kubectl get --raw='/readyz' >/dev/null || fail "the kubeconfig no longer reaches the apiserver"
+ok "kubeconfig still valid"
+
+AFTER="$(node_identities)"
+if [ "$BEFORE" != "$AFTER" ]; then
+  diff <(echo "$BEFORE") <(echo "$AFTER") >&2 || true
+  fail "the node set changed — a node was replaced, added or removed by a re-run"
+fi
+ok "$(echo "$AFTER" | wc -l) node(s) unchanged, same creation timestamps"
+
+echo "✓ ${PROVIDER}/${ROLE}: idempotent"

--- a/scripts/dev/staging-upgrade.sh
+++ b/scripts/dev/staging-upgrade.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Upgrade Kubernetes, then Talos, on a running staging cluster — and measure the
+# interruption instead of asserting there was none.
+#
+# 1.0.0 shipped the upgrade path unverified. It was then proven by hand on all
+# three clouds (2026-08-13) and has had no unattended coverage since, which is
+# the same position 1.0.0 was in.
+#
+# WHERE THE TARGET COMES FROM. Not from upstream's newest release: from
+# `cluster/variables.tf`, the pair this repository actually ships. The staging
+# tfvars is expected to pin a patch BELOW it, so a run upgrades toward what a
+# reader deploying today would land on, and Renovate bumping the defaults is what
+# keeps the lane fed. Override with UPGRADE_TALOS_TO / UPGRADE_K8S_TO.
+#
+# NOTHING HERE RETRIES. The first apply after a `talos_version` bump is known to
+# fail on OVH and Outscale (backlog: "Provider produced inconsistent final plan").
+# A retry would turn that defect into a green run, which is how it survived this
+# long.
+#
+# DRY_RUN=1 resolves the versions and rewrites a COPY of the tfvars, then stops
+# before the first task. It needs no cluster and no credentials, and it is what
+# makes the version arithmetic below testable rather than first exercised on a
+# paying account.
+#
+# Usage: staging-upgrade.sh <provider> <role> [ssh-key]
+set -euo pipefail
+
+PROVIDER="${1:?usage: staging-upgrade.sh <provider> <role> [ssh-key]}"
+ROLE="${2:?usage: staging-upgrade.sh <provider> <role> [ssh-key]}"
+KEY="${3:-$HOME/.ssh/id_ed25519}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TFVARS="$ROOT/infrastructure/opentofu/cluster/envs/${ROLE}-${PROVIDER}.tfvars"
+
+# The apiserver is allowed to blink while a control plane restarts — the hand-run
+# on 2026-08-13 lost 3 probe seconds to it. This is a ceiling on that blink, not
+# a claim of zero: raise it only with a measurement that says why.
+MAX_PROBE_FAILS="${MAX_PROBE_FAILS:-15}"
+
+export KUBECONFIG="$ROOT/infrastructure/opentofu/cluster/kubeconfig"
+
+fail() { echo "✗ $*" >&2; exit 1; }
+ok() { echo "✓ $*"; }
+
+[ -f "$TFVARS" ] || fail "no $TFVARS"
+
+if [ "${DRY_RUN:-}" = "1" ]; then
+  DRY_COPY="$(mktemp)"
+  cp "$TFVARS" "$DRY_COPY"
+  TFVARS="$DRY_COPY"
+  trap 'rm -f "$DRY_COPY"' EXIT
+fi
+
+# --- Where we are, and where we are going -------------------------------------
+
+tfvar_get() { # <key> — the tfvars pin, or cluster/variables.tf's default
+  local v
+  v="$(grep -E "^[[:space:]]*${1}[[:space:]]*=" "$TFVARS" | head -1 |
+    sed -E 's/^[^=]*=[[:space:]]*"?([^"#]*)"?.*/\1/' | tr -d '[:space:]')"
+  [ -n "$v" ] || v="$(awk "/variable \"$1\"/,/^}/" "$ROOT/infrastructure/opentofu/cluster/variables.tf" |
+    sed -nE 's/^[[:space:]]*default[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' | head -1)"
+  printf '%s' "$v"
+}
+
+tfvar_set() { # <key> <value> — replace the pin, or add one if the file has none
+  local key="$1" value="$2"
+  if grep -qE "^[[:space:]]*${key}[[:space:]]*=" "$TFVARS"; then
+    sed -i -E "s|^([[:space:]]*${key}[[:space:]]*=[[:space:]]*).*|\1\"$value\"|" "$TFVARS"
+  else
+    printf '\n%s = "%s"\n' "$key" "$value" >>"$TFVARS"
+  fi
+  [ "$(tfvar_get "$key")" = "$value" ] || fail "could not set $key to $value in $TFVARS"
+}
+
+default_of() { # <key> — cluster/variables.tf only, ignoring the tfvars
+  awk "/variable \"$1\"/,/^}/" "$ROOT/infrastructure/opentofu/cluster/variables.tf" |
+    sed -nE 's/^[[:space:]]*default[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' | head -1
+}
+
+TALOS_FROM="$(tfvar_get talos_version)"
+K8S_FROM="$(tfvar_get kubernetes_version)"
+TALOS_TO="${UPGRADE_TALOS_TO:-$(default_of talos_version)}"
+K8S_TO="${UPGRADE_K8S_TO:-$(default_of kubernetes_version)}"
+
+echo "  Talos      ${TALOS_FROM} → ${TALOS_TO}"
+echo "  Kubernetes ${K8S_FROM} → ${K8S_TO}"
+
+if [ "$TALOS_FROM" = "$TALOS_TO" ] && [ "$K8S_FROM" = "$K8S_TO" ]; then
+  # Loud, and a failure — not a skip. A lane that quietly exercises nothing is
+  # indistinguishable from a lane that passed, and this one costs money to run.
+  fail "the staging tfvars already pins both target versions, so this run would
+  upgrade nothing. Pin a patch below cluster/variables.tf in STAGING_TFVARS_B64,
+  or pass UPGRADE_TALOS_TO / UPGRADE_K8S_TO."
+fi
+
+if [ "${DRY_RUN:-}" = "1" ]; then
+  # Guarded exactly as the real path is, or the dry run would show a rewrite the
+  # real run never performs.
+  if [ "$K8S_FROM" != "$K8S_TO" ]; then tfvar_set kubernetes_version "$K8S_TO"; fi
+  if [ "$TALOS_FROM" != "$TALOS_TO" ]; then tfvar_set talos_version "$TALOS_TO"; fi
+  echo "--- what the tfvars would become ---"
+  diff -u "$ROOT/infrastructure/opentofu/cluster/envs/${ROLE}-${PROVIDER}.tfvars" "$TFVARS" || true
+  ok "dry run: versions resolved and the tfvars rewrite is well-formed"
+  exit 0
+fi
+
+# --- The probe ----------------------------------------------------------------
+# One second apart, against the endpoint in the kubeconfig — never a tunnel to a
+# single node, which measures the node we are deliberately taking away.
+
+PROBE_LOG="$(mktemp)"
+probe() {
+  while :; do
+    if kubectl get --raw=/readyz --request-timeout=2s >/dev/null 2>&1; then
+      echo ok
+    else
+      echo FAIL
+    fi
+    sleep 1
+  done >>"$PROBE_LOG"
+}
+probe &
+PROBE_PID=$!
+# shellcheck disable=SC2064  # PROBE_PID must expand now, not at trap time
+trap "kill $PROBE_PID 2>/dev/null || true; rm -f '$PROBE_LOG'" EXIT
+
+report_probe() {
+  local fails total
+  fails="$(grep -c FAIL "$PROBE_LOG" || true)"
+  total="$(wc -l <"$PROBE_LOG")"
+  echo "  probe: ${fails} FAIL in ${total} samples (~1s apart)"
+  [ "$fails" -le "$MAX_PROBE_FAILS" ] ||
+    fail "the API was unreachable for ~${fails}s, over the ${MAX_PROBE_FAILS}s this lane allows"
+}
+
+# --- Kubernetes first: no reboot, so it isolates the control-plane roll --------
+
+if [ "$K8S_FROM" != "$K8S_TO" ]; then
+  echo "--- Kubernetes ${K8S_FROM} → ${K8S_TO} ---"
+  tfvar_set kubernetes_version "$K8S_TO"
+  task infra ROLE="$ROLE" PROVIDER="$PROVIDER"
+
+  # Talos reconciles the static pods and the kubelets; the node's reported
+  # version is the observable end of that, and it is not instant.
+  echo "waiting for every kubelet to report ${K8S_TO}"
+  for _ in $(seq 1 60); do
+    STALE="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.kubeletVersion}{"\n"}{end}' |
+      grep -cvx "$K8S_TO" || true)"
+    [ "$STALE" -eq 0 ] && break
+    sleep 10
+  done
+  [ "${STALE:-1}" -eq 0 ] || fail "${STALE} kubelet(s) still not on ${K8S_TO} after 10 minutes"
+  ok "every kubelet on ${K8S_TO}"
+  report_probe
+fi
+
+# --- Then Talos, in place ------------------------------------------------------
+
+if [ "$TALOS_FROM" != "$TALOS_TO" ]; then
+  echo "--- Talos ${TALOS_FROM} → ${TALOS_TO} ---"
+
+  # The nodes ignore their image attribute, but the image DATA SOURCE still has
+  # to resolve, and it derives its name from talos_version. Without this the
+  # plan fails on an image the account does not have.
+  task talos-image PROVIDER="$PROVIDER" VERSION="$TALOS_TO" ENSURE=1
+
+  tfvar_set talos_version "$TALOS_TO"
+  task infra ROLE="$ROLE" PROVIDER="$PROVIDER"
+
+  # One node at a time, health-gated between each; control planes first because
+  # a worker's upgrade needs a healthy control plane to drain against.
+  task rolling-replace PROVIDER="$PROVIDER" KEY="$KEY" -- --cp-only --upgrade
+  task rolling-replace PROVIDER="$PROVIDER" KEY="$KEY" -- --workers-only --upgrade
+
+  RUNNING="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.osImage}{"\n"}{end}' |
+    grep -cv "$TALOS_TO" || true)"
+  [ "$RUNNING" -eq 0 ] || fail "${RUNNING} node(s) are not running Talos ${TALOS_TO}"
+  ok "every node on Talos ${TALOS_TO}"
+  report_probe
+fi
+
+# --- What a clean upgrade leaves behind ----------------------------------------
+
+# Zero destroys. A plan that wants to replace nodes means the boot image and the
+# running version have disagreed — that plan would take the cluster down.
+# See modules/providers/provider-contract.md § "Node image drift".
+task plan ROLE="$ROLE" PROVIDER="$PROVIDER" STRICT=1 ||
+  fail "the plan is not empty after the upgrade — read provider-contract.md § Node image drift before re-running anything"
+ok "plan empty after the upgrade"
+
+"$ROOT/scripts/dev/staging-verify.sh" "$PROVIDER" "$ROLE"
+
+report_probe
+echo "✓ ${PROVIDER}/${ROLE}: upgraded ${TALOS_FROM}→${TALOS_TO} / ${K8S_FROM}→${K8S_TO}, in place"

--- a/scripts/internal/install-task.sh
+++ b/scripts/internal/install-task.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Install go-task, pinned and checksum-verified.
+#
+# There were two ways Task got installed and neither was good. CI used
+# `arduino/setup-task`, a third-party action that queries the releases API
+# UNAUTHENTICATED from a shared runner IP — that is what took `main` red on
+# 2026-08-13 with nothing wrong in the code. `setup.sh` used
+# `sh -c "$(curl https://taskfile.dev/install.sh)"`, unpinned and unverified, in a
+# repository that checksums helm, gitleaks, feint and tflint.
+#
+# One way now, the same shape as every other tool here: a pinned version, the
+# project's own checksums file, and no third party in the path.
+#
+# Usage: install-task.sh [bin-dir]        (default: /usr/local/bin, else ~/.local/bin)
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.*)$
+TASK_VERSION="3.52.0"
+
+BIN_DIR="${1:-}"
+if [ -z "$BIN_DIR" ]; then
+  if [ -w /usr/local/bin ]; then BIN_DIR=/usr/local/bin
+  elif command -v sudo >/dev/null 2>&1; then BIN_DIR=/usr/local/bin
+  else BIN_DIR="$HOME/.local/bin"
+  fi
+fi
+SUDO=""
+[ -w "$BIN_DIR" ] || [ ! -d "$BIN_DIR" ] || SUDO="sudo"
+
+# `task --version` prints a bare "3.52.0" today and "Task version: v3.x.y" on
+# older releases, so match either, and bound it so 3.52.0 does not match 3.52.01.
+if command -v task >/dev/null 2>&1 &&
+  task --version 2>/dev/null | grep -qE "(^|[^0-9.])v?${TASK_VERSION//./\\.}([^0-9.]|\$)"; then
+  echo "task v${TASK_VERSION} already installed"
+  exit 0
+fi
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) asset="task_linux_amd64.tar.gz" ;;
+  Linux-aarch64 | Linux-arm64) asset="task_linux_arm64.tar.gz" ;;
+  Darwin-x86_64) asset="task_darwin_amd64.tar.gz" ;;
+  Darwin-arm64) asset="task_darwin_arm64.tar.gz" ;;
+  *) echo "✗ no published task binary for $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+base="https://github.com/go-task/task/releases/download/v${TASK_VERSION}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/task_checksums.txt" "$base/task_checksums.txt"
+# --ignore-missing: the file lists every platform, and without it the check fails
+# on the ones we did not download — which reads like a bad binary.
+(cd "$tmp" && sha256sum -c task_checksums.txt --ignore-missing)
+
+tar xzf "$tmp/$asset" -C "$tmp" task
+mkdir -p "$BIN_DIR" 2>/dev/null || $SUDO mkdir -p "$BIN_DIR"
+$SUDO install -m 0755 "$tmp/task" "$BIN_DIR/task"
+echo "installed task v${TASK_VERSION} → $BIN_DIR/task"

--- a/scripts/internal/install-tflint.sh
+++ b/scripts/internal/install-tflint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Install tflint, pinned and checksum-verified.
+#
+# `task lint` calls it and `scripts/setup.sh` did not install it, so the first
+# command a new contributor runs failed on a machine this repository's own setup
+# had just declared ready. Measured 2026-08-14 in a bare ubuntu:24.04.
+#
+# Three copies of this download existed before: a SHA-pinned CI action, a block
+# in the session-start hook, and nothing at all in setup.sh. One now.
+#
+# Usage: install-tflint.sh [bin-dir]      (default: /usr/local/bin, else ~/.local/bin)
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=terraform-linters/tflint
+TFLINT_VERSION="v0.64.0"
+
+BIN_DIR="${1:-}"
+if [ -z "$BIN_DIR" ]; then
+  if [ -w /usr/local/bin ] || command -v sudo >/dev/null 2>&1; then
+    BIN_DIR=/usr/local/bin
+  else
+    BIN_DIR="$HOME/.local/bin"
+  fi
+fi
+SUDO=""
+[ -w "$BIN_DIR" ] || [ ! -d "$BIN_DIR" ] || SUDO="sudo"
+
+if command -v tflint >/dev/null 2>&1 && tflint --version 2>/dev/null | grep -qF "${TFLINT_VERSION#v}"; then
+  echo "tflint ${TFLINT_VERSION} already installed"
+  exit 0
+fi
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) asset="tflint_linux_amd64.zip" ;;
+  Linux-aarch64 | Linux-arm64) asset="tflint_linux_arm64.zip" ;;
+  Darwin-x86_64) asset="tflint_darwin_amd64.zip" ;;
+  Darwin-arm64) asset="tflint_darwin_arm64.zip" ;;
+  *) echo "✗ no published tflint binary for $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+# tflint ships a zip, and a bare ubuntu:24.04 has no unzip — setup.sh only pulls
+# it in later, for the AWS bundle, so this ran first and died on a missing tool.
+if ! command -v unzip >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    $SUDO apt-get update -qq && $SUDO apt-get install -y -qq unzip
+  else
+    echo "✗ unzip is required to install tflint, and I cannot install it here" >&2
+    exit 1
+  fi
+fi
+
+base="https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
+# Grep the one line rather than --ignore-missing: tflint's checksums file lists
+# every asset, and we want a hard failure if OUR asset is not in it.
+(cd "$tmp" && grep " ${asset}\$" checksums.txt | sha256sum -c -)
+
+unzip -q -o "$tmp/$asset" -d "$tmp"
+mkdir -p "$BIN_DIR" 2>/dev/null || $SUDO mkdir -p "$BIN_DIR"
+$SUDO install -m 0755 "$tmp/tflint" "$BIN_DIR/tflint"
+echo "installed tflint ${TFLINT_VERSION} → $BIN_DIR/tflint"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -119,20 +119,27 @@ install_checkov() {
     else
         echo "⚠️  Could not install checkov automatically — 'task security' will stop"
         echo "   at the checkov step. Install it manually: pipx install checkov"
+        return
+    fi
+
+    # Installed is not the same as reachable. pipx and `pip --user` both land in
+    # ~/.local/bin, which is not on PATH on a fresh Ubuntu — so `task security`
+    # still died with "executable file not found" on a machine where checkov was
+    # present. pipx says so in a warning nobody reads; this makes it true instead.
+    if ! command -v checkov &> /dev/null && [ -x "$HOME/.local/bin/checkov" ]; then
+        command -v pipx &> /dev/null && pipx ensurepath >/dev/null 2>&1 || true
+        export PATH="$HOME/.local/bin:$PATH"
+        echo "⚠️  checkov is in ~/.local/bin, which was not on your PATH."
+        echo "   Added for the rest of this script and to your shell profile;"
+        echo "   open a new shell, or: export PATH=\"\$HOME/.local/bin:\$PATH\""
     fi
 }
 
 install_task() {
-    echo "Installing Task..."
-    if [ -w /usr/local/bin ]; then
-        sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
-    elif command -v sudo &> /dev/null; then
-        $SUDO sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
-    else
-        mkdir -p ~/.local/bin
-        sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
-        echo "NOTE: task installed to ~/.local/bin. Ensure it's in your PATH."
-    fi
+    # One installer, shared with CI, pinned and checksum-verified. This used to
+    # pipe an unpinned https://taskfile.dev/install.sh into sh — the only tool
+    # here that was neither pinned nor verified.
+    "$(dirname "${BASH_SOURCE[0]}")/internal/install-task.sh"
 }
 
 install_awscli_bundle() {
@@ -256,7 +263,14 @@ if ! check_cmd task; then
     install_task
 fi
 
-# 5b. Check checkov (`task security` runs it directly; only CI ever had it)
+# 5b. Check tflint — `task lint` calls it, and this script did not install it, so
+# the first command a contributor runs failed on a machine we had just called
+# ready. Found 2026-08-14 in a bare ubuntu:24.04.
+if ! check_cmd tflint; then
+    "$(dirname "${BASH_SOURCE[0]}")/internal/install-tflint.sh"
+fi
+
+# 5c. Check checkov (`task security` runs it directly; only CI ever had it)
 if ! check_cmd checkov; then
     install_checkov
 fi


### PR DESCRIPTION
## What this is

Everything that made "deploy + idempotency + upgrade on three clouds" a claim rather than a fact was that a human ran the commands once. `staging.yml` was supposed to be the answer, and it had **never executed**: merged 2026-08-13 with no `staging` environment and none of its secrets set, so its first scheduled fire (Monday 03:17 UTC) would have died on an empty blob. A workflow that has never run looks exactly like one that passes.

## The lane

| Before | After |
|---|---|
| cron fell through to `inputs.provider \|\| 'scaleway'` → OVH and Outscale never exercised | dispatch = the provider you pick; schedule = all three |
| one shared `STAGING_TFVARS_B64` | one **per provider** — a shared blob would write Scaleway's addresses into OVH's env file the moment this ran as a matrix |
| no SSH key step; `task up` refuses to start without one | `STAGING_SSH_PRIVATE_KEY`, validated with `ssh-keygen -y` before anything bills |
| deploy → verify → destroy | + idempotency + upgrade |
| `timeout-minutes: 90` | 210, sized for the three stages |

**Idempotency** (`staging-idempotency.sh`): a second `task up` must leave an empty plan, the same nodes with the same `creationTimestamp`s, and a kubeconfig that still reaches the apiserver — the three things the 2026-07-30 defect broke.

**Upgrade** (`staging-upgrade.sh`): Kubernetes then Talos, in place, 1s readyz probe throughout, target read from `cluster/variables.tf` so Renovate keeps the lane fed. **No retry** of the apply known to fail on OVH/Outscale — a retry would turn that defect green. Refuses to run rather than pass when the tfvars already pins both targets.

## Also here

- **Task and tflint were the last unpinned tools.** `arduino/setup-task` queries the releases API *unauthenticated* from a shared runner IP — that took `main` red on 2026-08-13 with nothing wrong in the code — and `setup.sh` piped an unpinned `taskfile.dev/install.sh` into `sh`. A token would have fixed the symptom. Both replaced by `scripts/internal/install-{task,tflint}.sh`: pinned, checksum-verified, one file each, shared by CI, `setup.sh` and the session-start hook (which had a third hand-written copy).
- **`task setup` still did not leave a machine able to run `task lint`.** tflint was never installed; checkov was installed into `~/.local/bin` and left off PATH, so `task security` died about a tool that was present. Found only by re-running the bare-container validation. Now 11/11.
- **Feint 0.7.3** — both issues this repo filed are served: `CreateTags` (#99) and a whole Scaleway product answering a plain-text 404 the SDK discarded (#74; `/lb/v1/` and `/vpc-gw/v2/` answer `501` in Scaleway's dialect now). The fixture tags six kinds rather than putting back the three it had removed.
- **`docs/upgrade.md` (+ `.fr.md`)** — the runbook this repository did not have. The procedure lived in a doc titled "release checklist 1.0.1" and in `.claude/skills/`: readable by a release manager and by an assistant, not by an operator upgrading on a Tuesday. §7 now points at it.
- **The version-bump failure has a name**: upstream `siderolabs/terraform-provider-talos`#352, on `.machine_configuration_hash`, fixed in the 0.12.0 pre-release line only. Which also explains why running it twice works. Not "most likely the port-ready guards". Still open, with the decision written down instead of a guess.
- **Three stale claims corrected**, including the published 1.0.0 release note, which blamed seven PodDisruptionBudgets for a drain that one was pinning.

## Rungs reached

- ✅ mocked — `tofu test` 41/41, `validate`, `tflint`, `yamllint`, `actionlint`, language and skill-parity checks
- ✅ emulated — `task feint-test` green on 0.7.3, both providers, both lanes; `feint-record` re-measured
- ✅ clean machine — `scripts/setup.sh` exit 0 in a bare `ubuntu:24.04`, eleven tools out of eleven reachable
- ❌ real cloud — **the two new staging stages have not run against a provider, and cannot until the secrets exist.** Their version arithmetic is covered by `DRY_RUN=1`. `scripts/dev/check-staging-secrets.sh` prints exactly what is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM