### PR TITLE
security: a real IP leaked through a test fixture, and a purge does not close it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ## [0.1.0] — 2026-08-20
 
+> **The 0.1.0 tag was moved once before publication**, from `421c1ee` to
+> `fc24092`. Reading the published tag as a stranger — §9 of the release
+> checklist, which exists for this — found a real admin IP that had been serving
+> as a test fixture in `check-gitleaks-rules.sh` since 2026-08-13. History was
+> rewritten and the tag re-cut on the clean commit. No release had been published
+> under the first tag, and nothing depended on it. GitHub still serves the old
+> blob by direct SHA and the diff of the pull request that introduced it; only
+> GitHub Support can remove those.
+
 **One Talos cluster, on one supported cloud, with one fixed foundation: Cilium.**
 Infrastructure only — nothing above that layer. Start at
 [`docs/first-cluster.md`](docs/first-cluster.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,23 @@ dans `OpenAether-apps` et ont nécessité une purge d'historique (`git
 filter-repo`, `--replace-text` ET `--replace-message` — les messages de commit
 ne sont PAS couverts par le premier seul).
 
+**Le gitignore ne suffit pas : les FIXTURES DE TEST fuient aussi.** Incident du
+2026-08-20, trouvé pendant le §9 de la 0.1.0 : une IP admin réelle servait de cas
+`CATCH` dans `check-gitleaks-rules.sh`, publique depuis le 2026-08-13. Elle avait
+été choisie *parce que* la règle exige une adresse routable — une plage RFC 5737
+serait allowlistée et le test ne prouverait rien. Le bon choix est la plage
+RFC 1112 « réservée usage futur », allouée à personne : routable aux yeux de la
+règle, à personne dans les faits. Ne pas écrire l'adresse ici — cette page est
+scannée, la fixture ne l'est pas (`.gitleaks-envdata.toml` l'exempte par chemin),
+et l'écrire a fait rougir la CI de la PR qui documentait l'incident.
+
+**Et une purge d'historique ne referme pas tout.** Mesuré le jour même, après un
+`filter-repo` vérifié sur 1885 blobs : les refs sont propres depuis un clone neuf,
+mais GitHub sert encore le diff de la PR d'origine et l'ancien blob par son SHA
+(`/contents/<path>?ref=<vieux-sha>`). Seul le support GitHub peut les faire
+disparaître. Une donnée publiée est publiée ; la purge limite la suite, elle
+n'annule pas le passé.
+
 ## Objectif produit — socle Talos modulaire, management CAPI optionnel
 
 OpenAether déploie **un cluster Talos** sur **n'importe quel provider** (Proxmox ou

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -257,6 +257,19 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
       **Closes:** a mutation for each shape, each seen to go red before it is
       believed; counts asserted against expected values. Rung: `task test`.
 
+- [ ] **The purged IP is still served by GitHub, and only GitHub can stop that.**
+      A real admin address reached this public repository on 2026-08-13 as a
+      `CATCH` fixture in `check-gitleaks-rules.sh`. History was rewritten on
+      2026-08-20 (`filter-repo`, `--replace-text` AND `--replace-message`) and a
+      fresh clone is clean — 1885 blobs scanned, 0 occurrences, the scan itself
+      checked against an unpurged clone so it was known to detect. What is STILL
+      served, measured the same day: the diff of PR #21, and the old blob by
+      direct SHA (`/contents/<path>?ref=<old-sha>` returns it). Anyone who cloned
+      before the rewrite has it regardless.
+      **Closes:** GitHub Support asked to garbage-collect the unreachable objects
+      and remove PR #21's stored diff, and both re-checked afterwards with the
+      same two queries. Rung: nothing local can prove this one.
+
 - [ ] **Encrypted worker volumes are applied and never verified.** The reference
       Scaleway cluster declares `worker_storage`, three `scaleway_block_volume`
       resources are in its state, and `modules/talos/main.tf:181` renders a LUKS2


### PR DESCRIPTION
Found during §9 of the 0.1.0 checklist — reading the published tag as a stranger,
which is what that step exists for.

`check-gitleaks-rules.sh` used a **real admin IP** as its `CATCH` fixture for the
routable-IPv4 rule. Public since 2026-08-13.

It was routable on purpose: the rule allowlists RFC 5737 and RFC 1918, so a
documentation address would be swallowed and the test would prove nothing. The
replacement is `240.0.0.1` — RFC 1112 "reserved for future use", allocated to
nobody, not in the allowlist. Verified before it was proposed: `6 caught, 8
ignored`, the same verdict as with the real address.

**History has been rewritten** (`filter-repo`, `--replace-text` AND
`--replace-message`) and force-pushed. Verified from a fresh clone: 1885 blobs,
0 occurrences, 0 commit messages. The scan itself was checked against an
unpurged clone first — my first version returned 0 there too, because it piped
`<sha> <path>` into `cat-file --batch-check` and read no blobs at all.

**The purge does not close it, and this PR says so.** Measured the same day:
GitHub still serves PR #21's diff and the old blob by direct SHA. Only Support
can remove those. Both facts are recorded in `CLAUDE.md` beside the 2026-07-31
incident, with the follow-up as a backlog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM
