### PR TITLE
feat(feint): pin 0.10.0, and make the pin something feint-up actually honours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ Talos API, never from the tool that performed the upgrade.
   restarts an apiserver per control plane by itself. Two workloads, two numbers
   that do not compare — quote the 5/7/8 figures.
 - **353 offline assertions across 14 harnesses**, every one mutation-tested
-  (`task test-scripts`). The emulated lane runs feint 0.9.0 against Scaleway provider
+  (`task test-scripts`). The emulated lane runs feint 0.10.0 against Scaleway provider
   2.81.0 — the same version the clusters run.
 
 ### Fixed

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -64,7 +64,7 @@ Destroy always takes two commands and no flag collapses them. S3 credentials are
 namespaced by the cloud that HOLDS the bucket, and a cross-provider backup is
 proven — an encrypted tfstate at Outscale while the cluster runs on Scaleway.
 353 offline assertions across 14 harnesses, every one mutation-tested; the
-emulated lane runs feint 0.9.0 against Scaleway provider 2.81.0, the version the
+emulated lane runs feint 0.10.0 against Scaleway provider 2.81.0, the version the
 clusters run.
 
 **The root cause behind a week of upgrade failures is fixed**, and it was ours:
@@ -495,7 +495,7 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
       Separately, `feint shapes` compares our providers' answers against a real
       cloud, which a proxy cannot do alone — recording needs a real account and
       rides on the next real-cloud session, then `--check` runs offline.
-      The measurements behind this predate feint 0.9.0 and must be re-run.
+      The measurements behind this predate feint 0.10.0 and must be re-run.
       **Closes:** `task feint-apply` reaching an apply on the real cluster root,
       both providers; `feint shapes --check` green against a recording.
 

--- a/docs/emulated-cloud.fr.md
+++ b/docs/emulated-cloud.fr.md
@@ -116,7 +116,7 @@ régressions de câblage avant de dépenser.
 
 ## Manques connus
 
-Épinglé sur **Feint 0.9.0** (`scripts/dev/feint.sh`). Ce que cette voie ne peut
+Épinglé sur **Feint 0.10.0** (`scripts/dev/feint.sh`). Ce que cette voie ne peut
 toujours pas porter, tout consigné dans [`backlog.md`](backlog.md) :
 
 | Non exercé | Pourquoi |

--- a/docs/emulated-cloud.md
+++ b/docs/emulated-cloud.md
@@ -112,7 +112,7 @@ the only proof of a deployment; this catches wiring regressions before spending.
 
 ## Known gaps
 
-Pinned to **Feint 0.9.0** (`scripts/dev/feint.sh`). What this lane still cannot
+Pinned to **Feint 0.10.0** (`scripts/dev/feint.sh`). What this lane still cannot
 carry, all recorded in [`backlog.md`](backlog.md):
 
 | Not exercised | Why |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -112,13 +112,14 @@ task feint-down
       empty re-plan and a destroy confirmed against the API → 2026-08-20, feint
       0.9.0: Scaleway 8 added / empty re-plan / 8 destroyed, Outscale 27 / empty
       / 27, both confirmed against the API, no credentials in the shell.
-- [x] the ranking shows no operation that was not there before — but there are
-      now **three**, not four: 2 on Scaleway (`lb ips`, `vpc-gw ips`) and 1 on
-      Outscale (`CreateLoadBalancer`), all answering 501 or 404. `ipam BookIP`
-      left the list because feint 0.9.0 **serves** it now — it appears under
-      "already served" with 3 calls in 200/201. Fewer is not the alarm; a new one
-      would be, and there is none. Update this line, not the count, when the
-      emulator gains another.
+- [x] the ranking is **empty on both providers** — `every operation the client
+      called is served by a pack`. It was three under 0.9.0 (`lb ips` and
+      `vpc-gw ips` on Scaleway, `CreateLoadBalancer` on Outscale) and four before
+      that; 0.10.0 closed the last of them, and the served-and-exercised count rose
+      from 19 to 50 on Scaleway and 23 to 27 on Outscale because the plan now
+      reaches the load balancers instead of stopping at them. An empty ranking is
+      not the alarm this line watches for — a NEW entry is, and there is none.
+      Update the line, not the count, when one appears.
 - [x] the guard refuses a non-loopback endpoint — check it both ways, as a Task
       variable and as an environment variable. A Task variable is not an
       environment variable, and this test once passed without testing anything.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -96,7 +96,7 @@ baseline and not a picture of what was already there.
 
 ## 3. Emulated cloud — no account, real provider binaries
 
-The lane is pinned to Feint 0.9.0, running against the same Scaleway provider
+The lane is pinned to Feint 0.10.0, running against the same Scaleway provider
 version the clusters run.
 
 ```bash

--- a/scripts/dev/feint.sh
+++ b/scripts/dev/feint.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # renovate: datasource=github-releases depName=stephrobert/feint extractVersion=^v(?<version>.*)$
-FEINT_VERSION="0.9.0"
+FEINT_VERSION="0.10.0"
 FEINT_ENDPOINT="${FEINT_ENDPOINT:-http://127.0.0.1:4599}"
 BIN_DIR="${FEINT_BIN_DIR:-$HOME/.local/bin}"
 
@@ -307,7 +307,13 @@ case "${1:-}" in
   install) install_feint ;;
   start)
     guard_local "$FEINT_ENDPOINT"
-    command -v feint >/dev/null 2>&1 || install_feint
+    # install_feint unconditionally: it returns early when the version already
+    # matches, and it is the ONLY thing that compares one. This used to read
+    # `command -v feint || install_feint`, which installs when the binary is
+    # ABSENT and never asks which version a present one is — so FEINT_VERSION was
+    # honoured on a fresh machine and decorative on every machine that had already
+    # run the lane. Bumping the pin to 0.10.0 on 2026-08-21 kept running 0.9.0.
+    install_feint
     # Idempotent: `feint start` refuses when one is already listening, and a
     # target you cannot run twice is a target nobody re-runs after a failure.
     # Matched on the output, not the exit code: `feint status` exits 0 either


### PR DESCRIPTION
Small and self-contained, as asked.

## The version pin was not honoured

Bumping `FEINT_VERSION` changed nothing — `feint version` still answered `v0.9.0`
and the lane ran on it. The start path reads

```bash
command -v feint >/dev/null 2>&1 || install_feint
```

which installs when the binary is **absent** and never asks which version a
present one is. `install_feint` does compare — that guard is at `feint.sh:89` —
but start never reaches it once anything called feint exists. So the pin was
honoured on a fresh machine and **decorative on every machine that had already
run the lane**.

**CI is unaffected**: it calls `feint.sh install` directly (`ci.yml:259`), the path
that compares. This only ever bit developer machines.

start now calls `install_feint` unconditionally and lets it decide. Proof: the same
`task feint-up` that had been silently reusing 0.9.0 downloaded and installed
0.10.0.

## 0.10.0, measured

No credentials in the shell:

| | Scaleway | Outscale |
|---|---|---|
| plan against the emulator | ✅ | ✅ |
| apply / empty re-plan / destroy | ✅ 8 / 8 | ✅ 27 / 27 |

**The unserved-operation ranking is now empty on both providers** — `every
operation the client called is served by a pack`. It was three under 0.9.0
(`lb ips`, `vpc-gw ips`, `CreateLoadBalancer`), and 0.10.0 closed the last of them
(#315). Served-and-exercised rose from 19 to 50 on Scaleway and 23 to 27 on
Outscale, because the plan now reaches the load balancers instead of stopping at
them.

0.10.0's other changes are almost all in `--vm incus-ovn`, the runtime that boots
real machines, which this lane does not use. The two that could reach us — the
transcript's new `host` field and CLI surface version 5 — broke neither the plan
nor the CRUD cycle.

## One correction

A blanket sed over "feint 0.9.0" rewrote two dated statements. One is reverted:
`ipam BookIP` left the ranking because **0.9.0** served it, not 0.10.0. The other
is kept deliberately — measurements that predated 0.9.0 predate 0.10.0 too, and
that is the version they must now be re-run against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM
