### PR TITLE
fix(local): the Kubernetes host port is movable, like every other one already was

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1293,10 +1293,14 @@ tasks:
     desc: "Deploy the local Talos cluster — 3 CP + 3 workers (config + containers + bootstrap + kubeconfig)"
     vars:
       TALOS_API_PORT_BASE: '{{.TALOS_API_PORT_BASE | default "45000"}}'
+      # The host side of the Kubernetes API. 6443 is the obvious choice and the
+      # reason it was hardcoded — until a Hyper-V block landed on 6404-6503 and
+      # the one port nobody could move turned out to be the one that collided.
+      K8S_API_PORT: '{{.K8S_API_PORT | default "6443"}}'
     cmds:
       # Fail fast on a Hyper-V port reservation: Docker Desktop only reports it
       # as an opaque 500, five retries and a 90s timeout later.
-      - ./scripts/dev/check-host-ports.sh {{.TALOS_API_PORT_BASE}}
+      - ./scripts/dev/check-host-ports.sh {{.TALOS_API_PORT_BASE}} {{.K8S_API_PORT}}
       # cilium-local.yaml is gitignored, so a fresh clone has none — render it
       # rather than boot a cluster with no CNI. Mirrors what `up` does for the
       # cloud manifest.
@@ -1315,7 +1319,8 @@ tasks:
         export TF_VAR_cilium_manifest="$(cat infrastructure/opentofu/cluster/bootstrap-manifests/cilium-local.yaml \
           2>/dev/null || echo 'CILIUM-MANIFEST-PLACEHOLDER')"
         tofu -chdir=infrastructure/opentofu-local apply -var talos_bootstrap=true \
-          -var talos_api_port_base={{.TALOS_API_PORT_BASE}} -auto-approve
+          -var talos_api_port_base={{.TALOS_API_PORT_BASE}} \
+            -var k8s_api_port={{.K8S_API_PORT}} -auto-approve
 
   local-test:
     desc: "Full end-to-end local test: 3 CP + 3 workers + etcd quorum + Cilium + Flux + GitOps"

--- a/infrastructure/opentofu-local/main.tf
+++ b/infrastructure/opentofu-local/main.tf
@@ -94,7 +94,7 @@ module "local" {
   cp_ip_base          = 10
   worker_ip_base      = 20
   talos_api_port_base = var.talos_api_port_base
-  k8s_api_port        = 6443
+  k8s_api_port        = var.k8s_api_port
 
   # Generated configs from modules/talos (one per node — identical, node-agnostic)
   control_plane_configs = module.talos.control_plane_machine_configs

--- a/infrastructure/opentofu-local/variables.tf
+++ b/infrastructure/opentofu-local/variables.tf
@@ -69,6 +69,24 @@ variable "talos_api_port_base" {
   }
 }
 
+# The HOST side of the Kubernetes API mapping. modules/providers/local publishes
+# `127.0.0.1:<this>:6443` — 6443 inside the container is what Kubernetes serves on
+# and never moves; only the host side is ours to choose.
+#
+# It was hardcoded to 6443 here while the module had accepted a variable all
+# along, so a Hyper-V block landing on 6404-6503 (measured 2026-08-21) left the
+# credential-free rung unrunnable with no way around it. The Talos ports were
+# already movable; this was the one that was not.
+variable "k8s_api_port" {
+  description = "Host port mapped to control plane 0's Kubernetes API. Preflighted against the Hyper-V exclusions by scripts/dev/check-host-ports.sh."
+  type        = number
+  default     = 6443
+  validation {
+    condition     = var.k8s_api_port >= 1024 && var.k8s_api_port <= 65535
+    error_message = "k8s_api_port must be between 1024 and 65535."
+  }
+}
+
 # Accept cilium manifest override (for local simplified variant)
 variable "cilium_manifest" {
   description = "Cilium manifest content. Set via TF_VAR_cilium_manifest from cilium-local.yaml."

--- a/scripts/dev/check-host-ports.sh
+++ b/scripts/dev/check-host-ports.sh
@@ -10,12 +10,17 @@
 # No-op off WSL2 (netsh.exe absent) and non-fatal if the exclusions are
 # unreadable: this guards a known trap, it must never block a working setup.
 #
-# Usage: check-host-ports.sh [base]   (default: the tfvars/variable default)
+# Usage: check-host-ports.sh [talos-base] [k8s-port]   (defaults: the variable defaults)
 set -uo pipefail
 
 BASE="${1:-45000}"
-# cp_i → base+i (3), worker_i → base+10+i (3), plus the Kubernetes API on 6443.
-PORTS=("$((BASE))" "$((BASE + 1))" "$((BASE + 2))" "$((BASE + 10))" "$((BASE + 11))" "$((BASE + 12))" 6443)
+# Both defaults mirror infrastructure/opentofu-local/variables.tf. The Kubernetes
+# port used to be a literal here, which was fine while it was a literal there too
+# — and wrong the moment it became movable, because this guard would have kept
+# checking 6443 while the apply published something else.
+K8S="${2:-6443}"
+# cp_i → base+i (3), worker_i → base+10+i (3), plus the Kubernetes API.
+PORTS=("$((BASE))" "$((BASE + 1))" "$((BASE + 2))" "$((BASE + 10))" "$((BASE + 11))" "$((BASE + 12))" "$K8S")
 
 command -v netsh.exe >/dev/null 2>&1 || exit 0
 
@@ -39,12 +44,13 @@ if [ "$conflict" -ne 0 ]; then
   Docker Desktop cannot publish these ports; the apply would fail on an opaque
   500 and then on "Talos API not ready after 90s".
 
-  Pick a free base (it needs base..base+12 clear) and pass it through:
-      task local-up TALOS_API_PORT_BASE=<base>
+  Both are movable, and the message above says which one collided:
+      task local-up TALOS_API_PORT_BASE=<base>   # Talos, needs base..base+12 clear
+      task local-up K8S_API_PORT=<port>          # the Kubernetes API, one port
   Current reservations:
 $(printf '%s\n' "$RANGES" | sed 's/^/      /')
 EOT
   exit 1
 fi
 
-echo "✓ host ports free (base $BASE)"
+echo "✓ host ports free (Talos base $BASE, Kubernetes $K8S)"


### PR DESCRIPTION
`task local-up` would not start on a WSL2 machine: `✗ host port 6443 is inside the Hyper-V reserved range 6404-6503`. Confirmed against Windows — `netsh` lists that block excluded, and those ranges **move across reboots**, which the guard's own header already warned about for the Talos ports.

The Talos ports were movable through `TALOS_API_PORT_BASE`. The Kubernetes one was a literal in three places, and it was the one that collided — so **the credential-free rung, the one `CONTRIBUTING` sends newcomers to, was unrunnable with no way around it.**

`modules/providers/local` had accepted `k8s_api_port` all along and publishes `127.0.0.1:<it>:6443` — the container side is what Kubernetes serves on and never moves; only the host side is ours to choose. The local root simply hardcoded it.

**The guard's remedy was wrong too**, in the way that matters: it said to pass `TALOS_API_PORT_BASE` whichever port had collided, so an operator hitting the Kubernetes one was told to move the six that were fine.

```
check-host-ports.sh 45000 6443   → ✗ inside 6404-6503, rc=1
check-host-ports.sh 45000 50010  → ✗ inside 50000-50059, rc=1
check-host-ports.sh 45000 16443  → ✓ free, rc=0
task local-up K8S_API_PORT=16443 → 14 resources, 6/6 nodes Ready, Cilium 6/6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM