### PR TITLE
ci(security): audit the pipeline itself, not only what it carries

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,3 +43,81 @@ jobs:
 
       - name: Run gitleaks
         run: gitleaks git -v --redact
+
+  # ---------------------------------------------------------------------------
+  # gitleaks above reads what the pipeline CARRIES. Nothing read the pipeline
+  # itself — unpinned actions, dangerous triggers, a checkout of a fork's HEAD
+  # under pull_request_target, over-broad permissions, a security job quietly
+  # weakened. Those live in the workflow files, and until now only review stood
+  # between a pull request and any of them.
+  #
+  # 0.1.0 deleted the credentialed lane, so no workflow here touches a cloud
+  # account. That removes the worst blast radius and removes nothing else: these
+  # two workflows still run on every pull request, with a token, against a
+  # public repository.
+  # ---------------------------------------------------------------------------
+  pipeline-audit:
+    name: Pipeline audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write  # SARIF upload to Code Scanning
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      # Deliberately no .plumber.yaml. A config file REPLACES the built-in policy
+      # instead of extending it: a minimal one, measured on 2026-08-11, left 22 of
+      # the 23 controls "skipped" while the run still read as normal — a gate
+      # checking one thing in twenty-three and reporting success. The policy stays
+      # the shipped default, and the step below asserts what stood down.
+      #
+      # branchMustBeProtected is NOT skipped here, deliberately, and this run is
+      # the experiment. `main` has been protected since 2026-08-20 — 13 required
+      # checks, no force-push, no deletions — and plumber's own control answers
+      # `passed` when it can read that, measured locally on 2026-08-21 with a
+      # token that can. What is not known is whether the DEFAULT CI token can:
+      # an earlier run on v0.4.36 reported it could not, and that plumber then
+      # exits 3 ("incomplete data") and withholds every other verdict. That claim
+      # is inherited, not measured here, and the cheapest way to settle it is to
+      # let this job answer. If it exits 3, the skip comes back with the evidence
+      # in the commit that adds it.
+      - name: Plumber
+        uses: getplumber/plumber@031bc86d1e5f661626e2000f4f8779912d608d5f  # v0.4.39
+        with:
+          # Publishing the score sends this repository's name to a hosted badge
+          # service. That is a decision to take on purpose, not a CI default.
+          score-push: false
+          upload-sarif: ${{ github.event_name == 'push' }}
+          upload-artifacts: false
+
+      # A scanner that quietly stops scanning is the failure mode this repository
+      # keeps meeting. Two controls stand down by design; a third means the policy
+      # moved under us, and a green run would say nothing about it.
+      - name: The audit still audits
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json, sys
+
+          try:
+              report = json.load(open("plumber-report.json"))
+          except OSError:
+              sys.exit("::error::no plumber-report.json — the analysis never ran")
+
+          controls = {k: v for k, v in report.items()
+                      if k.endswith("Result") and isinstance(v, dict)}
+          skipped = sorted(k for k, v in controls.items() if v.get("status") == "skipped")
+          ran = [k for k, v in controls.items() if v.get("status") not in (None, "skipped")]
+          # Only requiredActionsResult stands down on its own — measured against
+          # v0.4.39 on this tree, 22 of 23 evaluated. branchProtectionResult joins
+          # it only if the token cannot read the settings, which is what this run
+          # is here to find out.
+          expected = ["requiredActionsResult"]
+
+          if report.get("dataCollectionDegraded") or skipped != expected:
+              sys.exit(f"::error::{len(ran)} controls evaluated, skipped={skipped} "
+                       f"(expected {expected}), "
+                       f"degraded={report.get('dataCollectionDegraded')}")
+          print(f"{len(ran)} controls evaluated, {len(skipped)} stood down as declared")
+          PY

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -196,6 +196,27 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
       **Closes:** one bump of a node size on a live cluster, with the probe
       running, and the answer recorded either way. Rung: real cloud.
 
+- [ ] **Nothing local runs the pipeline audit.** `plumber` gates the workflow
+      files in CI, and the only way to know what it says before pushing is to
+      fetch the binary by hand — which is how this branch measured the control
+      count and the stand-down set. Every other checker here has a task:
+      `task security`, `task lint`, `task test-scripts`.
+      **Closes:** `task pipeline-audit` installing the pinned, checksum-verified
+      binary and running the policy CI runs, wired into `task security`. Rung:
+      mocked.
+
+- [ ] **branchMustBeProtected may be unreadable to the CI token, and that is
+      inherited rather than measured.** `main` has been protected since
+      2026-08-20, and plumber's control answers `passed` when it can read the
+      settings — measured locally 2026-08-21 with a token that can. A run on
+      v0.4.36 reported the default CI token cannot, and that plumber then exits 3
+      and withholds every other verdict. The job ships WITHOUT the skip so that
+      run answers it. If it exits 3, the alternative is `administration: read` on
+      that job — widening the token to satisfy one control — and that is the
+      trade to decide, not to default.
+      **Closes:** the CI run's own answer, recorded here, and the skip or the
+      permission chosen with it. Rung: the pipeline itself.
+
 - [ ] **Nothing lets you ask what is in the state.** Reading it takes the root
       directory, its per-cluster `TF_DATA_DIR` and two credentials resolved
       through `resolve-s3-cred.sh` — four things to get right, and getting one


### PR DESCRIPTION
Small and self-contained, like #30.

gitleaks reads what the workflows **carry**. Nothing read the workflows themselves
— unpinned actions, dangerous triggers, a fork's HEAD checked out under
`pull_request_target`, over-broad permissions, a security job quietly weakened.
Those live in the workflow files, and until now only review stood between a pull
request and any of them.

## Rebuilt, not rebased

`claude/plumber-cicd-audit` dates from 2026-08-11 and two thirds of it no longer
apply:

- its **tflint fix landed on main independently**, and better — extracted into
  `scripts/internal/install-tflint.sh`
- its **central justification died with `staging.yml`** on 2026-08-20: "a
  regression detector over the credentialed lane, whose trigger surface is its
  whole design"

The audit is still worth having. These two workflows run on every pull request,
with a token, against a public repository.

## Measured here, not inherited

Binary v0.4.39 fetched checksum-verified and run against this tree:

```
23 controls · 22 evaluated · 0 findings · passed: true
stand-down: requiredActionsResult
```

Pinned by SHA to **v0.4.39**, three patches on from what that branch used. The one
change that could have moved the ground is 0.4.39's *findings control library* —
the count is unchanged at 23.

## Two deliberate choices

**No `.plumber.yaml`.** A config file *replaces* the built-in policy rather than
extending it. A minimal one left 22 of 23 controls skipped while the run still
read as normal — a gate checking one thing in twenty-three and reporting success.
`The audit still audits` asserts the stand-down **set** instead, which is what
catches a policy moving underneath.

**`branchMustBeProtected` is NOT skipped, and this run is the experiment.** `main`
has been protected since 2026-08-20 (13 required checks, no force-push, no
deletions) and plumber's own control answers `passed` when it can read that —
measured locally with a token that can. Whether the **default CI token** can is a
claim inherited from the earlier branch and never measured here. Letting this job
answer costs one round-trip. **If it exits 3, the skip comes back with the
evidence in the commit that adds it** — the alternative being `administration:
read`, which widens the token to satisfy one control, and that is a trade to
decide rather than default.

Backlogged: nothing local runs this audit, where every other checker here has a
task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM
