### PR TITLE
fix(docs): 333 offline assertions across 11 harnesses, not 353 across 14

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -72,16 +72,15 @@ jobs:
       # checking one thing in twenty-three and reporting success. The policy stays
       # the shipped default, and the step below asserts what stood down.
       #
-      # branchMustBeProtected is NOT skipped here, deliberately, and this run is
-      # the experiment. `main` has been protected since 2026-08-20 — 13 required
-      # checks, no force-push, no deletions — and plumber's own control answers
-      # `passed` when it can read that, measured locally on 2026-08-21 with a
-      # token that can. What is not known is whether the DEFAULT CI token can:
-      # an earlier run on v0.4.36 reported it could not, and that plumber then
-      # exits 3 ("incomplete data") and withholds every other verdict. That claim
-      # is inherited, not measured here, and the cheapest way to settle it is to
-      # let this job answer. If it exits 3, the skip comes back with the evidence
-      # in the commit that adds it.
+      # branchMustBeProtected is NOT skipped, and that was an open question until
+      # this job answered it. A run on v0.4.36 reported the default CI token could
+      # not read repository settings, and that plumber then exits 3 ("incomplete
+      # data") withholding every other verdict — which is why the earlier attempt
+      # skipped the control. Measured under v0.4.39 on 2026-08-21: the default
+      # token CAN read them. The run reported `22 controls evaluated, 1 stood down
+      # as declared` and the control passed. `main` has been protected since
+      # 2026-08-20 — 13 required checks, no force-push, no deletions — so this is
+      # a control with something to check, not a formality.
       - name: Plumber
         uses: getplumber/plumber@031bc86d1e5f661626e2000f4f8779912d608d5f  # v0.4.39
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ Talos API, never from the tool that performed the upgrade.
   that run moved Talos alone, while the 5 s run also moved Kubernetes, which
   restarts an apiserver per control plane by itself. Two workloads, two numbers
   that do not compare — quote the 5/7/8 figures.
-- **353 offline assertions across 14 harnesses**, every one mutation-tested
+- **333 offline assertions across 11 harnesses**, every one mutation-tested
   (`task test-scripts`). The emulated lane runs feint 0.10.0 against Scaleway provider
   2.81.0 — the same version the clusters run.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -63,7 +63,7 @@ every apply plans to a file and applies THAT file, and a saved plan never prompt
 Destroy always takes two commands and no flag collapses them. S3 credentials are
 namespaced by the cloud that HOLDS the bucket, and a cross-provider backup is
 proven — an encrypted tfstate at Outscale while the cluster runs on Scaleway.
-353 offline assertions across 14 harnesses, every one mutation-tested; the
+333 offline assertions across 11 harnesses, every one mutation-tested; the
 emulated lane runs feint 0.10.0 against Scaleway provider 2.81.0, the version the
 clusters run.
 
@@ -205,18 +205,6 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
       binary and running the policy CI runs, wired into `task security`. Rung:
       mocked.
 
-- [ ] **branchMustBeProtected may be unreadable to the CI token, and that is
-      inherited rather than measured.** `main` has been protected since
-      2026-08-20, and plumber's control answers `passed` when it can read the
-      settings — measured locally 2026-08-21 with a token that can. A run on
-      v0.4.36 reported the default CI token cannot, and that plumber then exits 3
-      and withholds every other verdict. The job ships WITHOUT the skip so that
-      run answers it. If it exits 3, the alternative is `administration: read` on
-      that job — widening the token to satisfy one control — and that is the
-      trade to decide, not to default.
-      **Closes:** the CI run's own answer, recorded here, and the skip or the
-      permission chosen with it. Rung: the pipeline itself.
-
 - [ ] **Nothing lets you ask what is in the state.** Reading it takes the root
       directory, its per-cluster `TF_DATA_DIR` and two credentials resolved
       through `resolve-s3-cred.sh` — four things to get right, and getting one
@@ -226,14 +214,19 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
       **Closes:** `task state PROVIDER=…` listing entries from a fresh shell.
       Rung: real cloud, and it costs nothing.
 
-- [ ] **Two harnesses failed once and passed on the next run, unchanged.**
-      `test-gates-local.sh` and `test-cnpg-gates-local.sh`, 2026-08-20, run back
-      to back in the same loop: red then green with no edit between. A test whose
-      colour is not a function of the code under test is worse than no test,
-      because a real failure is indistinguishable from the flake. Suspected but
-      unverified: both spin something local and raced.
-      **Closes:** the cause named, and the two run 20× consecutively green.
-      Rung: mocked.
+- [ ] **`test-talos-local.sh` hangs instead of saying there is no cluster.**
+      Its two siblings, `test-gates-local.sh` and `test-cnpg-gates-local.sh`, exit
+      1 in under a second with `✗ no local cluster — run: task local-up`. That one
+      blocks past 90 s. All three need a live Docker cluster and all three are
+      deliberately absent from `task test-scripts` (12 entries), so `task
+      preflight` is unaffected — but anyone running `scripts/dev/test-*.sh` over
+      the glob, as this session did, hangs there.
+      NOT the flake an earlier entry claimed: their colour tracks whether a local
+      cluster exists, which is not chance. It read as one because the first run
+      happened while a 150-minute-old cluster was still up and the second ran
+      after `local-down`.
+      **Closes:** the same one-second refusal as its siblings, seen with no
+      cluster running. Rung: mocked.
 
 - [ ] **One apply still throws away the plan it decided on.** Everything else
       plans to a file and applies that file. `scripts/ops/rolling-replace.sh:1272`

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -54,7 +54,7 @@ docker run --rm -v /tmp/repo.tar:/tmp/repo.tar:ro ubuntu:24.04 bash -c '
       `task --list-all` plus aliases. Checked to fail too: an invented name and
       two just-deleted scripts all came back absent.
 - [x] `task preflight` green — lint, render, validate, `tofu test` and the script
-      harnesses. 353 offline assertions across 14 harnesses, every one
+      harnesses. 333 offline assertions across 11 harnesses, every one
       mutation-tested. **It went DOWN from 364 and that is not silent**: the
       staging lane was deleted this release and 14 of those assertions tested a
       script that no longer exists.


### PR DESCRIPTION
Three small corrections, all measured.

**The count.** `task test-scripts` runs twelve entries and deliberately excludes the three harnesses that need a live Docker cluster. `task preflight` never runs them, so the number it describes was never 353. Re-measured: **333 across 11**. `release-checklist.md` calls a silently shrunk count a red line — a silently inflated one is the same fault, and it was mine: I measured with `for t in scripts/dev/test-*.sh`, which is not what preflight does.

**The "flake" that was not one.** `test-gates-local.sh` exits 1 in under a second with `✗ no local cluster — run: task local-up`. Their colour tracks whether a local cluster exists, which is not chance — the passing run happened while a 150-minute-old cluster was up, the failing one after `local-down`. What is actually wrong is narrower: `test-talos-local.sh` **hangs past 90 s** where its siblings refuse in one.

**The question #31 shipped open is closed.** A v0.4.36 run reported the default CI token could not read branch-protection settings. Under v0.4.39 it **can** — the job reported `22 controls evaluated, 1 stood down as declared` and `branchMustBeProtected` passed. The answer is in the workflow comment now; the backlog entry holding the question is gone because it is answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM