### PR TITLE
docs(backlog): indexing that subnet does not destroy it, and the entry said it did

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -353,11 +353,14 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
       Not a small fix: on Outscale placement comes from the SUBNET, so spreading
       means one subnet per subregion, volumes in the matching subregion, and a
       decision about the NAT service (one = a single egress failure domain).
-      Indexing `outscale_subnet.private` moves its address and replaces
-      everything attached to it — a fresh deploy only, never a live cluster.
+      Indexing `outscale_subnet.private` does NOT destroy it — OpenTofu proposes
+      the move to instance zero by itself, and a `moved` block makes it explicit.
+      What gets replaced is a node whose subnet changes, one at a time, which is
+      what `scripts/ops/rolling-replace.sh` already does. So a live migration is
+      untested here, not impossible.
       **Closes:** an Outscale deploy whose `kubectl get nodes -o wide` shows
       control planes in at least two subregions, `task cluster-verify` green.
-      Rung: real cloud, new cluster.
+      Rung: real cloud.
 
 - [ ] **`task cluster-up` cannot add a node to a cluster it already bootstrapped.**
       Its `infra` step applies with `talos_bootstrap=true` once bootstrapped


### PR DESCRIPTION
One correction, nothing else. The findings that used to share this branch are now
**#38**, because they propose no change to make — which is what an issue is for.

The Outscale multi-subregion entry justified *"a fresh deploy only, never a live
cluster"* with *"indexing `outscale_subnet.private` moves its address and replaces
everything attached to it"*.

That is not what OpenTofu does. From its own refactoring guide:

> When you add `count` to an existing resource that didn't use it, OpenTofu
> automatically proposes to move the original object to instance zero, unless you
> write a `moved` block explicitly mentioning that resource.

What does get replaced is a node whose subnet changes — one at a time, which is
what `scripts/ops/rolling-replace.sh` already does. So a live migration is
untested here, not impossible, and the rung drops "new cluster" along with the
claim that required it.

Left standing, that sentence tells whoever picks the ticket up that the cheap path
is closed when it is not.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM
