### PR TITLE
feat: cluster-up lands the versions it declares, and the climb no longer eats its own steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,7 @@ Talos API, never from the tool that performed the upgrade.
   that run moved Talos alone, while the 5 s run also moved Kubernetes, which
   restarts an apiserver per control plane by itself. Two workloads, two numbers
   that do not compare — quote the 5/7/8 figures.
-- **333 offline assertions across 11 harnesses**, every one mutation-tested
+- **344 offline assertions across 11 harnesses**, every one mutation-tested
   (`task test-scripts`). The emulated lane runs feint 0.10.0 against Scaleway provider
   2.81.0 — the same version the clusters run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,7 @@ Talos API, never from the tool that performed the upgrade.
   that run moved Talos alone, while the 5 s run also moved Kubernetes, which
   restarts an apiserver per control plane by itself. Two workloads, two numbers
   that do not compare — quote the 5/7/8 figures.
-- **353 offline assertions across 11 harnesses**, every one mutation-tested
+- **358 offline assertions across 11 harnesses**, every one mutation-tested
   (`task test-scripts`). The emulated lane runs feint 0.10.0 against Scaleway provider
   2.81.0 — the same version the clusters run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,7 @@ Talos API, never from the tool that performed the upgrade.
   that run moved Talos alone, while the 5 s run also moved Kubernetes, which
   restarts an apiserver per control plane by itself. Two workloads, two numbers
   that do not compare — quote the 5/7/8 figures.
-- **344 offline assertions across 11 harnesses**, every one mutation-tested
+- **353 offline assertions across 11 harnesses**, every one mutation-tested
   (`task test-scripts`). The emulated lane runs feint 0.10.0 against Scaleway provider
   2.81.0 — the same version the clusters run.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -405,7 +405,8 @@ tasks:
   cluster-up:
     aliases: [up]
     desc: >-
-      Idempotent one-shot bring-up: image -> render manifests -> infra -> tunnels -> bootstrap. Usage: task cluster-up
+      Idempotent one-shot bring-up: image -> render manifests -> infra -> tunnels -> bootstrap -> converge the
+      fleet onto the versions the tfvars pins (editing that file IS the decision to upgrade). Usage: task cluster-up
       ROLE=management|workload PROVIDER=… [KEY=~/.ssh/yourkey] [VERSION=v1.13.4] [FORCE=1] [APPROVE=auto].
       It shows the plan and asks once before it spends; APPROVE=auto answers for you, for CI and for a
       shell that cannot be asked.
@@ -499,6 +500,14 @@ tasks:
         else
           echo "✓ bootstrap manifests already rendered — skipping (FORCE=1 to re-render)"
         fi
+      # What the plan below CANNOT show. `ignore_changes` on the node image keeps a
+      # version roll out of the OpenTofu plan entirely, so an operator reading that
+      # plan would approve a bring-up and get every node rolled without ever having
+      # seen it. Best effort: with no cluster yet there is nothing to read and this
+      # says nothing. It deliberately does NOT refresh kubeconfig first — `tofu
+      # output` failing truncates the file it writes to, and overwriting a good
+      # kubeconfig to print a notice is a bad trade.
+      - ./scripts/internal/converge-versions.sh {{.PROVIDER}} {{.ROLE}} {{.KEY}} --check
       # ONE human checkpoint on the whole journey, and it is here — the step that
       # spends. `up` plans, shows it, asks once, then applies EXACTLY that plan:
       # never two different plans, and never a silent apply. APPROVE=auto skips the
@@ -531,6 +540,16 @@ tasks:
           # Not passing this was the whole defect: cluster-up answered its own
           # gate and then let phase 2 ask a question nobody could hear.
           APPROVE: "{{.APPROVE}}"
+      # rolling-replace hard-requires ./kubeconfig and ./talosconfig in the cluster
+      # directory, and nothing above has written either of them.
+      - task: kubeconfig
+        vars:
+          ROLE: "{{.ROLE}}"
+          PROVIDER: "{{.PROVIDER}}"
+      # Editing the tfvars IS the decision to upgrade, so the command that reads it
+      # has to reach it. APPROVE=auto inside is not a bypass: the one checkpoint
+      # above already asked, and --check had told it what this would roll.
+      - ./scripts/internal/converge-versions.sh {{.PROVIDER}} {{.ROLE}} {{.KEY}}
       # Do NOT end on "every step above is idempotent": that line came out
       # identical on the first run, which applied 43 changes in phase 1 and 17 in
       # phase 2, and on the second, which applied none. Idempotence is a property

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -558,9 +558,10 @@ tasks:
       # runs, so a `#` inside would be printed as the last thing the operator reads.
       - |
         echo "✓ cluster-up complete."
-        echo "  Run this exact command again to converge again. Its plan is the"
-        echo "  verdict, not this line: on a cluster that already matches the"
-        echo "  configuration OpenTofu prints 'No changes.' and applies nothing."
+        echo "  Two verdicts, and neither of them is this line: OpenTofu's plan for"
+        echo "  the infrastructure, and the version check above for the fleet — asked"
+        echo "  separately because ignore_changes keeps a roll out of the plan."
+        echo "  Run this exact command again to converge again."
 
   # ===========================================================================
   # Cluster Lifecycle

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1250,7 +1250,8 @@ tasks:
     desc: >-
       Ask the CLUSTER whether it is what this release promises: apiserver up, every node Ready, the
       requested number of control planes, Cilium on each, CoreDNS serving, no Flux, no app load
-      balancer, a tfstate replica in the backup store. Usage: task verify PROVIDER=scaleway [ROLE=management]
+      balancer, the Talos and Kubernetes versions the config pins, the schematic it pins, and
+      a tfstate replica in the backup store. Usage: task verify PROVIDER=scaleway [ROLE=management]
     # See backup-state above: the *provider-env anchor needs this dir, and the
     # first version of this target shipped without it and exited 127 everywhere.
     dir: infrastructure/opentofu/cluster

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -843,9 +843,9 @@ tasks:
     desc: >-
       Replace nodes one at a time (drain→targeted apply→wait) with NO downtime. Use after a ForceNew change
       (instance_type / Talos image) instead of infra, which replaces all nodes in parallel and breaks etcd
-      quorum. Management clusters only (see scripts/ops/rolling-replace.sh). Targets are derived from `tofu
-      state list` — provider-agnostic; --upgrade exercised live on Scaleway, OVH and Outscale.
-      Usage: task cluster-roll PROVIDER=… [KEY=~/.ssh/key] [APPROVE=auto]
+      quorum. Targets are derived from `tofu state list` — provider-agnostic; --upgrade exercised live on
+      Scaleway, OVH and Outscale. ROLE picks the env file and the state, and defaults to management.
+      Usage: task cluster-roll PROVIDER=… [ROLE=management|workload] [KEY=~/.ssh/key] [APPROVE=auto]
       [-- --workers-only|--cp-only|--dry-run|--upgrade]
     dir: infrastructure/opentofu/cluster
     # PROVIDER is REQUIRED, not defaulted. Twenty targets used to fall back to
@@ -866,9 +866,13 @@ tasks:
       APPROVE: '{{.APPROVE | default "ask"}}'
     env: *provider-env
     cmds:
-      - tofu init -reconfigure $(../../../scripts/internal/tf-backend.sh envs/management-{{.PROVIDER}}.tfvars)
+      - tofu init -reconfigure $(../../../scripts/internal/tf-backend.sh envs/{{.ROLE}}-{{.PROVIDER}}.tfvars)
       - SSH_KEY="{{.KEY}}" ../../../scripts/bootstrap/talos-tunnels.sh open .
-      - ../../../scripts/ops/rolling-replace.sh {{.PROVIDER}} {{if eq .APPROVE "auto"}}--yes {{end}}{{.CLI_ARGS}}
+      # --role BEFORE CLI_ARGS: a role passed by the caller in `-- …` then wins,
+      # which is the ordering every other flag here already has.
+      - >-
+        ../../../scripts/ops/rolling-replace.sh {{.PROVIDER}} --role={{.ROLE}}
+        {{if eq .APPROVE "auto"}}--yes {{end}}{{.CLI_ARGS}}
       - task: _backup-state
         vars: {PROVIDER: "{{.PROVIDER}}"}
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -54,7 +54,7 @@ docker run --rm -v /tmp/repo.tar:/tmp/repo.tar:ro ubuntu:24.04 bash -c '
       `task --list-all` plus aliases. Checked to fail too: an invented name and
       two just-deleted scripts all came back absent.
 - [x] `task preflight` green — lint, render, validate, `tofu test` and the script
-      harnesses. 337 offline assertions across 11 harnesses, every one
+      harnesses. 344 offline assertions across 11 harnesses, every one
       mutation-tested. **It went DOWN from 364 and that is not silent**: the
       staging lane was deleted this release and 14 of those assertions tested a
       script that no longer exists.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -54,7 +54,7 @@ docker run --rm -v /tmp/repo.tar:/tmp/repo.tar:ro ubuntu:24.04 bash -c '
       `task --list-all` plus aliases. Checked to fail too: an invented name and
       two just-deleted scripts all came back absent.
 - [x] `task preflight` green — lint, render, validate, `tofu test` and the script
-      harnesses. 333 offline assertions across 11 harnesses, every one
+      harnesses. 337 offline assertions across 11 harnesses, every one
       mutation-tested. **It went DOWN from 364 and that is not silent**: the
       staging lane was deleted this release and 14 of those assertions tested a
       script that no longer exists.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -54,7 +54,7 @@ docker run --rm -v /tmp/repo.tar:/tmp/repo.tar:ro ubuntu:24.04 bash -c '
       `task --list-all` plus aliases. Checked to fail too: an invented name and
       two just-deleted scripts all came back absent.
 - [x] `task preflight` green — lint, render, validate, `tofu test` and the script
-      harnesses. 353 offline assertions across 11 harnesses, every one
+      harnesses. 358 offline assertions across 11 harnesses, every one
       mutation-tested. **It went DOWN from 364 and that is not silent**: the
       staging lane was deleted this release and 14 of those assertions tested a
       script that no longer exists.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -54,7 +54,7 @@ docker run --rm -v /tmp/repo.tar:/tmp/repo.tar:ro ubuntu:24.04 bash -c '
       `task --list-all` plus aliases. Checked to fail too: an invented name and
       two just-deleted scripts all came back absent.
 - [x] `task preflight` green — lint, render, validate, `tofu test` and the script
-      harnesses. 344 offline assertions across 11 harnesses, every one
+      harnesses. 353 offline assertions across 11 harnesses, every one
       mutation-tested. **It went DOWN from 364 and that is not silent**: the
       staging lane was deleted this release and 14 of those assertions tested a
       script that no longer exists.

--- a/docs/status.md
+++ b/docs/status.md
@@ -74,6 +74,16 @@ on 2026-08-20, the new LBU `active` with 3 backends, and **request 399530 is
 closed**. One Net from before the fix still refuses deletion on a dependency no
 read returns; only Outscale can clear that, and a second request is open for it.
 
+**A bumped pin used to land nowhere, and every signal said otherwise.** Measured
+on a live Scaleway cluster 2026-08-21: with `talos_version` bumped and NOT
+applied, `cluster-verify` answered `11 passed, 0 failed`, exit 0 — the fleet a
+version behind its own configuration and nothing red anywhere, because the check
+compared the running *schematic*, which a version bump does not change. The
+verifier now compares the running versions too and answers `12 passed, 1 failed`
+on that same state. The convergence half was measured the same day: a seven-step
+climb from (Talos 1.12.7, Kubernetes 1.30.0) to (1.13.9, 1.36.3) on six nodes,
+longest apiserver outage **5 s**.
+
 **Dependency watch, since 2026-08-24.** Cléa (`scripts/clea/`, `docs/clea.md`)
 reads every version this repository claims, resolves what upstream published,
 and probes a bump by installing it from cold and upgrading over the old one in

--- a/infrastructure/opentofu/cluster/version-support.json
+++ b/infrastructure/opentofu/cluster/version-support.json
@@ -1,0 +1,19 @@
+{
+  "_comment": [
+    "Which Kubernetes minors each Talos minor supports. ONE source: versions-guard.tf",
+    "reads it with jsondecode, and scripts/dev/cluster-upgrade.sh reads it with jq to",
+    "build an upgrade path. Two copies of one fact is one too many — the Taskfile and",
+    "variables.tf disagreed about talos_version once, and the deploy built an image the",
+    "cluster then refused to find.",
+    "",
+    "Only ranges read from the upstream matrix belong here. An unknown Talos minor",
+    "fails on purpose rather than passing silently, so adding one forces a look at",
+    "the matrix rather than a guess."
+  ],
+  "_source": "https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix",
+  "_rule": "Talos supports the current Kubernetes minor and the five before it (n-5).",
+  "talos_minors": {
+    "1.12": { "k8s_min": 30, "k8s_max": 35 },
+    "1.13": { "k8s_min": 31, "k8s_max": 36 }
+  }
+}

--- a/infrastructure/opentofu/cluster/versions-guard.tf
+++ b/infrastructure/opentofu/cluster/versions-guard.tf
@@ -10,10 +10,10 @@
 # ==============================================================================
 
 locals {
-  k8s_minors_by_talos_minor = {
-    "1.12" = { min = 30, max = 35 }
-    "1.13" = { min = 31, max = 36 }
-  }
+  # The map lives in version-support.json, not here: cluster-upgrade.sh needs the
+  # same ranges to build an upgrade path, and a second copy would be a second
+  # source of truth. jsondecode reads it natively; jq reads it there.
+  k8s_minors_by_talos_minor = jsondecode(file("${path.module}/version-support.json")).talos_minors
 
   talos_minor_key = join(".", slice(split(".", trimprefix(var.talos_version, "v")), 0, 2))
   k8s_minor_num   = tonumber(split(".", trimprefix(var.kubernetes_version, "v"))[1])
@@ -28,8 +28,8 @@ resource "terraform_data" "version_pair_guard" {
       # Conditional, not `&&`: the range is null for an unknown Talos minor, and
       # reading .min off null would error before the message could be shown.
       condition = local.k8s_supported == null ? false : (
-        local.k8s_minor_num >= local.k8s_supported.min &&
-        local.k8s_minor_num <= local.k8s_supported.max
+        local.k8s_minor_num >= local.k8s_supported.k8s_min &&
+        local.k8s_minor_num <= local.k8s_supported.k8s_max
       )
       error_message = "talos_version ${var.talos_version} and kubernetes_version ${var.kubernetes_version} are not a supported pair. Talos ${local.talos_minor_key} either supports a different Kubernetes range, or is not in cluster/versions-guard.tf yet — check https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix and extend the map rather than widening it blindly."
     }

--- a/scripts/dev/cluster-upgrade.sh
+++ b/scripts/dev/cluster-upgrade.sh
@@ -300,8 +300,8 @@ if [ "$TALOS_DONE" = 0 ]; then
   # --yes: there is no terminal here, and without it rolling-replace stops at its
   # confirmation prompt and exits 1 — which is how an unattended lane discovers
   # that a script it depends on was only ever run by hand.
-  task cluster-roll PROVIDER="$PROVIDER" KEY="$KEY" APPROVE=auto -- --cp-only --upgrade
-  task cluster-roll PROVIDER="$PROVIDER" KEY="$KEY" APPROVE=auto -- --workers-only --upgrade
+  task cluster-roll PROVIDER="$PROVIDER" ROLE="$ROLE" KEY="$KEY" APPROVE=auto -- --cp-only --upgrade
+  task cluster-roll PROVIDER="$PROVIDER" ROLE="$ROLE" KEY="$KEY" APPROVE=auto -- --workers-only --upgrade
 
   # Same trap as the kubelet count above: with no nodes returned, `grep -cv`
   # answers 0 and a dead cluster reports a clean Talos upgrade.

--- a/scripts/dev/cluster-upgrade.sh
+++ b/scripts/dev/cluster-upgrade.sh
@@ -440,8 +440,15 @@ upgrade_talos_to() { # <version>
 # dispatch without a test fixture pinning versions that look real. The harness
 # feeds it a path with the two upgrade_* stubbed out and reads the call order.
 walk_path() { # <talos-from> <k8s-from> <total>   — reads "talos k8s" lines on stdin
-  local prev_t="$1" prev_k="$2" total="$3" step=0 st sk
-  while read -r st sk; do
+  local prev_t="$1" prev_k="$2" total="$3" step=0 st sk line
+  # Drain stdin BEFORE the first step, never between two. Inside the loop
+  # `task cluster-roll` reaches ssh and talosctl, and both READ STDIN — the same
+  # stdin that feeds this loop. On Scaleway the Talos roll of step 2 ate steps
+  # 3-7: the climb ended, exited 0, and announced a version the cluster never ran.
+  local -a steps=()
+  mapfile -t steps
+  for line in "${steps[@]}"; do
+    read -r st sk <<<"$line"
     [ -n "$st" ] || continue
     step=$((step + 1))
     if [ "$total" -gt 1 ]; then
@@ -456,7 +463,9 @@ walk_path() { # <talos-from> <k8s-from> <total>   — reads "talos k8s" lines on
 
 # A here-string, NOT a pipe. `printf | walk_path` puts the loop in a subshell,
 # where `fail` exits the subshell and the run carries on past a step that did not
-# land — measured: the harness went 35/8 the moment it was a pipe.
+# land — measured: the harness went 35/8 the moment it was a pipe. The here-string
+# fixes that and does NOT protect the stream: walk_path drains it before the first
+# step because the steps themselves read stdin. Both traps, one line apart.
 walk_path "$TALOS_FROM" "$K8S_FROM" "$PATH_STEPS" <<<"$UPGRADE_PATH"
 
 # --- What a clean upgrade leaves behind ----------------------------------------

--- a/scripts/dev/cluster-upgrade.sh
+++ b/scripts/dev/cluster-upgrade.sh
@@ -75,6 +75,96 @@ default_of() { # <key> — cluster/variables.tf only, ignoring the tfvars
     sed -nE 's/^[[:space:]]*default[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' | head -1
 }
 
+# --- the path, one minor at a time -------------------------------------------
+# Kubernetes forbids skipping a minor on the way up, and Talos supports a WINDOW
+# of Kubernetes minors, not all of them — so a valid start and a valid end can be
+# joined by a step that is neither. Going (1.12, 1.30) → (1.13, 1.36) by moving
+# Talos first lands on (1.13, 1.30), which is below 1.13's floor of 1.31 and is
+# refused at apply time, after the previous step has already landed.
+#
+# The ranges come from cluster/version-support.json — the same file
+# versions-guard.tf reads, so the path and the gate cannot disagree about what is
+# supported. Every step this builds is a real apply, and that gate runs on each.
+SUPPORT_JSON="$ROOT/infrastructure/opentofu/cluster/version-support.json"
+
+minor_of()   { printf '%s' "$1" | sed -E 's/^v?([0-9]+\.[0-9]+).*/\1/'; }
+k8s_minor()  { printf '%s' "$1" | sed -E 's/^v?[0-9]+\.([0-9]+).*/\1/'; }
+
+# Is this Talos minor allowed to run this Kubernetes minor?
+pair_ok() { # <talos-version> <k8s-version>
+  local lo hi km
+  km="$(k8s_minor "$2")"
+  read -r lo hi <<<"$(jq -r --arg m "$(minor_of "$1")" \
+        '.talos_minors[$m] // empty | "\(.k8s_min) \(.k8s_max)"' "$SUPPORT_JSON")"
+  [ -n "${lo:-}" ] || return 1          # a Talos minor the matrix has never heard of
+  [ "$km" -ge "$lo" ] && [ "$km" -le "$hi" ]
+}
+
+# Intermediate hops land on `.0`: that patch always exists for a Kubernetes minor,
+# and the step is left again immediately. Only the LAST hop of each axis carries
+# the patch that was actually pinned.
+# Which version string to use for a minor on the way through. NEVER `.0` for the
+# minor already running: dropping v1.12.7 to v1.12.0 to pass through is a patch
+# DOWNGRADE, and the first draft of this did exactly that.
+_at_minor() { # <minor> <current-version> <target-version>
+  local m="$1" cur="$2" tgt="$3"
+  if   [ "$m" = "$(minor_of "$tgt")" ]; then printf '%s' "$tgt"
+  elif [ "$m" = "$(minor_of "$cur")" ]; then printf '%s' "$cur"
+  else printf 'v%s.0' "$m"; fi
+}
+
+# The whole path is built and validated BEFORE a line of it is printed: a caller
+# that reads steps and then a refusal has already been told to start something
+# that cannot finish.
+version_path() { # <talos-from> <k8s-from> <talos-to> <k8s-to> → one "talos k8s" per line
+  local t="$1" k="$2" tt="$3" kt="$4" tm km ttm ktm guard=0 nt out=""
+  tm="$(minor_of "$t")";   km="$(k8s_minor "$k")"
+  ttm="$(minor_of "$tt")"; ktm="$(k8s_minor "$kt")"
+
+  if [ "${tm%%.*}" != "${ttm%%.*}" ]; then
+    echo "✗ a Talos MAJOR change (${tm} → ${ttm}) is not a path this builds" >&2; return 1
+  fi
+  if [ "${tm#*.}" -gt "${ttm#*.}" ] || [ "$km" -gt "$ktm" ]; then
+    echo "✗ ${t}/${k} → ${tt}/${kt} goes DOWN. Downgrades are not a path this builds." >&2; return 1
+  fi
+  # No minor moves: there is no path to build, and the window is none of this
+  # function's business. The plan-time guard checks the destination pair on every
+  # apply regardless, and consulting the map here would refuse any pair it has not
+  # been taught — a fictional test fixture, or a legitimate minor on the day
+  # someone bumps before extending version-support.json.
+  if [ "$tm" = "$ttm" ] && [ "$km" = "$ktm" ]; then
+    printf '%s %s\n' "$tt" "$kt"; return 0
+  fi
+
+  pair_ok "$tt" "$kt" || {
+    echo "✗ the TARGET ${tt}/${kt} is not a supported pair — nothing to path toward." >&2; return 1; }
+
+  while [ "$tm" != "$ttm" ] || [ "$km" != "$ktm" ]; do
+    guard=$((guard + 1))
+    [ "$guard" -le 40 ] || { echo "✗ path did not converge in 40 steps — refusing to guess" >&2; return 1; }
+
+    # Talos first when it is legal: its window moves the ceiling up, so taking it
+    # early keeps the path short and never strands Kubernetes below a new floor.
+    nt="${tm%%.*}.$(( ${tm#*.} + 1 ))"
+    if [ "$tm" != "$ttm" ] && pair_ok "v${nt}.0" "v1.${km}.0"; then
+      tm="$nt"
+    elif [ "$km" -lt "$ktm" ] && pair_ok "v${tm}.0" "v1.$((km + 1)).0"; then
+      km=$((km + 1))
+    else
+      echo "✗ no supported step out of Talos ${tm} / Kubernetes 1.${km} toward ${ttm}/1.${ktm}." >&2
+      echo "  Neither axis can move without leaving the window in version-support.json." >&2
+      return 1
+    fi
+    out+="$(_at_minor "$tm" "$t" "$tt") $(_at_minor "1.${km}" "$k" "$kt")"$'\n'
+  done
+
+  # The loop only exits with both minors matched, and the same-minor case returned
+  # long before it — so `out` is never empty here. A fallback that filled it was
+  # dead the moment that early return went in, and a mutation proved it: removing
+  # it changed nothing.
+  printf '%s' "$out"
+}
+
 TALOS_TO="${UPGRADE_TALOS_TO:-$(default_of talos_version)}"
 K8S_TO="${UPGRADE_K8S_TO:-$(default_of kubernetes_version)}"
 
@@ -175,6 +265,29 @@ if [ "$K8S_DONE" = 1 ] && [ "$TALOS_DONE" = 1 ]; then
 
   UPGRADE_TALOS_TO / UPGRADE_K8S_TO override the targets upward instead, but only
   if a newer patch actually exists upstream."
+fi
+
+# --- the path, announced before anything moves --------------------------------
+# Built and validated up front. A run that discovers half way that the next step
+# is unsupported has already landed the ones before it, and a cluster stranded on
+# an intermediate pair is worse than one that never started.
+#
+# NOTE, and it is the honest limit of this release: the steps are COMPUTED and
+# REFUSED here, not yet walked. The apply below still goes straight to the target,
+# which is correct for one minor and wrong for two — the execution loop is the
+# next piece of work, and the backlog says so.
+if ! UPGRADE_PATH="$(version_path "$TALOS_FROM" "$K8S_FROM" "$TALOS_TO" "$K8S_TO")"; then
+  fail "no supported upgrade path from Talos ${TALOS_FROM} / Kubernetes ${K8S_FROM}
+  to Talos ${TALOS_TO} / Kubernetes ${K8S_TO}. The ranges are in
+  cluster/version-support.json, which is also what the plan-time guard reads."
+fi
+PATH_STEPS="$(printf '%s' "$UPGRADE_PATH" | grep -c .)"
+if [ "$PATH_STEPS" -gt 1 ]; then
+  echo
+  echo "▶ This is a ${PATH_STEPS}-step climb, one minor at a time (talos k8s):"
+  printf '%s' "$UPGRADE_PATH" | nl -w4 -s'  ' | sed 's/^/    /'
+  echo "⚠ cluster-upgrade applies the TARGET in one go. For more than one minor that" >&2
+  echo "  is not what Kubernetes allows — walk the steps by hand until the loop exists." >&2
 fi
 
 if [ "${DRY_RUN:-}" = "1" ]; then

--- a/scripts/dev/cluster-upgrade.sh
+++ b/scripts/dev/cluster-upgrade.sh
@@ -268,14 +268,9 @@ if [ "$K8S_DONE" = 1 ] && [ "$TALOS_DONE" = 1 ]; then
 fi
 
 # --- the path, announced before anything moves --------------------------------
-# Built and validated up front. A run that discovers half way that the next step
-# is unsupported has already landed the ones before it, and a cluster stranded on
-# an intermediate pair is worse than one that never started.
-#
-# NOTE, and it is the honest limit of this release: the steps are COMPUTED and
-# REFUSED here, not yet walked. The apply below still goes straight to the target,
-# which is correct for one minor and wrong for two — the execution loop is the
-# next piece of work, and the backlog says so.
+# Built and validated up front, then walked below. A run that discovers half way
+# that the next step is unsupported has already landed the ones before it, and a
+# cluster stranded on an intermediate pair is worse than one that never started.
 if ! UPGRADE_PATH="$(version_path "$TALOS_FROM" "$K8S_FROM" "$TALOS_TO" "$K8S_TO")"; then
   fail "no supported upgrade path from Talos ${TALOS_FROM} / Kubernetes ${K8S_FROM}
   to Talos ${TALOS_TO} / Kubernetes ${K8S_TO}. The ranges are in
@@ -286,8 +281,7 @@ if [ "$PATH_STEPS" -gt 1 ]; then
   echo
   echo "▶ This is a ${PATH_STEPS}-step climb, one minor at a time (talos k8s):"
   printf '%s' "$UPGRADE_PATH" | nl -w4 -s'  ' | sed 's/^/    /'
-  echo "⚠ cluster-upgrade applies the TARGET in one go. For more than one minor that" >&2
-  echo "  is not what Kubernetes allows — walk the steps by hand until the loop exists." >&2
+  echo "  Every step is a full apply, so the plan-time pair guard runs on each one."
 fi
 
 if [ "${DRY_RUN:-}" = "1" ]; then
@@ -368,44 +362,49 @@ report_probe() {
   fail "the API was unreachable for ${longest}s in a row, over the ${MAX_PROBE_FAILS}s this lane allows (samples in ${keep})"
 }
 
-# --- Kubernetes first: no reboot, so it isolates the control-plane roll --------
+# --- One step of the climb ------------------------------------------------------
+#
+# Each of these was a `if [ "$X_DONE" = 0 ]` block moving straight to the target.
+# They are functions now because the path can have seven steps, and every one of
+# them is the same operation against a different version. Nothing inside changed.
 
-if [ "$K8S_DONE" = 0 ]; then
-  echo "--- Kubernetes ${K8S_FROM} → ${K8S_TO} ---"
-  tfvar_set kubernetes_version "$K8S_TO"
+upgrade_k8s_to() { # <version>
+  local target="$1"
+  echo "--- Kubernetes → ${target} ---"
+  tfvar_set kubernetes_version "$target"
   task infra-apply ROLE="$ROLE" PROVIDER="$PROVIDER" KEY="$KEY" APPROVE=auto
 
   # Talos reconciles the static pods and the kubelets; the node's reported
   # version is the observable end of that, and it is not instant.
-  echo "waiting for every kubelet to report ${K8S_TO}"
+  echo "waiting for every kubelet to report ${target}"
+  local seen stale
   for _ in $(seq 1 60); do
     # COUNT THE NODES, not just the stale ones. `grep -cvx` over the output of a
     # kubectl that answered nothing returns 0, which reads exactly like "every
     # kubelet is on the target" — a dead apiserver used to pass this.
-    SEEN="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.kubeletVersion}{"\n"}{end}' 2>/dev/null |
-      grep -c . || true)"
-    STALE="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.kubeletVersion}{"\n"}{end}' 2>/dev/null |
-      grep -cvx "$K8S_TO" || true)"
-    [ "$SEEN" -gt 0 ] && [ "$STALE" -eq 0 ] && break
+    seen="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.kubeletVersion}{"\n"}{end}' 2>/dev/null |
+             grep -c . || true)"
+    stale="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.kubeletVersion}{"\n"}{end}' 2>/dev/null |
+             grep -cvx "$target" || true)"
+    [ "$seen" -gt 0 ] && [ "$stale" -eq 0 ] && break
     sleep 10
   done
-  [ "${SEEN:-0}" -gt 0 ] || fail "the apiserver reported no nodes at all — nothing was verified, and this is not an upgrade that succeeded"
-  [ "${STALE:-1}" -eq 0 ] || fail "${STALE} kubelet(s) still not on ${K8S_TO} after 10 minutes"
-  ok "every kubelet on ${K8S_TO} (${SEEN} node(s) seen)"
+  [ "${seen:-0}" -gt 0 ] || fail "the apiserver reported no nodes at all — nothing was verified, and this is not an upgrade that succeeded"
+  [ "${stale:-1}" -eq 0 ] || fail "${stale} kubelet(s) still not on ${target} after 10 minutes"
+  ok "every kubelet on ${target} (${seen} node(s) seen)"
   report_probe
-fi
+}
 
-# --- Then Talos, in place ------------------------------------------------------
-
-if [ "$TALOS_DONE" = 0 ]; then
-  echo "--- Talos ${TALOS_FROM} → ${TALOS_TO} ---"
+upgrade_talos_to() { # <version>
+  local target="$1"
+  echo "--- Talos → ${target} ---"
 
   # The nodes ignore their image attribute, but the image DATA SOURCE still has
   # to resolve, and it derives its name from talos_version. Without this the
   # plan fails on an image the account does not have.
-  task image-build PROVIDER="$PROVIDER" VERSION="$TALOS_TO" ENSURE=1
+  task image-build PROVIDER="$PROVIDER" VERSION="$target" ENSURE=1
 
-  tfvar_set talos_version "$TALOS_TO"
+  tfvar_set talos_version "$target"
   task infra-apply ROLE="$ROLE" PROVIDER="$PROVIDER" KEY="$KEY" APPROVE=auto
 
   # One node at a time, health-gated between each; control planes first because
@@ -418,14 +417,47 @@ if [ "$TALOS_DONE" = 0 ]; then
 
   # Same trap as the kubelet count above: with no nodes returned, `grep -cv`
   # answers 0 and a dead cluster reports a clean Talos upgrade.
-  OSIMAGES="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.osImage}{"\n"}{end}' 2>/dev/null | grep -c . || true)"
-  RUNNING="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.osImage}{"\n"}{end}' 2>/dev/null |
-    grep -cv "$TALOS_TO" || true)"
-  [ "$OSIMAGES" -gt 0 ] || fail "the apiserver reported no nodes at all after the Talos roll — nothing was verified"
-  [ "$RUNNING" -eq 0 ] || fail "${RUNNING} node(s) are not running Talos ${TALOS_TO}"
-  ok "every node on Talos ${TALOS_TO} (${OSIMAGES} node(s) seen)"
+  local osimages running
+  osimages="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.osImage}{"\n"}{end}' 2>/dev/null | grep -c . || true)"
+  running="$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.osImage}{"\n"}{end}' 2>/dev/null |
+              grep -cv "$target" || true)"
+  [ "$osimages" -gt 0 ] || fail "the apiserver reported no nodes at all after the Talos roll — nothing was verified"
+  [ "$running" -eq 0 ] || fail "${running} node(s) are not running Talos ${target}"
+  ok "every node on Talos ${target} (${osimages} node(s) seen)"
   report_probe
-fi
+}
+
+# --- Walk the path, one minor at a time -----------------------------------------
+#
+# Kubernetes first within a step, when both move — it reboots nothing, so it
+# isolates the control-plane roll from the node roll. The path builder never
+# produces a step that moves both, but the order is stated rather than assumed.
+#
+# Each step is a full apply, so the plan-time pair guard runs on every one of
+# them: an intermediate the matrix does not support cannot slip through here.
+
+# A function, and not for tidiness: it is the only way to exercise a seven-step
+# dispatch without a test fixture pinning versions that look real. The harness
+# feeds it a path with the two upgrade_* stubbed out and reads the call order.
+walk_path() { # <talos-from> <k8s-from> <total>   — reads "talos k8s" lines on stdin
+  local prev_t="$1" prev_k="$2" total="$3" step=0 st sk
+  while read -r st sk; do
+    [ -n "$st" ] || continue
+    step=$((step + 1))
+    if [ "$total" -gt 1 ]; then
+      echo
+      echo "════ step ${step}/${total} — Talos ${st}, Kubernetes ${sk}"
+    fi
+    [ "$sk" = "$prev_k" ] || upgrade_k8s_to "$sk"
+    [ "$st" = "$prev_t" ] || upgrade_talos_to "$st"
+    prev_t="$st"; prev_k="$sk"
+  done
+}
+
+# A here-string, NOT a pipe. `printf | walk_path` puts the loop in a subshell,
+# where `fail` exits the subshell and the run carries on past a step that did not
+# land — measured: the harness went 35/8 the moment it was a pipe.
+walk_path "$TALOS_FROM" "$K8S_FROM" "$PATH_STEPS" <<<"$UPGRADE_PATH"
 
 # --- What a clean upgrade leaves behind ----------------------------------------
 

--- a/scripts/dev/infra-verify.sh
+++ b/scripts/dev/infra-verify.sh
@@ -48,6 +48,13 @@ info() { printf '\n▶ %s\n' "$*"; }
 
 K() { timeout 60 kubectl "$@"; }
 
+# Sourced HERE, not where the first caller happens to be: the version check below
+# needs `tfv` too, and it runs long before the backup section that used to own
+# this line. common.sh is function definitions only, so sourcing it early costs
+# nothing and runs nothing.
+# shellcheck source=../lib/common.sh
+source "$ROOT/scripts/lib/common.sh"
+
 info "The cluster answers"
 
 # WAIT, do not sample once. `task cluster-up` returns when the Talos bootstrap RPC
@@ -169,6 +176,70 @@ if [ "$PROVIDER" != local ]; then
   fi
 fi
 
+# --- The fleet runs the versions the config pins --------------------------------
+#
+# `cluster-up` writes the pinned installer image into the machine config and asks
+# NO node to upgrade — `talosctl upgrade` lives in rolling-replace.sh alone. So a
+# bumped pin leaves the fleet a version behind with an empty plan behind it, and
+# the schematic check below cannot see it: a version bump does not change the
+# schematic. Every signal read green. This is the one that does not.
+#
+# kubectl, not talosctl: the node publishes both versions to the apiserver, which
+# section 1 has already proven reachable. So unlike the schematic this needs no
+# tunnel, cannot degrade for want of one, and a mismatch is a hard failure rather
+# than a warning.
+info "The fleet runs the versions the config pins"
+
+# The distinct set across all nodes, or empty. custom-columns rather than
+# jsonpath, and `|| true` because with no cluster the grep matches nothing and
+# pipefail would otherwise turn an empty answer into a dead script. Same reader as
+# cluster-upgrade.sh:97 — deliberately, so the two cannot disagree about what the
+# fleet runs.
+fleet_versions() { # <field>
+  K get nodes --no-headers -o "custom-columns=V:$1" 2>/dev/null |
+    sed -E 's/^Talos \((v[^)]+)\)$/\1/' | grep -E '^v' | sort -u | paste -sd, - || true
+}
+
+# The pin, with the precedence scripts/internal/talos-version.sh already defines:
+# the env file if it pins one, otherwise the root's default. An env file that
+# omits the key is a DELIBERATE choice to track the default (see the header of
+# envs/management-*.tfvars), so an empty read falls through — it is never a fault.
+pinned_version() { # <key>
+  local v="" blk
+  [ -f "$VER_TFVARS" ] && v="$(tfv "$VER_TFVARS" "$1")"
+  # The awk pattern is built HERE, not escaped inline: a \" inside single quotes
+  # inside $( ) inside " " is where bash stops agreeing with you.
+  blk="variable \"$1\""
+  [ -n "$v" ] || v="$(awk -v k="$blk" 'index($0, k) == 1, /^}/' \
+                        "$CLUSTER_DIR/variables.tf" 2>/dev/null |
+                      sed -nE 's/^[[:space:]]*default[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' | head -1)"
+  printf '%s' "$v"
+}
+
+# Four answers, not three. A comma means the nodes disagree with EACH OTHER, which
+# is neither "matches" nor "drifted" — it is a roll that stopped half way, and
+# saying "drifted" there would send the operator looking for the wrong thing.
+version_check() { # <label> <field> <key>
+  local have want
+  have="$(fleet_versions "$2")"
+  want="$(pinned_version "$3")"
+  if [ -z "$want" ]; then
+    warn "no ${3} pinned in ${VER_TFVARS##*/} or variables.tf — nothing to compare the fleet against"
+  elif [ -z "$have" ]; then
+    unk "could not read the running ${1} from any node — the fleet's version is UNCHECKED"
+  elif case "$have" in *,*) true ;; *) false ;; esac; then
+    bad "the fleet is MIXED on ${1}: ${have}. The config pins ${want} — a roll stopped part way. Finish it: task cluster-upgrade PROVIDER=${PROVIDER}"
+  elif [ "$have" = "$want" ]; then
+    ok "every node runs the pinned ${1} (${want})"
+  else
+    bad "the fleet runs ${1} ${have}, the config pins ${want} — the pin was changed and never landed. Roll them: task cluster-upgrade PROVIDER=${PROVIDER}"
+  fi
+}
+
+VER_TFVARS="$CLUSTER_DIR/envs/${ROLE}-${PROVIDER}.tfvars"
+version_check "Talos"      '.status.nodeInfo.osImage'        talos_version
+version_check "Kubernetes" '.status.nodeInfo.kubeletVersion' kubernetes_version
+
 # --- The fleet runs the image the config names ----------------------------------
 #
 # The version tag is not the image. The schematic carries the system extensions,
@@ -214,9 +285,7 @@ else
   # The shared helpers, not a local copy: this file used to build the bucket name
   # inline, so any change to the convention — the bucket_suffix, for one — would
   # leave it probing the old name and reporting a missing backup that is there
-  # under another one. `tfv` comes from common.sh and takes <file> <key>.
-  # shellcheck source=../lib/common.sh
-  source "$ROOT/scripts/lib/common.sh"
+  # under another one. `tfv` takes <file> <key>; common.sh is sourced at the top.
   TFVARS="$CLUSTER_DIR/envs/${ROLE}-${PROVIDER}.tfvars"
   CN="$(tfv "$TFVARS" cluster_name)"; ENVN="$(tfv "$TFVARS" environment)"
   PRIM_EP="$(tfv "$TFVARS" s3_primary_endpoint)"; REPL_EP="$(tfv "$TFVARS" s3_replica_endpoint)"

--- a/scripts/dev/infra-verify.sh
+++ b/scripts/dev/infra-verify.sh
@@ -220,19 +220,24 @@ pinned_version() { # <key>
 # is neither "matches" nor "drifted" — it is a roll that stopped half way, and
 # saying "drifted" there would send the operator looking for the wrong thing.
 version_check() { # <label> <field> <key>
-  local have want
+  local have want fix
   have="$(fleet_versions "$2")"
   want="$(pinned_version "$3")"
+  # The remedy has to be one that exists HERE. `talosctl upgrade` needs a disk,
+  # which a container does not have, so cluster-upgrade is not a thing to send a
+  # local operator to — the local cluster is rebuilt, not upgraded.
+  if [ "$PROVIDER" = local ]; then fix="task local-down && task local-up"
+  else fix="task cluster-upgrade PROVIDER=${PROVIDER}"; fi
   if [ -z "$want" ]; then
     warn "no ${3} pinned in ${VER_TFVARS##*/} or variables.tf — nothing to compare the fleet against"
   elif [ -z "$have" ]; then
     unk "could not read the running ${1} from any node — the fleet's version is UNCHECKED"
   elif case "$have" in *,*) true ;; *) false ;; esac; then
-    bad "the fleet is MIXED on ${1}: ${have}. The config pins ${want} — a roll stopped part way. Finish it: task cluster-upgrade PROVIDER=${PROVIDER}"
+    bad "the fleet is MIXED on ${1}: ${have}. The config pins ${want} — a roll stopped part way. Finish it: ${fix}"
   elif [ "$have" = "$want" ]; then
     ok "every node runs the pinned ${1} (${want})"
   else
-    bad "the fleet runs ${1} ${have}, the config pins ${want} — the pin was changed and never landed. Roll them: task cluster-upgrade PROVIDER=${PROVIDER}"
+    bad "the fleet runs ${1} ${have}, the config pins ${want} — the pin was changed and never landed. Land it: ${fix}"
   fi
 }
 

--- a/scripts/dev/test-cluster-checks.sh
+++ b/scripts/dev/test-cluster-checks.sh
@@ -727,9 +727,12 @@ CONVERGE="$FAKE/scripts/internal/converge-versions.sh"
 cat >"$STUB_DIR/conv/kubectl" <<'STUB'
 #!/usr/bin/env bash
 printf 'kubectl %s\n' "$*" >>"${STUB_LOG:-/dev/null}"
+# Talos moves after a `cluster-roll`, Kubernetes moves after an `infra-apply` —
+# they are two different commands now, so each field flips on its own trigger.
 if grep -q 'cluster-roll' "${STUB_LOG:-/dev/null}" 2>/dev/null
-  then t="${CONV_T_AFTER:-}"; k="${CONV_K_AFTER:-}"
-  else t="${CONV_T_BEFORE:-}"; k="${CONV_K_BEFORE:-}"; fi
+  then t="${CONV_T_AFTER:-}"; else t="${CONV_T_BEFORE:-}"; fi
+if grep -q 'infra-apply' "${STUB_LOG:-/dev/null}" 2>/dev/null
+  then k="${CONV_K_AFTER:-}"; else k="${CONV_K_BEFORE:-}"; fi
 case "$*" in
   *osImage*)        [ -n "$t" ] || exit 0; printf 'Talos (%s)\nTalos (%s)\n' "$t" "$t" ;;
   *kubeletVersion*) [ -n "$k" ] || exit 0; printf '%s\n%s\n' "$k" "$k" ;;
@@ -790,6 +793,28 @@ conv v0.0.1 v0.0.1 v0.0.2 v0.0.2 --check
 { [ "$CONV_RC" -eq 0 ] && ! rolled . && printf '%s' "$CONV_OUT" | grep -q 'does not match'; } \
   && ok "--check reports the drift before the approval and rolls nothing" \
   || bad "--check rolled something or said nothing (rc=$CONV_RC): $CONV_OUT"
+
+# The defect found on 2026-08-24: a Kubernetes-only lag used to call
+# `cluster-roll --upgrade` unconditionally, which only ever runs `talosctl
+# upgrade` — the wrong mechanism for a version that moves through the machine
+# config alone. Assert on the MECHANISM, not on rolling-replace.sh's own
+# happen-to-be-harmless no-op: the Talos roll must not be invoked at all when
+# only Kubernetes lags, and the reverse.
+applied() { grep -q 'infra-apply' "$STUB_LOG" 2>/dev/null; }
+
+# Talos ALREADY on the pin, only Kubernetes lags — the case that used to call
+# cluster-roll unconditionally for a version that never moves through a roll.
+conv v0.0.2 v0.0.1 v0.0.2 v0.0.2
+{ [ "$CONV_RC" -eq 0 ] && applied && ! rolled cp-only && ! rolled workers-only; } \
+  && ok "a Kubernetes-only lag applies the config and never calls the Talos roll" \
+  || bad "a Kubernetes-only lag touched the roll (rc=$CONV_RC): $CONV_OUT"
+
+# Kubernetes ALREADY on the pin, only Talos lags.
+conv v0.0.1 v0.0.2 v0.0.2 v0.0.2
+{ [ "$CONV_RC" -eq 0 ] && rolled cp-only && rolled workers-only && ! applied; } \
+  && ok "a Talos-only lag rolls and never calls infra-apply on its own" \
+  || bad "a Talos-only lag skipped the roll or applied redundantly (rc=$CONV_RC): $CONV_OUT"
+
 
 # A fleet nobody could read is not a converged fleet. Before the apply that is
 # normal and silent; after it, claiming anything would be the original defect.

--- a/scripts/dev/test-cluster-checks.sh
+++ b/scripts/dev/test-cluster-checks.sh
@@ -482,6 +482,89 @@ YAML
     || bad "the Ready-condition filter selected '$got'"
 fi
 
+
+# =============================================================================
+# infra-verify: the fleet runs the versions the tfvars pin
+#
+# `cluster-up` writes the pinned installer image into the machine config and asks
+# no node to upgrade, so a bumped pin leaves the fleet behind with an empty plan
+# behind it — and the schematic check cannot see it, because a version bump does
+# not change the schematic. Until this section existed, infra-verify.sh was
+# symlinked into the fake root and never once executed: the only assertion about
+# the verifier was that cluster-upgrade CALLED it.
+#
+# PROVIDER=local on purpose: that path skips every `tofu output` and `aws s3`, so
+# the whole script is drivable by the stub kubectl alone.
+# =============================================================================
+echo
+echo "=== infra-verify: the fleet runs the versions the config pins ==="
+
+VERIFY_SH="$FAKE/scripts/dev/infra-verify.sh"
+LOCAL_DIR="$FAKE/infrastructure/opentofu-local"
+mkdir -p "$LOCAL_DIR"
+: >"$LOCAL_DIR/kubeconfig"; : >"$LOCAL_DIR/talosconfig"
+cat >"$LOCAL_DIR/variables.tf" <<'TFV'
+variable "talos_version" {
+  type    = string
+  default = "v0.0.2"
+}
+
+variable "kubernetes_version" {
+  type    = string
+  default = "v0.0.2"
+}
+TFV
+
+# Everything section 1 asks, answered green, so the run reaches the version
+# section instead of timing out in the bounded waits above it.
+BASE='get --raw=/readyz\t0\tok\n'
+BASE+='get nodes -l node-role.kubernetes.io/control-plane\t0\tcp-a Ready control-plane 9m\n'
+BASE+='k8s-app=cilium\t0\tcilium-a 1/1 Running%%cilium-b 1/1 Running\n'
+BASE+='readyReplicas\t0\t1\n'
+BASE+='get namespace flux-system\t1\tNotFound\n'
+BASE+='get nodes --no-headers\t0\tnode-a Ready control-plane 9m%%node-b Ready <none> 9m\n'
+
+verify_local() { run "$VERIFY_SH" local; }
+
+# The COUNT, not the message. Turning `unk` into `ok` leaves the sentence
+# identical — an assertion on the words alone survives that mutation, and did.
+unk_count() { sed -E 's/\x1b\[[0-9;]*m//g' <<<"$RUN_OUT" |
+                sed -nE 's/.*, ([0-9]+) could not be checked.*/\1/p' | tail -1; }
+
+# --- both pins matched --------------------------------------------------------
+plan 'osImage\t0\tTalos (v0.0.2)\n''kubeletVersion\t0\tv0.0.2\n'"$BASE"
+verify_local
+{ said 'every node runs the pinned Talos (v0.0.2)' && said 'every node runs the pinned Kubernetes (v0.0.2)'; } \
+  && ok "a fleet on the pinned versions passes" \
+  || bad "a fleet that matches its pins was not recognised as matching"
+
+# --- the case this section exists for -----------------------------------------
+# One patch behind, which is what a bumped tfvars and an un-rolled fleet look
+# like. The schematic is untouched by a version bump, so nothing else sees it.
+plan 'osImage\t0\tTalos (v0.0.1)\n''kubeletVersion\t0\tv0.0.2\n'"$BASE"
+verify_local
+{ said 'the fleet runs Talos v0.0.1, the config pins v0.0.2' && [ "$RUN_RC" -ne 0 ]; } \
+  && ok "a fleet a version behind its pin FAILS the run" \
+  || bad "a version behind the pin passed — the drift cluster-up leaves is invisible"
+
+# --- a roll that stopped half way ---------------------------------------------
+# Neither "matches" nor "drifted": saying "drifted" here would send the operator
+# to re-run an upgrade when the truth is that one is already half done.
+plan 'osImage\t0\tTalos (v0.0.1)%%Talos (v0.0.2)\n''kubeletVersion\t0\tv0.0.2\n'"$BASE"
+verify_local
+{ said 'the fleet is MIXED on Talos' && said 'v0.0.1,v0.0.2'; } \
+  && ok "a mixed fleet is named as mixed, not as drifted" \
+  || bad "a half-finished roll reads as a plain version drift"
+
+# --- the question could not be asked ------------------------------------------
+# `unk`, never `ok`: a node query that FAILED once read as "everything is on the
+# target" in this repository, which is the defect this whole file exists for.
+plan 'osImage\t1\tError from server: connection refused\n''kubeletVersion\t0\tv0.0.2\n'"$BASE"
+verify_local
+{ said 'could not read the running Talos' && [ "$(unk_count)" -ge 1 ] \
+  && ! said 'every node runs the pinned Talos'; } \
+  && ok "an unanswered version query is UNCHECKED ($(unk_count) unknown), not a pass" \
+  || bad "a failed node query read as a fleet on the target, or was not counted as unknown"
 echo
 printf '%s passed, %s failed, %s hung, %s skipped, %s known defect(s) in the scripts under test\n' \
   "$PASS" "$FAIL" "$HUNG" "$SKIPPED" "$KNOWN"

--- a/scripts/dev/test-cluster-checks.sh
+++ b/scripts/dev/test-cluster-checks.sh
@@ -565,6 +565,93 @@ verify_local
   && ! said 'every node runs the pinned Talos'; } \
   && ok "an unanswered version query is UNCHECKED ($(unk_count) unknown), not a pass" \
   || bad "a failed node query read as a fleet on the target, or was not counted as unknown"
+
+# =============================================================================
+# cluster-upgrade: the path across minors
+#
+# Kubernetes forbids skipping a minor on the way up, and Talos supports a WINDOW
+# of Kubernetes minors — so a valid start and a valid end can be joined by a step
+# that is neither. (1.12, 1.30) → (1.13, 1.36) taken Talos-first lands on
+# (1.13, 1.30), below 1.13's floor of 1.31, and is refused at apply time — after
+# the step before it has already landed on a paying cluster.
+#
+# The functions are sourced rather than driven through the script: the harness
+# fixture pins v0.0.1/v0.0.2, which carries no minor semantics at all.
+# =============================================================================
+echo
+echo "=== cluster-upgrade: the path across minors ==="
+
+PATH_FNS="$STUB_DIR/pathfns.sh"
+_a=$(grep -n '^SUPPORT_JSON=' "$ROOT/scripts/dev/cluster-upgrade.sh" | cut -d: -f1)
+_b=$(awk -v a="$_a" 'NR>a && /^}$/ {n=NR} NR>a && /^TALOS_TO=/ {print n; exit}' "$ROOT/scripts/dev/cluster-upgrade.sh")
+{ printf 'ROOT=%q\n' "$ROOT"; sed -n "${_a},${_b}p" "$ROOT/scripts/dev/cluster-upgrade.sh"; } > "$PATH_FNS"
+# rc 127 from a failed extraction would make every negative below score a pass.
+# shellcheck source=/dev/null
+if source "$PATH_FNS" 2>/dev/null && declare -f version_path >/dev/null; then
+  ok "the path functions were extracted and are callable"
+else
+  bad "could not extract version_path — every assertion below would be vacuous"
+fi
+
+CLIMB="$(version_path v1.12.7 v1.30.0 v1.13.9 v1.36.3 2>/dev/null)"
+[ "$(printf '%s' "$CLIMB" | grep -c .)" = 7 ] \
+  && ok "(1.12.7, 1.30.0) → (1.13.9, 1.36.3) is a 7-step climb" \
+  || bad "expected 7 steps, got $(printf '%s' "$CLIMB" | grep -c .)"
+
+# EVERY pair on the way, not just the ends. This is the whole point.
+_bad=0
+while read -r tv kv; do
+  [ -n "$tv" ] || continue
+  pair_ok "$tv" "$kv" || { _bad=$((_bad + 1)); }
+done <<<"$CLIMB"
+[ "$_bad" = 0 ] \
+  && ok "…and every pair along it is inside the supported window" \
+  || bad "${_bad} step(s) of the climb are pairs the guard would refuse"
+
+# The first draft passed through v1.12.0 while the cluster ran v1.12.7 — a patch
+# DOWNGRADE, commanded by a function whose job is to go up.
+[ "$(printf '%s' "$CLIMB" | head -1 | awk '{print $1}')" = v1.12.7 ] \
+  && ok "the minor it is already on keeps its patch — no downgrade on the way through" \
+  || bad "step 1 moves Talos to $(printf '%s' "$CLIMB" | head -1 | awk '{print $1}'), off the running v1.12.7"
+
+[ "$(version_path v1.13.8 v1.36.3 v1.13.9 v1.36.3 2>/dev/null)" = "v1.13.9 v1.36.3" ] \
+  && ok "a patch bump is one step, not an empty list" \
+  || bad "a patch-only move produced $(version_path v1.13.8 v1.36.3 v1.13.9 v1.36.3 2>/dev/null | tr '\n' '/')"
+
+# Kubernetes alone, Talos held still — a real thing to want, and the ONLY route
+# that consults a Talos minor's CEILING. Every climb that also moves Talos takes
+# it first, so 1.12's k8s_max is never read on those: narrowing it to 31 changed
+# nothing and looked like a weak test until this case existed.
+_k8sonly="$(version_path v1.12.7 v1.30.0 v1.12.9 v1.35.0 2>/dev/null)"
+{ [ "$(printf '%s' "$_k8sonly" | grep -c .)" = 5 ] \
+  && [ "$(printf '%s' "$_k8sonly" | tail -1)" = "v1.12.9 v1.35.0" ]; } \
+  && ok "Kubernetes 1.30 → 1.35 on a held Talos is five steps, up to the ceiling" \
+  || bad "a Kubernetes-only climb to 1.12's ceiling produced $(printf '%s' "$_k8sonly" | tr '\n' '/')"
+
+# On the MESSAGE, not just the verdict: without the guard the loop refuses a
+# downgrade anyway, having tried and failed to climb — same exit code, and an
+# operator told "no supported step out of 1.13" when they asked to go DOWN reads
+# it as a broken map. The guard's whole value is the sentence.
+_dn="$(version_path v1.13.9 v1.36.3 v1.12.7 v1.30.0 2>&1)"; _dnrc=$?
+{ [ "$_dnrc" -ne 0 ] && grep -q 'goes DOWN' <<<"$_dn"; } \
+  && ok "a downgrade is refused AS a downgrade, not as a dead end" \
+  || bad "downgrade refused without saying so (rc=$_dnrc): ${_dn%%$'\n'*}"
+
+# Refused BEFORE printing: a caller shown steps and then a refusal has been told
+# to start something that cannot finish.
+# Also on the message. The loop would refuse this on its own after climbing and
+# failing, so the verdict alone does not distinguish "your target is not in the
+# matrix" from "I got stuck somewhere on the way" — and only the first is true.
+_out="$(version_path v1.12.7 v1.30.0 v1.99.0 v1.36.3 2>/dev/null)"; _rc=$?
+_err="$(version_path v1.12.7 v1.30.0 v1.99.0 v1.36.3 2>&1 >/dev/null)"
+{ [ "$_rc" -ne 0 ] && [ -z "$_out" ] && grep -q 'the TARGET' <<<"$_err"; } \
+  && ok "an unreachable TARGET is named as such, with no steps printed" \
+  || bad "refused without naming the target (rc=$_rc, steps=${_out:+yes}): ${_err%%$'\n'*}"
+
+# And the control: the guard must refuse something, or it guards nothing.
+pair_ok v1.13.9 v1.30.0 \
+  && bad "1.13 + Kubernetes 1.30 accepted — below the floor of 1.31" \
+  || ok "1.13 + Kubernetes 1.30 refused — the window is actually consulted"
 echo
 printf '%s passed, %s failed, %s hung, %s skipped, %s known defect(s) in the scripts under test\n' \
   "$PASS" "$FAIL" "$HUNG" "$SKIPPED" "$KNOWN"

--- a/scripts/dev/test-cluster-checks.sh
+++ b/scripts/dev/test-cluster-checks.sh
@@ -714,6 +714,95 @@ _eat="$(walk_path v1.12.7 v1.30.0 7 <<<"$CLIMB7" | grep -cE '^(k8s|talos) ' || t
   || bad "a stdin-reading step truncated the climb to ${_eat}/7 dispatches"
 
 unset -f upgrade_k8s_to upgrade_talos_to walk_path
+echo "=== converge-versions: the half of cluster-up that OpenTofu cannot do ==="
+
+# Its own stub, because both reads ask the SAME question — `custom-columns` on the
+# same field — so the shared plan cannot tell "before the roll" from "after" it.
+# This one keys on whether a roll has happened, which is exactly the distinction
+# the post-roll re-read exists to make.
+mkdir -p "$FAKE/scripts/internal" "$FAKE/scripts/lib" "$STUB_DIR/conv"
+ln -s "$ROOT/scripts/internal/converge-versions.sh" "$FAKE/scripts/internal/converge-versions.sh"
+ln -s "$ROOT/scripts/lib/common.sh" "$FAKE/scripts/lib/common.sh"
+CONVERGE="$FAKE/scripts/internal/converge-versions.sh"
+cat >"$STUB_DIR/conv/kubectl" <<'STUB'
+#!/usr/bin/env bash
+printf 'kubectl %s\n' "$*" >>"${STUB_LOG:-/dev/null}"
+if grep -q 'cluster-roll' "${STUB_LOG:-/dev/null}" 2>/dev/null
+  then t="${CONV_T_AFTER:-}"; k="${CONV_K_AFTER:-}"
+  else t="${CONV_T_BEFORE:-}"; k="${CONV_K_BEFORE:-}"; fi
+case "$*" in
+  *osImage*)        [ -n "$t" ] || exit 0; printf 'Talos (%s)\nTalos (%s)\n' "$t" "$t" ;;
+  *kubeletVersion*) [ -n "$k" ] || exit 0; printf '%s\n%s\n' "$k" "$k" ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod +x "$STUB_DIR/conv/kubectl"
+cat >"$STUB_DIR/conv/task" <<'STUB'
+#!/usr/bin/env bash
+printf 'task %s\n' "$*" >>"${STUB_LOG:-/dev/null}"
+STUB
+chmod +x "$STUB_DIR/conv/task"
+
+conv() { # <t-before> <k-before> <t-after> <k-after> [--check]
+  : >"$STUB_LOG"
+  CONV_OUT="$(PATH="$STUB_DIR/conv:$PATH" \
+    CONV_T_BEFORE="$1" CONV_K_BEFORE="$2" CONV_T_AFTER="${3:-$1}" CONV_K_AFTER="${4:-$2}" \
+    "$CONVERGE" "$PROVIDER" "$ROLE" "$KEYFILE" ${5:+--check} 2>&1)"; CONV_RC=$?
+}
+rolled() { grep -q "cluster-roll.*$1" "$STUB_LOG" 2>/dev/null; }
+
+tfvars v0.0.2 v0.0.2
+
+# The NORMAL case first. cluster-up leaves the fleet matching its pin, so this
+# runs on every ordinary bring-up: if it rolled here it would re-roll every node
+# of every healthy cluster, for ever.
+conv v0.0.2 v0.0.2
+{ [ "$CONV_RC" -eq 0 ] && ! rolled . ; } \
+  && ok "a fleet already on the pin is not rolled" \
+  || bad "an up-to-date fleet was rolled anyway (rc=$CONV_RC): $CONV_OUT"
+
+conv v0.0.1 v0.0.1 v0.0.2 v0.0.2
+{ [ "$CONV_RC" -eq 0 ] && rolled cp-only && rolled workers-only; } \
+  && ok "a drifted fleet is rolled, control planes before workers" \
+  || bad "the drift was not converged (rc=$CONV_RC): $CONV_OUT"
+
+# The defect stage 3 found, one level up: the roll reporting success is the
+# CLIENT talking. Ask the fleet again, and refuse to claim what it does not say.
+conv v0.0.1 v0.0.1 v0.0.1 v0.0.1
+{ [ "$CONV_RC" -ne 0 ] && printf '%s' "$CONV_OUT" | grep -q 'after the roll'; } \
+  && ok "a roll that did not move the fleet fails instead of announcing success" \
+  || bad "a roll that changed nothing was reported as converged (rc=$CONV_RC)"
+
+# One axis at a time. The scenario above lags on BOTH, so the Talos check alone
+# catches it and the Kubernetes one can be deleted with every assertion still
+# green — measured, it survived the mutation. These two isolate each branch.
+conv v0.0.1 v0.0.1 v0.0.2 v0.0.1
+{ [ "$CONV_RC" -ne 0 ] && printf '%s' "$CONV_OUT" | grep -q 'Kubernetes v0.0.1'; } \
+  && ok "…and a Kubernetes-only lag is caught on its own" \
+  || bad "a Kubernetes-only lag survived the post-roll re-read (rc=$CONV_RC): $CONV_OUT"
+
+conv v0.0.1 v0.0.1 v0.0.1 v0.0.2
+{ [ "$CONV_RC" -ne 0 ] && printf '%s' "$CONV_OUT" | grep -q 'Talos v0.0.1'; } \
+  && ok "…and a Talos-only lag is caught on its own" \
+  || bad "a Talos-only lag survived the post-roll re-read (rc=$CONV_RC): $CONV_OUT"
+
+conv v0.0.1 v0.0.1 v0.0.2 v0.0.2 --check
+{ [ "$CONV_RC" -eq 0 ] && ! rolled . && printf '%s' "$CONV_OUT" | grep -q 'does not match'; } \
+  && ok "--check reports the drift before the approval and rolls nothing" \
+  || bad "--check rolled something or said nothing (rc=$CONV_RC): $CONV_OUT"
+
+# A fleet nobody could read is not a converged fleet. Before the apply that is
+# normal and silent; after it, claiming anything would be the original defect.
+conv "" ""
+{ [ "$CONV_RC" -ne 0 ] && printf '%s' "$CONV_OUT" | grep -q 'UNKNOWN'; } \
+  && ok "an unreadable fleet is refused, not called converged" \
+  || bad "an unreadable fleet did not stop the run (rc=$CONV_RC): $CONV_OUT"
+
+conv "" "" "" "" --check
+[ "$CONV_RC" -eq 0 ] \
+  && ok "…but before the apply, no cluster to read is not an error" \
+  || bad "--check failed with no cluster yet (rc=$CONV_RC): $CONV_OUT"
+
 echo
 printf '%s passed, %s failed, %s hung, %s skipped, %s known defect(s) in the scripts under test\n' \
   "$PASS" "$FAIL" "$HUNG" "$SKIPPED" "$KNOWN"

--- a/scripts/dev/test-cluster-checks.sh
+++ b/scripts/dev/test-cluster-checks.sh
@@ -652,6 +652,55 @@ _err="$(version_path v1.12.7 v1.30.0 v1.99.0 v1.36.3 2>&1 >/dev/null)"
 pair_ok v1.13.9 v1.30.0 \
   && bad "1.13 + Kubernetes 1.30 accepted — below the floor of 1.31" \
   || ok "1.13 + Kubernetes 1.30 refused — the window is actually consulted"
+
+# The dispatch across a real seven-step path. The harness fixture pins v0.0.1 on
+# purpose — fictional, so nobody copies it into an environment — which means it
+# carries no minor semantics and exercises exactly one step. walk_path is a
+# function so this can feed it a path directly, with the two operations stubbed.
+_wa=$(grep -n '^walk_path() {' "$ROOT/scripts/dev/cluster-upgrade.sh" | cut -d: -f1)
+_wb=$(awk -v a="$_wa" 'NR>=a && /^}$/ {print NR; exit}' "$ROOT/scripts/dev/cluster-upgrade.sh")
+eval "$(sed -n "${_wa},${_wb}p" "$ROOT/scripts/dev/cluster-upgrade.sh")"
+declare -f walk_path >/dev/null \
+  && ok "walk_path was extracted and is callable" \
+  || bad "could not extract walk_path — the assertions below would be vacuous"
+
+CLIMB7="$(version_path v1.12.7 v1.30.0 v1.13.9 v1.36.3 2>/dev/null)"
+upgrade_k8s_to()   { echo "k8s $1"; }
+upgrade_talos_to() { echo "talos $1"; }
+_seq="$(walk_path v1.12.7 v1.30.0 7 <<<"$CLIMB7" | grep -E '^(k8s|talos) ' | tr '\n' '|')"
+_want='k8s v1.31.0|talos v1.13.9|k8s v1.32.0|k8s v1.33.0|k8s v1.34.0|k8s v1.35.0|k8s v1.36.3|'
+[ "$_seq" = "$_want" ] \
+  && ok "seven steps dispatch as one Kubernetes hop, then Talos, then five more" \
+  || bad "dispatch order wrong: $_seq"
+
+# An axis that does not move must not be touched. Talos appears once in that
+# sequence, not seven times — re-applying an unchanged version would re-roll six
+# nodes for nothing, six times over.
+[ "$(grep -c '^talos ' <<<"$(walk_path v1.12.7 v1.30.0 7 <<<"$CLIMB7")")" = 1 ] \
+  && ok "…and Talos is rolled once, not once per step" \
+  || bad "Talos was dispatched $(grep -c '^talos ' <<<"$(walk_path v1.12.7 v1.30.0 7 <<<"$CLIMB7")") times"
+
+# The within-step order is DEFENSIVE: version_path never emits a step that moves
+# both axes, so nothing in a real climb observes it, and swapping the two lines
+# changed no assertion. Feed it the step the builder cannot produce, and the
+# choice becomes checkable — Kubernetes first, because it reboots nothing and so
+# keeps the control-plane roll separate from the node roll.
+upgrade_k8s_to()   { echo "k8s $1"; }
+upgrade_talos_to() { echo "talos $1"; }
+_both="$(walk_path v1.12.7 v1.30.0 1 <<<"v1.13.9 v1.31.0" | grep -E '^(k8s|talos) ' | tr '\n' '|')"
+[ "$_both" = 'k8s v1.31.0|talos v1.13.9|' ] \
+  && ok "a step moving both axes does Kubernetes first — the reboot-free one" \
+  || bad "both-axis step dispatched as: $_both"
+
+# The one that matters most. `printf … | walk_path` put the loop in a subshell,
+# where a failing step exits the subshell and the run carries on to the next —
+# measured, the harness went 35/8. A step that fails must stop the climb.
+upgrade_k8s_to() { echo "k8s $1"; [ "$1" = v1.32.0 ] && { echo "BOOM" >&2; exit 1; }; return 0; }
+_out="$( walk_path v1.12.7 v1.30.0 7 <<<"$CLIMB7" 2>/dev/null )" || true
+{ grep -q 'k8s v1.32.0' <<<"$_out" && ! grep -q 'k8s v1.33.0' <<<"$_out"; } \
+  && ok "a step that fails stops the climb instead of walking past it" \
+  || bad "the climb continued after a failed step: $(tr '\n' '|' <<<"$_out")"
+unset -f upgrade_k8s_to upgrade_talos_to walk_path
 echo
 printf '%s passed, %s failed, %s hung, %s skipped, %s known defect(s) in the scripts under test\n' \
   "$PASS" "$FAIL" "$HUNG" "$SKIPPED" "$KNOWN"

--- a/scripts/dev/test-cluster-checks.sh
+++ b/scripts/dev/test-cluster-checks.sh
@@ -700,6 +700,19 @@ _out="$( walk_path v1.12.7 v1.30.0 7 <<<"$CLIMB7" 2>/dev/null )" || true
 { grep -q 'k8s v1.32.0' <<<"$_out" && ! grep -q 'k8s v1.33.0' <<<"$_out"; } \
   && ok "a step that fails stops the climb instead of walking past it" \
   || bad "the climb continued after a failed step: $(tr '\n' '|' <<<"$_out")"
+# The defect a real cluster found, and every stub above hid. Inside the loop
+# `task cluster-roll` reaches ssh and talosctl, and BOTH READ STDIN — the same
+# stdin the here-string feeds the loop. Measured on Scaleway 2026-08-21: the
+# Talos roll of step 2 swallowed steps 3-7, the climb exited 0 announcing
+# v1.36.3, and the cluster sat on v1.31.0 with every check green. A stub that
+# drains stdin, as ssh does, reproduces it without a cloud.
+upgrade_k8s_to()   { echo "k8s $1"; }
+upgrade_talos_to() { echo "talos $1"; cat >/dev/null; }
+_eat="$(walk_path v1.12.7 v1.30.0 7 <<<"$CLIMB7" | grep -cE '^(k8s|talos) ' || true)"
+[ "$_eat" = 7 ] \
+  && ok "a step that reads stdin cannot swallow the rest of the climb" \
+  || bad "a stdin-reading step truncated the climb to ${_eat}/7 dispatches"
+
 unset -f upgrade_k8s_to upgrade_talos_to walk_path
 echo
 printf '%s passed, %s failed, %s hung, %s skipped, %s known defect(s) in the scripts under test\n' \

--- a/scripts/dev/test-rolling-replace.sh
+++ b/scripts/dev/test-rolling-replace.sh
@@ -421,5 +421,49 @@ grep -q 'etcd forfeit-leadership' "$ROOT/scripts/ops/rolling-replace.sh" \
   || bad "no forfeit-leadership — the last control plane still forces an election"
 
 
+
+echo
+echo "=== the roll reads the role's env file, not always management's ==="
+# `task cluster-roll` declared a ROLE variable that nothing read, and both the
+# Taskfile and this script spelled the env file `management-<provider>.tfvars`.
+# So `cluster-upgrade ROLE=workload` applied the workload tfvars in its two
+# phases and then rolled against the MANAGEMENT state. Three call sites had to
+# agree, and only a source read can see two of them — a stub kubectl cannot
+# observe which file `tofu init` was handed.
+SUT_R="$ROOT/scripts/ops/rolling-replace.sh"
+TFY="$ROOT/Taskfile.yml"
+
+grep -qE '^TFVARS="envs/\$\{ROLE\}-\$\{PROVIDER\}\.tfvars"$' "$SUT_R" \
+  && ok "rolling-replace builds the env path from the role" \
+  || bad "rolling-replace still hardcodes a role in TFVARS"
+
+[ "$(grep -c 'envs/management-\${PROVIDER}' "$SUT_R")" = 0 ] \
+  && ok "…and no hardcoded 'management' env path is left in it" \
+  || bad "a hardcoded management env path survives in rolling-replace"
+
+grep -q -- '--role=\*)' "$SUT_R" \
+  && ok "it accepts --role=" || bad "no --role= in the flag parser"
+
+# The default is what keeps every existing caller working: nothing else in the
+# repository passed a role before this change.
+grep -qE '^ROLE="management"$' "$SUT_R" \
+  && ok "…defaulting to management, so existing callers are unchanged" \
+  || bad "no management default — existing callers would break"
+
+# The Taskfile half. Both its lines have to move together: the tofu init that
+# selects the BACKEND, and the script call that selects the STATE it rolls.
+grep -q 'tf-backend.sh envs/{{.ROLE}}-{{.PROVIDER}}.tfvars' "$TFY" \
+  && ok "cluster-roll inits the backend for the role" \
+  || bad "cluster-roll still inits the management backend whatever the role"
+
+grep -q 'rolling-replace.sh {{.PROVIDER}} --role={{.ROLE}}' "$TFY" \
+  && ok "…and passes that role to the script" \
+  || bad "cluster-roll does not pass ROLE to rolling-replace"
+
+# And the caller that had the role all along and never forwarded it.
+[ "$(grep -c 'task cluster-roll PROVIDER="\$PROVIDER" ROLE="\$ROLE"' "$ROOT/scripts/dev/cluster-upgrade.sh")" = 2 ] \
+  && ok "cluster-upgrade forwards its role on both rolls" \
+  || bad "cluster-upgrade still rolls without saying which role"
+
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/internal/converge-versions.sh
+++ b/scripts/internal/converge-versions.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Bring the RUNNING fleet to the versions the config pins — the half of
+# `cluster-up` that OpenTofu cannot do.
+#
+# `cluster-up` writes the pinned installer image into the machine config and asks
+# NO node to upgrade, so a bumped pin lands a machine config and leaves the fleet
+# a version behind, with an empty plan behind it. Editing the tfvars IS the
+# decision to upgrade; this is what makes the command reach it.
+#
+# NOT cluster-upgrade.sh. That script fails BY DESIGN when the fleet already
+# matches both targets — exactly the state cluster-up leaves behind — so folding
+# it in would turn every ordinary bring-up into a hard failure. This reuses the
+# roll it calls, and nothing else.
+#
+# --check reports and rolls nothing. cluster-up runs it BEFORE the approval
+# question, so the operator says yes to a journey that includes the roll instead
+# of discovering it afterwards. `ignore_changes` on the image attribute keeps the
+# roll out of the OpenTofu plan entirely, so the plan cannot show it.
+#
+# Usage: converge-versions.sh <provider> <role> <key> [--check]
+set -euo pipefail
+
+PROVIDER="${1:?usage: converge-versions.sh <provider> <role> <key> [--check]}"
+ROLE="${2:?usage: converge-versions.sh <provider> <role> <key> [--check]}"
+KEY="${3:-$HOME/.ssh/id_ed25519}"; KEY="${KEY/#\~/$HOME}"
+CHECK_ONLY=0; [ "${4:-}" = --check ] && CHECK_ONLY=1
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLUSTER_DIR="$ROOT/infrastructure/opentofu/cluster"
+TFVARS="$CLUSTER_DIR/envs/${ROLE}-${PROVIDER}.tfvars"
+# shellcheck source=../lib/common.sh
+source "$ROOT/scripts/lib/common.sh"
+export KUBECONFIG="${KUBECONFIG:-$CLUSTER_DIR/kubeconfig}"
+
+fail() { echo "✗ $*" >&2; exit 1; }
+
+want_talos="$(oa_pinned_version "$CLUSTER_DIR" "$TFVARS" talos_version)"
+want_k8s="$(oa_pinned_version "$CLUSTER_DIR" "$TFVARS" kubernetes_version)"
+have_talos="$(oa_fleet_versions '.status.nodeInfo.osImage')"
+have_k8s="$(oa_fleet_versions '.status.nodeInfo.kubeletVersion')"
+
+# Nothing pinned anywhere is a legitimate configuration, not a drift.
+if [ -z "$want_talos" ] && [ -z "$want_k8s" ]; then
+  echo "  no talos_version or kubernetes_version pinned — nothing to converge toward"
+  exit 0
+fi
+
+# No cluster to ask. Before the apply that is the normal case and says nothing
+# useful; after it, a fleet we cannot read is a fleet we cannot claim anything
+# about — and claiming it anyway is the defect this whole file exists to close.
+if [ -z "$have_talos" ] && [ -z "$have_k8s" ]; then
+  [ "$CHECK_ONLY" = 1 ] && exit 0
+  fail "the apiserver named no nodes, so the running versions are UNKNOWN.
+  Nothing was rolled and nothing can be promised about this fleet.
+  Check the cluster, then: task cluster-verify PROVIDER=${PROVIDER} ROLE=${ROLE}"
+fi
+
+drift=0
+[ -n "$want_talos" ] && [ "$have_talos" != "$want_talos" ] && drift=1
+[ -n "$want_k8s" ]   && [ "$have_k8s"   != "$want_k8s"   ] && drift=1
+
+if [ "$drift" = 0 ]; then
+  echo "✓ the fleet already runs the pinned versions (Talos ${have_talos}, Kubernetes ${have_k8s}) — nothing to roll"
+  exit 0
+fi
+
+echo "▶ the fleet does not match the pin:"
+[ "$have_talos" = "$want_talos" ] || echo "    Talos      running ${have_talos:-?} → pinned ${want_talos}"
+[ "$have_k8s"   = "$want_k8s"   ] || echo "    Kubernetes running ${have_k8s:-?} → pinned ${want_k8s}"
+
+if [ "$CHECK_ONLY" = 1 ]; then
+  echo "    Approving below also approves rolling every node, one at a time, to close this."
+  exit 0
+fi
+
+# A Kubernetes-only move must NOT reboot nodes, and a Talos move must. Both are
+# what --upgrade already means to the roll; control planes first, because a
+# worker's upgrade drains against a healthy control plane.
+task cluster-roll PROVIDER="$PROVIDER" ROLE="$ROLE" KEY="$KEY" APPROVE=auto -- --cp-only --upgrade
+task cluster-roll PROVIDER="$PROVIDER" ROLE="$ROLE" KEY="$KEY" APPROVE=auto -- --workers-only --upgrade
+
+# Ask again. The roll reporting success is the client talking; this is the fleet.
+got_talos="$(oa_fleet_versions '.status.nodeInfo.osImage')"
+got_k8s="$(oa_fleet_versions '.status.nodeInfo.kubeletVersion')"
+[ -n "$got_talos" ] || fail "after the roll the apiserver named no nodes — nothing was verified"
+[ -z "$want_talos" ] || [ "$got_talos" = "$want_talos" ] ||
+  fail "after the roll the fleet runs Talos ${got_talos}, the config pins ${want_talos}"
+[ -z "$want_k8s" ] || [ "$got_k8s" = "$want_k8s" ] ||
+  fail "after the roll the fleet runs Kubernetes ${got_k8s}, the config pins ${want_k8s}"
+echo "✓ converged: every node runs Talos ${got_talos}, Kubernetes ${got_k8s}"

--- a/scripts/internal/converge-versions.sh
+++ b/scripts/internal/converge-versions.sh
@@ -73,11 +73,29 @@ if [ "$CHECK_ONLY" = 1 ]; then
   exit 0
 fi
 
-# A Kubernetes-only move must NOT reboot nodes, and a Talos move must. Both are
-# what --upgrade already means to the roll; control planes first, because a
-# worker's upgrade drains against a healthy control plane.
-task cluster-roll PROVIDER="$PROVIDER" ROLE="$ROLE" KEY="$KEY" APPROVE=auto -- --cp-only --upgrade
-task cluster-roll PROVIDER="$PROVIDER" ROLE="$ROLE" KEY="$KEY" APPROVE=auto -- --workers-only --upgrade
+# Kubernetes moves through the machine config, not through a roll: an
+# `infra-apply` writes kubernetes_version into talos_machine_configuration_apply
+# and every kubelet picks it up on its own — cluster-upgrade.sh:upgrade_k8s_to()
+# does exactly this and rolls nothing. `cluster-roll --upgrade` only ever runs
+# `talosctl upgrade`, the TALOS image, so calling it for a Kubernetes-only lag
+# would roll every node for a version it does not carry. rolling-replace.sh does
+# make that harmless today — it compares the RUNNING image to the pinned one and
+# skips a node that already matches — but relying on that no-op is the wrong
+# thing to depend on, and if a Kubernetes-only lag ever coincides with a real
+# Talos lag, calling the roll unconditionally here would roll it against the
+# WRONG target: converge-versions never passes TALOS_IMAGE, so the roll derives
+# it from the state's current installer_image output, which is fine only because
+# the two moves never overlap in this script.
+if [ -n "$want_k8s" ] && [ "$have_k8s" != "$want_k8s" ]; then
+  task infra-apply ROLE="$ROLE" PROVIDER="$PROVIDER" KEY="$KEY" APPROVE=auto
+fi
+
+# Talos moves through a roll: control planes first, because a worker's upgrade
+# drains against a healthy control plane.
+if [ -n "$want_talos" ] && [ "$have_talos" != "$want_talos" ]; then
+  task cluster-roll PROVIDER="$PROVIDER" ROLE="$ROLE" KEY="$KEY" APPROVE=auto -- --cp-only --upgrade
+  task cluster-roll PROVIDER="$PROVIDER" ROLE="$ROLE" KEY="$KEY" APPROVE=auto -- --workers-only --upgrade
+fi
 
 # Ask again. The roll reporting success is the client talking; this is the fleet.
 got_talos="$(oa_fleet_versions '.status.nodeInfo.osImage')"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -209,3 +209,31 @@ oa_talos_endpoint_ok() { # <host> <port>
   timeout 10 openssl s_client -connect "${1}:${2}" -brief </dev/null 2>&1 |
     grep -qiE 'CONNECTION ESTABLISHED|Peer certificate|Protocol version'
 }
+
+# --- Versions: what the fleet RUNS, and what the config PINS -------------------
+# Two readers, here rather than in each caller, because a disagreement between
+# them is invisible: both answers look like a version string either way.
+
+# The distinct set across all nodes, or empty. `|| true` because with no cluster
+# the grep matches nothing and pipefail would turn an empty answer into a dead
+# script. A comma in the result means a MIXED fleet — a roll that stopped part way.
+# Usage: oa_fleet_versions <node-field>
+oa_fleet_versions() {
+  timeout 60 kubectl get nodes --no-headers -o "custom-columns=V:$1" 2>/dev/null |
+    sed -E 's/^Talos \((v[^)]+)\)$/\1/' | grep -E '^v' | sort -u | paste -sd, - || true
+}
+
+# The tfvars wins, `variables.tf` is the tracked fallback: envs/management-*.tfvars
+# deliberately omit the pins on some clusters to inherit the default, so an empty
+# tfvars answer is a legitimate "use the default", never an error.
+# Usage: oa_pinned_version <cluster-dir> <tfvars-file> <key>
+oa_pinned_version() {
+  local dir="$1" tfvars="$2" k="$3" v="" blk
+  [ -f "$tfvars" ] && v="$(tfv "$tfvars" "$k")"
+  # Built HERE, not escaped inline: a \" inside single quotes inside $( ) inside
+  # " " is where bash stops agreeing with you.
+  blk="variable \"$k\""
+  [ -n "$v" ] || v="$(awk -v key="$blk" 'index($0, key) == 1, /^}/' "$dir/variables.tf" 2>/dev/null |
+                      sed -nE 's/^[[:space:]]*default[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' | head -1)"
+  printf '%s' "$v"
+}

--- a/scripts/ops/rolling-replace.sh
+++ b/scripts/ops/rolling-replace.sh
@@ -55,6 +55,14 @@ SCOPE="all"        # all | workers | cp
 DRY_RUN=0
 ASSUME_YES=0
 UPGRADE=0         # --upgrade: in-place `talosctl upgrade`, no VM replacement
+# The role used to be the literal "management", here and in the Taskfile, while
+# `task cluster-roll` declared a ROLE variable nothing read. So `cluster-upgrade
+# ROLE=workload` applied the workload tfvars in both its phases and then rolled
+# against the MANAGEMENT state. Defaulted, so every existing caller is unchanged.
+ROLE="management"
+# `--role=x`, one token: the loop below is a `for` over "$@" and cannot consume a
+# following word. Splitting it into a while/shift parser to gain a space would
+# rewrite the argument handling of every other flag for no benefit.
 for arg in "$@"; do
   case "$arg" in
     --workers-only) SCOPE="workers" ;;
@@ -62,9 +70,11 @@ for arg in "$@"; do
     --dry-run)      DRY_RUN=1 ;;
     --upgrade)      UPGRADE=1 ;;
     --yes|-y)       ASSUME_YES=1 ;;
+    --role=*)       ROLE="${arg#--role=}" ;;
     *) echo "✗ unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
+[ -n "$ROLE" ] || { echo "✗ --role= given with no value" >&2; exit 2; }
 
 # Provider → module name in cluster/main.tf (junction modules, count-gated).
 case "$PROVIDER" in
@@ -88,7 +98,7 @@ if [[ "$PROVIDER" == "proxmox" ]]; then
 fi
 
 # --- config ------------------------------------------------------------------
-TFVARS="envs/management-${PROVIDER}.tfvars"
+TFVARS="envs/${ROLE}-${PROVIDER}.tfvars"
 TALOSCONFIG_FILE="${TALOSCONFIG:-./talosconfig}"
 KUBECONFIG_FILE="${KUBECONFIG:-./kubeconfig}"
 # 300s was not enough for a database switchover, and the run continued anyway.


### PR DESCRIPTION
`task cluster-up` declared a version it never landed. Bump `talos_version`, run
it, and the machine config carried the new installer image while every node kept
running the old one — and nothing caught it, because `cluster-verify` compared the
running **schematic**, which a version bump does not change. Empty plan, 11/11
green, fleet a version behind.

Four stages, and a defect that only a real cluster could find.

**1 — `cluster-verify` compares running versions to the pin.** Four verdicts, not
three: a comma in the fleet's answer is a MIXED fleet, which is its own case. Seen
red on a live cluster where `main`, minutes apart, called the same drift 11/11
green.

**2 — `cluster-roll` rolls the role it was given.** `ROLE` was declared and never
used: `cluster-upgrade ROLE=workload` applied the workload tfvars and then rolled
against the management state.

**3 — the climb walks one minor at a time.** `version-support.json` is the single
source of truth, read by both `versions-guard.tf` and `cluster-upgrade.sh`. The
window is consulted only when a minor moves, so a fictional test fixture is not
refused for having no minor semantics. Measured end to end on Scaleway:
`(1.12.7, 1.30.0) → (1.13.9, 1.36.3)`, seven steps, Kubernetes to 1.31 **before**
Talos moves — because Talos 1.13's floor is 1.31 and moving Talos first leaves the
window.

**4 — `cluster-up` converges.** Not by calling `cluster-upgrade.sh`, which fails by
design when the fleet already matches — exactly the state `cluster-up` leaves
behind. `scripts/internal/converge-versions.sh` runs twice: `--check` before the
approval, because `ignore_changes` on the node image keeps a roll out of the
OpenTofu plan entirely and the operator must not approve a bring-up and get a
fleet-wide roll they could not have read; then for real after `bootstrap-phase2`
and `task kubeconfig`, which had to be added because nothing wrote the file
`rolling-replace` requires. It re-reads the fleet afterwards, because the roll
reporting success is the client talking.

## The defect the cloud found

The seven-step climb ran two steps, ended normally, exited 0, and printed
`upgraded v1.12.7→v1.13.9 / v1.30.0→v1.36.3` while the fleet sat on Kubernetes
v1.31.0. `cluster-verify` returned 13/13 — truthfully, because the climb rewrites
the tfvars per step, so the cluster genuinely matched what the config now asked
for. Every signal agreed and five upgrades had not happened.

`walk_path` read its step list on stdin; `task cluster-roll` reaches ssh and
talosctl, and both read stdin. Step 1 moves Kubernetes only and touched nothing.
Step 2 rolls Talos and ate steps 3 through 7. Fixed by draining stdin into an
array before the first step. The harness could not have caught it — its stubs
never read stdin. The new assertion stubs one that does and reproduces 2/7
offline, the same two the cloud produced.

## Rungs reached

- **Mocked** — 385 assertions, 0 failed.
- **Mutation** — every guard added here was killed on purpose first. Two of the new
  assertions were hollow and only mutation showed it: deleting the post-roll
  Kubernetes check survived because the scenario lagged on both axes and the Talos
  check hid it, and `rolled -- --cp-only` passed `--` as `$1` so both roll
  assertions matched any roll at all.
- **Feint** — the real cluster root plans against the emulator, the pair guard seen
  **red** (exit 201) on an out-of-window pair, apply/empty-replan/destroy green,
  unserved-operation ranking empty.
- **Real cloud (Scaleway)** — the full climb, 6 nodes, longest apiserver outage
  **5s**; and `cluster-up` on a matching fleet rolling **nothing**, three
  `No changes.`, `0 added, 0 changed, 0 destroyed`.

## Not reached, and stated as such

The **drift** case of stage 4 has offline proof only. No Talos patch exists beyond
v1.13.9, so drift cannot be created forward on this cluster; proving it in the
cloud means rebuilding at an older pair first.

The `version_path_guard` the plan called for was never written, and that is
recorded rather than quietly dropped: walking one apply per step makes it
redundant *for callers who use the script*, but someone editing the tfvars from
(1.12.7, 1.30.0) to (1.13.9, 1.36.3) and applying gets a supported destination
pair and a six-minor Kubernetes skip in the same breath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsDcgCBBUiA4QbKKFkwSbM