### PR TITLE
docs: two people land on this repository, and only one of them was served

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -7,9 +7,27 @@
 
 🇬🇧 [English version](README.md)
 
+## Par où commencer
+
+Deux profils différents arrivent ici, et ils ne cherchent pas la même page.
+
+**Vous voulez un cluster.** Commencez par celui qui ne demande ni compte ni
+credentials — `task local-up` monte un cluster Talos de six nœuds dans Docker.
+Puis [Démarrage rapide](#démarrage-rapide) pour un cloud, ou
+[`docs/first-cluster.fr.md`](docs/first-cluster.fr.md) pour la version pas à pas,
+de la machine nue à un cluster qu'on rejoint, met à jour et détruit.
+
+**Vous voulez contribuer.** [`CONTRIBUTING.md`](CONTRIBUTING.md) porte les règles
+qui ne se devinent pas — ce qui compte comme preuve, les trois barreaux qu'un
+changement doit gravir, et comment se signe un commit écrit avec une IA. Le
+travail ouvert est dans [`docs/backlog.md`](docs/backlog.md), et chaque entrée
+nomme le barreau qu'elle exige : `task test` et `mocked` sont celles qu'on peut
+fermer sans compte cloud.
+
 ## Version
 
-**0.1.0, non publiée** — infrastructure seule. Cinq choses et rien d'autre :
+**0.1.0** — publiée le 2026-08-20 en pré-version. Infrastructure seule. Cinq
+choses et rien d'autre :
 déployer, un cluster HA sain (Talos + Cilium), l'idempotence, les upgrades
 Kubernetes et Talos, et un état OpenTofu chiffré côté client dans S3 avec un
 réplica optionnel chez un second provider. kubeconfig et talosconfig sont
@@ -250,6 +268,7 @@ task security            # contrôles de durcissement
 | [docs/upgrade.fr.md](docs/upgrade.fr.md) | Faire bouger Kubernetes et Talos sur un cluster qui doit rester debout |
 | [docs/release-checklist.md](docs/release-checklist.md) | Ce qu'il faut lancer avant de taguer, dans l'ordre qui échoue le moins cher |
 | [docs/backlog.md](docs/backlog.md) | **Source de vérité** : état courant, dette, améliorations (anglais seulement) |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | **À lire avant une première pull request** : ce qui compte comme preuve, les trois barreaux, les trailers de commit, les contributions assistées par IA |
 
 ## Sécurité
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,27 @@
 
 🇫🇷 [Version française](README.fr.md)
 
+## Where to go
+
+Two different people land here, and they want different pages.
+
+**You want a cluster.** Start with the one that needs no account and no
+credentials — `task local-up` brings a six-node Talos cluster up in Docker. Then
+[Quick start](#quick-start) for a cloud, or
+[`docs/first-cluster.md`](docs/first-cluster.md) for the walked-through version,
+bare machine to a cluster you can reach, upgrade and destroy.
+
+**You want to contribute.** [`CONTRIBUTING.md`](CONTRIBUTING.md) has the rules
+that are not obvious — what counts as proof, the three rungs a change has to
+climb, and how commits made with an AI assistant are signed. The open work is
+[`docs/backlog.md`](docs/backlog.md), and its entries name the rung each one
+needs: `task test` and `mocked` are the ones you can close without a cloud
+account.
+
 ## Version
 
-**0.1.0, unreleased** — infrastructure only. Five things and nothing else:
+**0.1.0** — published 2026-08-20 as a pre-release. Infrastructure only. Five
+things and nothing else:
 deploy, a healthy HA cluster (Talos + Cilium), idempotency, Kubernetes and Talos
 upgrades, and an OpenTofu state encrypted client-side in S3 with an optional
 replica on a second provider. kubeconfig and talosconfig get the same treatment.
@@ -246,6 +264,7 @@ task security            # hardening checks
 | [docs/upgrade.md](docs/upgrade.md) | Moving Kubernetes and Talos on a cluster that has to stay up |
 | [docs/release-checklist.md](docs/release-checklist.md) | What to run before tagging a release, in the order that fails cheapest |
 | [docs/backlog.md](docs/backlog.md) | **Source of truth**: current state, debt, improvements (English only — living working document) |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | **Read before a first pull request**: what counts as proof, the three rungs, commit trailers, AI-assisted contributions |
 
 ## Security
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -11,6 +11,12 @@ rung it needs (mocked / emulated / real cloud, see
 has to be settled first; a task-shaped entry invites someone to build what nobody
 decided.
 
+**Taking one.** Every entry names the rung it needs, at the end: `task test` and
+`mocked` close on a laptop, `emulated` needs Feint and still no cloud account,
+`real cloud` spends money on somebody's project. Grep for `Rung:` — today 6 of the
+open entries are closable with no cloud account, and 23 name no rung at all, which
+is a defect in this file rather than in them.
+
 ⚠️ This file twice drifted into a lab notebook — 215 lines on 2026-07-29, then
 1449 on 2026-08-19, entries of 30 lines re-telling incidents that were already
 fixed. Read the top of it at the END of a session too, not only at the start:
@@ -93,6 +99,22 @@ attempted.
 applies, then decide whether 0.1.0 ships a staging lane at all.
 
 ## Open — infrastructure
+
+- [ ] **Nobody has measured whether a service keeps answering during an upgrade.**
+      The probe that produced the 5/7/8-second figures asks
+      `kubectl get --raw=/readyz` — the APISERVER, through the load-balanced
+      endpoint. That is the control plane: for those seconds `kubectl` does not
+      answer and nothing is scheduled. It is not a service interruption, and the
+      reason is architectural — Cilium's eBPF datapath does not consult the
+      apiserver to forward a packet — but architecture is DOCUMENTED, not
+      measured, and this repository has never run the second probe.
+      The roll does cordon and drain each node in turn, honouring
+      PodDisruptionBudgets, so workloads genuinely MOVE. Whether anything stopped
+      answering while they moved is unknown, and the number people will quote
+      makes it sound answered.
+      **Closes:** a second probe, on a real workload behind a Service, running for
+      the whole roll alongside the apiserver one, with both numbers reported.
+      Rung: real cloud.
 
 - [ ] **The API is unreachable for seconds during a control-plane roll.** Same
       probe (`/readyz`, ~1 Hz, through the load-balanced endpoint), asserting on


### PR DESCRIPTION
Two people land on this repository and they want different pages. The front door
addressed neither directly.

## Measured before changing anything

| | |
|---|---|
| lines between the top of the README and Quick start | **108** — and `task local-up`, the path needing no account at all, is at 131 |
| mentions of `CONTRIBUTING.md` in the README | **0** — absent even from a documentation table listing eight files |
| version line | still said **"0.1.0, unreleased"** the day after it was published |

A would-be contributor reaching the front door never learned there are rules,
three rungs of proof, or a required commit trailer.

## What changes

A signpost above the fold, in both languages, sending the two readers to different
pages — one to `task local-up`, the other to `CONTRIBUTING.md` and the backlog.
CONTRIBUTING joins the documentation table. The version line says what is true.

**The backlog now says how to take an entry.** Every entry already named its rung,
at the end, in prose that wraps across lines — so a contributor without a cloud
account had to read 674 lines to find the six they could actually close. The
header says to grep for `Rung:`, gives today's count, and admits the other half:
**23 open entries name no rung at all**, which is a defect in that file rather
than in them.

## One new entry, and it corrects something the release will be quoted on

The 5/7/8-second figures measure `kubectl get --raw=/readyz` — the **apiserver**.
For those seconds the control plane is unreachable and nothing is scheduled.

It is **not** a service interruption, and the reason is architectural: Cilium's
eBPF datapath does not consult the apiserver to forward a packet. But architecture
is DOCUMENTED, not measured, and nobody here has ever run a probe against a real
workload during a roll. The roll drains each node in turn, so workloads genuinely
move — whether anything stopped answering while they did is unknown, and the
number people will quote makes it sound answered.

`task preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM
