### PR TITLE
feat(access): admin_ip cannot open the cluster any more, and credentials can expire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,13 @@ go.work.sum
 # Talos & Kubernetes Credentials
 kubeconfig*
 talosconfig*
+# ⚠️ Those two globs have no slash, so they match at ANY depth — including a
+# SCRIPT whose name starts with them. `scripts/ops/talosconfig-new.sh` was
+# silently ignored on 2026-08-24, which would have pushed a Taskfile calling a
+# file that is not in the repository. Keep the globs broad (they guard a public
+# repo against a real credential) and exempt the code by name.
+!scripts/**/talosconfig*.sh
+!scripts/**/kubeconfig*.sh
 controlplane.yaml
 worker.yaml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,39 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ---
 
+## [Unreleased]
+
+### Security
+
+- **`admin_ip` refuses to open the cluster to the internet.** The variable had
+  no `validation`, so `["0.0.0.0/0"]` was accepted in silence — and it feeds
+  bastion sshd *and* the 6443 LB ACL on all four providers at once. Behind that
+  ACL sits a `system:masters` kubeconfig Kubernetes cannot revoke. Three rules
+  now reject an empty list, an entry without a prefix (including the `YOUR_IP/32`
+  of a copied example) and any `/0` — read from the prefix, so `198.51.100.7/0`
+  is caught too. Nine cases in
+  `cluster/tests/admin-ip-validation.tftest.hcl`; each rule was deleted in turn
+  and the suite watched to go red before it was kept.
+- **Admin access is documented as unrevocable where it is unrevocable.**
+  [`docs/admin-access.md`](docs/admin-access.md) now says what a leaked
+  kubeconfig costs, instead of leaving the reader to find out.
+
+### Added
+
+- **`task talosconfig-new`** — issues a role-scoped talosconfig with a TTL
+  (`os:reader`, 8 h by default) from the admin one, which the deploy hands out
+  as `os:admin` valid a **year**, identical for every task and every person.
+  It refuses to report success if the node grants roles other than those asked.
+  ⚠️ Proven on the Docker lane only; the cloud path needs open tunnels and has
+  never been run.
+- **`task local-rbac`** — asks the Docker cluster whether Talos *enforces* those
+  roles, which nothing here had ever established. Seven assertions, and each
+  denial carries its admin control beside it so a broken command cannot read as
+  a refused one. Measured 2026-08-24 on Talos v1.13.3: the node reports
+  `Enabled: RBAC` with no `machine.features.rbac` anywhere in this repository,
+  an `os:reader` config is refused a host read the admin config gets, and it
+  cannot mint itself an `os:admin` one.
+
 ## [0.1.0] — 2026-08-20
 
 > **This tag does not point at the commit first cut as 0.1.0.** That one,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ in git. 0.1.0 is the first entry describing something proven.
   [`docs/admin-access.md`](docs/admin-access.md) now says what a leaked
   kubeconfig costs, instead of leaving the reader to find out.
 
+### Fixed
+
+- **`task security` could not be completed on a machine set up by
+  `scripts/setup.sh`.** `install_checkov` tried pipx, then `python3 -m pip`,
+  then apt — and Ubuntu 24.04 ships python3 with neither pip nor pipx, so the
+  only branch left wanted sudo. A venv needs neither and carries its own pip;
+  it now sits between them, and `install_yamllint` finally gets the
+  "`pip3` is not always a binary" lesson its neighbour documented and never
+  received.
+
 ### Added
 
 - **`task talosconfig-new`** — issues a role-scoped talosconfig with a TTL

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -961,6 +961,26 @@ tasks:
     cmds:
       - ./scripts/bootstrap/talos-tunnels.sh close infrastructure/opentofu/cluster
 
+  talosconfig-new:
+    desc: >-
+      Issue a short-lived, role-scoped talosconfig from the admin one — the deploy hands out
+      os:admin valid a YEAR, and read-only work does not need it.
+      Usage: task talosconfig-new PROVIDER=scaleway [ROLES=os:reader] [TTL=8h]
+    # PROVIDER is REQUIRED, not defaulted — see cluster-upgrade above for why.
+    requires:
+      vars: [PROVIDER]
+    # The Docker lane has its own name for this, and it is `task local-rbac`,
+    # which mints one as part of proving the roles are enforced.
+    preconditions: *refuse-local
+    vars:
+      ROLES: '{{.ROLES | default "os:reader"}}'
+      TTL: '{{.TTL | default "8h"}}'
+    # ⚠️ Proven on the Docker lane only (task local-rbac). On a cloud lane the
+    # Talos API is reached through the bastion, so the tunnels must be open —
+    # `task tunnels-up PROVIDER=…` first. That path has never been run.
+    cmds:
+      - ./scripts/ops/talosconfig-new.sh {{.PROVIDER}} --roles {{.ROLES}} --ttl {{.TTL}}
+
   backup-state:
     desc: >-
       Replicate the (encrypted) tfstate to the -backup store (post-apply). Set BACKUP_AWS_* for a cross-provider
@@ -1356,10 +1376,25 @@ tasks:
     cmds:
       - ./scripts/dev/infra-verify.sh local
 
+  local-rbac:
+    desc: >-
+      Ask the local Docker cluster whether Talos ENFORCES the roles in a talosconfig: an os:reader
+      config is refused a host read that the admin config gets, and cannot mint itself an os:admin.
+      Usage: task local-rbac
+    # Rung zero for the whole scoped-credential idea. Until 2026-08-24 nobody
+    # knew whether roles were enforced at all, and the answer was priced at a
+    # real cloud run; it costs a container.
+    cmds:
+      - ./scripts/dev/test-talos-rbac.sh local
+
   local-test:
     desc: "Full end-to-end local test: 3 CP + 3 workers + etcd quorum + Cilium + Flux + GitOps"
     cmds:
       - ./scripts/dev/test-talos-local.sh
+      # The cluster is up and credentialed at this point, so the role assertions
+      # cost seconds here. A harness nobody invokes is this repository's most
+      # repeated defect.
+      - ./scripts/dev/test-talos-rbac.sh local
 
   local-status:
     desc: "Check local cluster health (3 CP + 3 workers)"

--- a/docs/admin-access.fr.md
+++ b/docs/admin-access.fr.md
@@ -124,7 +124,19 @@ sceller, rekey et rotation — ces gestes restent au root token hors ligne,
 délibérés et rares.
 
 ⚠️ Si ton IP publique change : mettre à jour `admin_ip` puis `task infra-apply`, sinon
-le bastion devient injoignable.
+le bastion devient injoignable. `admin_ip` refuse désormais une liste vide, une
+adresse sans préfixe et un `/0` — c'est la liste d'autorisation devant sshd du
+bastion ET devant 6443.
+
+⚠️ **Le kubeconfig n'est pas révocable.** `talosctl kubeconfig` émet un
+certificat client pour `O=system:masters`, qui court-circuite RBAC, et
+Kubernetes ne sait pas révoquer un certificat client : un kubeconfig qui fuite
+reste valable jusqu'à son expiration, et le seul remède est de faire tourner la
+CA du cluster. Traiter ce fichier comme le secret qu'il est — il est aussi dans
+le tfstate et dans les deux stores d'artefacts. Pour le travail en lecture
+seule, porter moins : `task talosconfig-new PROVIDER=…` émet un talosconfig
+`os:reader` qui expire en heures et ne peut pas s'en forger un d'admin (prouvé
+par `task local-rbac`).
 
 ## 7. SSO Grafana via Zitadel (OIDC)
 

--- a/docs/admin-access.md
+++ b/docs/admin-access.md
@@ -130,7 +130,17 @@ bao token create -policy=openaether-reader -ttl=8h -display-name=<name>
 key rotation — those stay with the offline root token, deliberate and rare.
 
 ⚠️ If your public IP changes: update `admin_ip` then `task infra-apply`, or the bastion
-becomes unreachable.
+becomes unreachable. `admin_ip` refuses an empty list, a bare address and a `/0`
+since it validates — it is the allowlist in front of both bastion sshd and 6443.
+
+⚠️ **The kubeconfig cannot be revoked.** `talosctl kubeconfig` issues a client
+certificate for `O=system:masters`, which bypasses RBAC, and Kubernetes has no
+revocation for client certificates: a leaked kubeconfig is valid until it
+expires, and the only remedy is rotating the cluster CA. Treat the file as the
+secret it is — it is also in the tfstate and in both artifact stores. For
+read-only work, carry less: `task talosconfig-new PROVIDER=… ` issues an
+`os:reader` talosconfig that expires in hours and cannot mint an admin one
+(proven by `task local-rbac`).
 
 ## 7. Grafana SSO through Zitadel (OIDC)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -13,7 +13,7 @@ decided.
 
 **Taking one.** Every entry names the rung it needs, at the end: `task test` and
 `mocked` close on a laptop, `emulated` needs Feint and still no cloud account,
-`real cloud` spends money on somebody's project. Grep for `Rung:` — today 8 of the
+`real cloud` spends money on somebody's project. Grep for `Rung:` — today 9 of the
 open entries are closable with no cloud account, and 19 name no rung at all, which
 is a defect in this file rather than in them, a `Decide:` aside.
 
@@ -126,17 +126,23 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
       Rung: mocked, then one real deploy to confirm health checks still pass.
 
 - [ ] **No credential in the admin path has ever been issued for less than a
-      year, or to a person.** One `os:admin` talosconfig (`modules/talos/main.tf:93`,
-      `crt_ttl` never set, so the provider default applies) and one `system:masters`
-      kubeconfig serve every operator and every task; both live in the tfstate,
-      in two gpg'd S3 stores and in clear on the operator's disk. Revoking either
-      means rotating a CA — and `talos_machine_secrets` carries `prevent_destroy`.
-      `machine.features.rbac` appears nowhere in this repository, so whether Talos
-      even enforces the roles is unknown.
-      **Closes:** `talosctl --talosconfig <reader> read /etc/hosts` DENIED on a live
-      cluster, the reader config issued by a `task talosconfig-new` wrapping
-      `talosctl config new --roles os:reader --crt-ttl 8h`. Rung: real cloud, one
-      command, no spend.
+      year, or to a person.** The talosconfig this repository hands out reports
+      `Roles: os:admin` and `Certificate expires: 1 year from now` — `crt_ttl` is
+      never set (`modules/talos/main.tf:93`), so the provider default stands. That
+      one config, plus a `system:masters` kubeconfig, serves every operator and
+      every task; both live in the tfstate, in two gpg'd S3 stores and in clear on
+      the operator's disk. Revoking either means rotating a CA, and
+      `talos_machine_secrets` carries `prevent_destroy`.
+      **The excuse is gone**: Talos enforces its roles with nothing added. Measured
+      on the Docker lane (v1.13.3) on 2026-08-24 — the node answers `Enabled: RBAC`,
+      and against an `os:reader` config minted at `--crt-ttl 8h`, `read /etc/hosts`
+      and `config new --roles os:admin` both return `PermissionDenied` with rc=1
+      while the admin config returns rc=0. `machine.features.rbac` appears nowhere
+      here and did not need to.
+      **Closes:** `task talosconfig-new` wrapping `talosctl config new --roles
+      os:reader --crt-ttl 8h`, the reader config used by the read-only tasks, and
+      the two denials above asserted in a harness. Rung: mocked — `task local-up`
+      proves it, no cloud account.
 
 - [ ] **The SSH-CA hooks have shipped inert since they were written.**
       `_shared/bastion-cloud-init.yaml.tftpl:86` sets `TrustedUserCAKeys` and

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -13,9 +13,9 @@ decided.
 
 **Taking one.** Every entry names the rung it needs, at the end: `task test` and
 `mocked` close on a laptop, `emulated` needs Feint and still no cloud account,
-`real cloud` spends money on somebody's project. Grep for `Rung:` — today 6 of the
-open entries are closable with no cloud account, and 23 name no rung at all, which
-is a defect in this file rather than in them.
+`real cloud` spends money on somebody's project. Grep for `Rung:` — today 8 of the
+open entries are closable with no cloud account, and 19 name no rung at all, which
+is a defect in this file rather than in them, a `Decide:` aside.
 
 ⚠️ This file twice drifted into a lab notebook — 215 lines on 2026-07-29, then
 1449 on 2026-08-19, entries of 30 lines re-telling incidents that were already
@@ -99,6 +99,68 @@ attempted.
 applies, then decide whether 0.1.0 ships a staging lane at all.
 
 ## Open — infrastructure
+
+- [ ] **A typo in `admin_ip` publishes cluster-admin to the internet.**
+      `cluster/variables.tf:274` declares it with no `validation` block, so
+      `["0.0.0.0/0"]` is accepted in silence and opens bastion sshd *and* the 6443
+      LB ACL on every provider at once. What sits behind that ACL is the
+      `talosctl kubeconfig` certificate — `O=system:masters`, which bypasses RBAC,
+      and Kubernetes has no revocation for client certificates, so a leak is
+      survivable only by rotating the cluster CA. Nothing catches it: no test and
+      no script in this repository reads an ACL, an `allowed_cidrs` or a
+      security-group rule.
+      **Closes:** three validations (non-empty, refuse `0.0.0.0/0` and `::/0`,
+      valid CIDR) and `cluster/tests/admin-ip-validation.tftest.hcl` using
+      `expect_failures = [var.admin_ip]`, `task test` green. Rung: mocked.
+
+- [ ] **The Scaleway node perimeter is not the one the comment describes.**
+      `scw/security.tf:45` says "Talos API — From Bastion ONLY" and allows 50000
+      from the bastion's **public** IP, which the bastion never uses: it reaches
+      the nodes over its private NIC. The rule is dead. What actually admits that
+      traffic is `:53-72` — `port = 0`, `protocol = "ANY"`, for `172.16.0.0/12`,
+      `10.0.0.0/8` and `100.64.0.0/10`, the last being Scaleway's shared carrier
+      range. So the documented posture and the enforced one differ, and nothing
+      at any rung would notice.
+      **Closes:** the dead rule deleted, the mesh rule scoped to this module's own
+      subnet, and a mocked assertion that no inbound rule carries `port == 0`.
+      Rung: mocked, then one real deploy to confirm health checks still pass.
+
+- [ ] **No credential in the admin path has ever been issued for less than a
+      year, or to a person.** One `os:admin` talosconfig (`modules/talos/main.tf:93`,
+      `crt_ttl` never set, so the provider default applies) and one `system:masters`
+      kubeconfig serve every operator and every task; both live in the tfstate,
+      in two gpg'd S3 stores and in clear on the operator's disk. Revoking either
+      means rotating a CA — and `talos_machine_secrets` carries `prevent_destroy`.
+      `machine.features.rbac` appears nowhere in this repository, so whether Talos
+      even enforces the roles is unknown.
+      **Closes:** `talosctl --talosconfig <reader> read /etc/hosts` DENIED on a live
+      cluster, the reader config issued by a `task talosconfig-new` wrapping
+      `talosctl config new --roles os:reader --crt-ttl 8h`. Rung: real cloud, one
+      command, no spend.
+
+- [ ] **The SSH-CA hooks have shipped inert since they were written.**
+      `_shared/bastion-cloud-init.yaml.tftpl:86` sets `TrustedUserCAKeys` and
+      `AuthorizedPrincipalsFile` to an empty file and an empty directory;
+      `bastion-harden-check.sh:140` already asserts they are there. Every bastion
+      therefore still authenticates a static key that only a `tofu apply` can
+      revoke, on a design that was finished except for the CA. Two template
+      variables close it, `""` keeping today's behaviour byte for byte.
+      ⚠️ A certificate with no `permit-port-forwarding` extension authenticates
+      and then refuses every `-L`: `talos-tunnels.sh` would report 0/6 against a
+      healthy bastion, which is exactly the 2026-08-18 failure.
+      **Closes:** on Feint, a signed certificate authenticates, the same key
+      without its certificate is REFUSED, and `ssh -o ExitOnForwardFailure=yes -L`
+      succeeds. Rung: emulated.
+
+- [ ] **Decide:** does OpenAether run an always-on host outside every cluster?
+      Every ambitious answer to admin access collapses into this one question — an
+      OIDC issuer for the apiserver, an SSH CA service, and a WireGuard control
+      plane all need it, and none of them may live in the cluster it guards. The
+      answer settles whether the four `bastion.tf` and `admin_ip` ever leave the
+      provider contract (the largest agnosticism win available, ~350 lines) or
+      whether the bastion stays and is hardened in place. Inputs: how many
+      operators there are, and whether this project will run a stateful service
+      with a restore that has been tested. **Not a task until it is answered.**
 
 - [ ] **Nobody has measured whether a service keeps answering during an upgrade.**
       The probe that produced the 5/7/8-second figures asks

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -13,7 +13,7 @@ decided.
 
 **Taking one.** Every entry names the rung it needs, at the end: `task test` and
 `mocked` close on a laptop, `emulated` needs Feint and still no cloud account,
-`real cloud` spends money on somebody's project. Grep for `Rung:` — today 9 of the
+`real cloud` spends money on somebody's project. Grep for `Rung:` — today 7 of the
 open entries are closable with no cloud account, and 19 name no rung at all, which
 is a defect in this file rather than in them, a `Decide:` aside.
 
@@ -100,19 +100,6 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
 
 ## Open — infrastructure
 
-- [ ] **A typo in `admin_ip` publishes cluster-admin to the internet.**
-      `cluster/variables.tf:274` declares it with no `validation` block, so
-      `["0.0.0.0/0"]` is accepted in silence and opens bastion sshd *and* the 6443
-      LB ACL on every provider at once. What sits behind that ACL is the
-      `talosctl kubeconfig` certificate — `O=system:masters`, which bypasses RBAC,
-      and Kubernetes has no revocation for client certificates, so a leak is
-      survivable only by rotating the cluster CA. Nothing catches it: no test and
-      no script in this repository reads an ACL, an `allowed_cidrs` or a
-      security-group rule.
-      **Closes:** three validations (non-empty, refuse `0.0.0.0/0` and `::/0`,
-      valid CIDR) and `cluster/tests/admin-ip-validation.tftest.hcl` using
-      `expect_failures = [var.admin_ip]`, `task test` green. Rung: mocked.
-
 - [ ] **The Scaleway node perimeter is not the one the comment describes.**
       `scw/security.tf:45` says "Talos API — From Bastion ONLY" and allows 50000
       from the bastion's **public** IP, which the bastion never uses: it reaches
@@ -125,24 +112,20 @@ applies, then decide whether 0.1.0 ships a staging lane at all.
       subnet, and a mocked assertion that no inbound rule carries `port == 0`.
       Rung: mocked, then one real deploy to confirm health checks still pass.
 
-- [ ] **No credential in the admin path has ever been issued for less than a
-      year, or to a person.** The talosconfig this repository hands out reports
-      `Roles: os:admin` and `Certificate expires: 1 year from now` — `crt_ttl` is
-      never set (`modules/talos/main.tf:93`), so the provider default stands. That
-      one config, plus a `system:masters` kubeconfig, serves every operator and
-      every task; both live in the tfstate, in two gpg'd S3 stores and in clear on
-      the operator's disk. Revoking either means rotating a CA, and
-      `talos_machine_secrets` carries `prevent_destroy`.
-      **The excuse is gone**: Talos enforces its roles with nothing added. Measured
-      on the Docker lane (v1.13.3) on 2026-08-24 — the node answers `Enabled: RBAC`,
-      and against an `os:reader` config minted at `--crt-ttl 8h`, `read /etc/hosts`
-      and `config new --roles os:admin` both return `PermissionDenied` with rc=1
-      while the admin config returns rc=0. `machine.features.rbac` appears nowhere
-      here and did not need to.
-      **Closes:** `task talosconfig-new` wrapping `talosctl config new --roles
-      os:reader --crt-ttl 8h`, the reader config used by the read-only tasks, and
-      the two denials above asserted in a harness. Rung: mocked — `task local-up`
-      proves it, no cloud account.
+- [ ] **The tooling to carry less exists, and nothing carries less.**
+      `task talosconfig-new` issues an `os:reader` config that expires in hours,
+      and `task local-rbac` proves the roles are enforced — but every read-only
+      task still runs on the `os:admin` config the deploy wrote, valid a year,
+      the same file for every operation and every person. The cloud path of
+      `talosconfig-new` has also never been run: it needs the bastion tunnels
+      open, and only the Docker lane has exercised it.
+      Wiring it is not free — `cluster-verify` and friends are proven on three
+      clouds, an 8 h credential has to be re-minted, and a task that mints one
+      per run turns a read into a write against the Talos API.
+      **Decide first:** re-mint per run, or cache one until it expires?
+      **Then closes:** `task cluster-verify PROVIDER=… ` green while its
+      `TALOSCONFIG` carries `os:reader`, and `task talosconfig-new` run once
+      through the tunnels. Rung: real cloud.
 
 - [ ] **The SSH-CA hooks have shipped inert since they were written.**
       `_shared/bastion-cloud-init.yaml.tftpl:86` sets `TrustedUserCAKeys` and

--- a/infrastructure/opentofu/cluster/tests/admin-ip-validation.tftest.hcl
+++ b/infrastructure/opentofu/cluster/tests/admin-ip-validation.tftest.hcl
@@ -1,0 +1,127 @@
+# admin_ip is the allowlist in front of bastion sshd AND the 6443 ACL. Until
+# this suite existed, nothing in the repository read a CIDR or an ACL, so
+# `["0.0.0.0/0"]` was accepted in silence and opened both on every provider at
+# once — in front of a `system:masters` kubeconfig Kubernetes cannot revoke.
+#
+# Every run plans with `node_distribution = {}`: no provider module activates,
+# so the suite needs none of the ~15 override_resource blocks scaleway.tftest.hcl
+# carries, and stays about the variable rather than about Scaleway. The mocks
+# are still declared because the root references those providers — `local`
+# included, since local_file writes kubeconfig/talosconfig into the module
+# directory and an unmocked run would overwrite a live cluster's credentials,
+# then delete them on teardown.
+#
+# A valid CIDR reaching the PROVIDERS is proven elsewhere and deliberately not
+# recopied: scaleway.tftest.hcl and k8s-lb-mode.tftest.hcl both plan the full
+# root with a routine admin_ip, so a rule that is too strict turns them red.
+
+mock_provider "scaleway" {}
+mock_provider "openstack" {}
+mock_provider "outscale" {}
+mock_provider "proxmox" {}
+mock_provider "talos" {}
+mock_provider "local" {}
+
+variables {
+  cluster_name        = "test-cluster"
+  environment         = "dev"
+  cluster_role        = "management"
+  talos_bootstrap     = false
+  backup_enabled      = false
+  node_distribution   = {}
+  admin_ip            = ["203.0.113.4/32"] # RFC 5737 TEST-NET-3
+  git_repo_url        = "https://github.com/test/repo.git"
+  cilium_manifest     = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cilium"
+  s3_primary_endpoint = "https://s3.fr-par.scw.cloud"
+  s3_primary_region   = "fr-par"
+  s3_replica_endpoint = "https://s3.fr-par.scw.cloud"
+  s3_replica_region   = "fr-par"
+}
+
+# --- Accepted. Without these the suite could go green by refusing everything,
+# which is the shape of defect this repository keeps finding. ---
+
+run "a_routine_cidr_is_accepted" {
+  command = plan
+
+  assert {
+    condition     = length(var.admin_ip) == 1
+    error_message = "A single /32 is the ordinary case and must survive validation."
+  }
+}
+
+run "several_cidrs_are_accepted" {
+  command = plan
+  variables {
+    admin_ip = ["203.0.113.4/32", "198.51.100.0/24", "10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = length(var.admin_ip) == 3
+    error_message = "A second operator, an office range and a private on-premise range are all legitimate."
+  }
+}
+
+# --- Refused. ---
+
+run "the_whole_internet_is_refused" {
+  command = plan
+  variables {
+    admin_ip = ["0.0.0.0/0"]
+  }
+  expect_failures = [var.admin_ip]
+}
+
+run "the_whole_internet_is_refused_in_ipv6" {
+  command = plan
+  variables {
+    admin_ip = ["::/0"]
+  }
+  expect_failures = [var.admin_ip]
+}
+
+# A /0 behind a routable-looking address: matching the string "0.0.0.0/0" would
+# let this through, which is why the rule reads the prefix instead.
+run "a_zero_prefix_on_a_real_address_is_refused" {
+  command = plan
+  variables {
+    admin_ip = ["198.51.100.7/0"]
+  }
+  expect_failures = [var.admin_ip]
+}
+
+# One good entry does not license a bad one — the security groups iterate the
+# whole list, so a single /0 anywhere in it opens the door.
+run "one_bad_entry_among_good_ones_is_refused" {
+  command = plan
+  variables {
+    admin_ip = ["203.0.113.4/32", "0.0.0.0/0"]
+  }
+  expect_failures = [var.admin_ip]
+}
+
+run "an_empty_list_is_refused" {
+  command = plan
+  variables {
+    admin_ip = []
+  }
+  expect_failures = [var.admin_ip]
+}
+
+run "a_bare_address_without_a_prefix_is_refused" {
+  command = plan
+  variables {
+    admin_ip = ["203.0.113.4"]
+  }
+  expect_failures = [var.admin_ip]
+}
+
+# The placeholder every *.tfvars.example ships. A copied-but-unedited env file
+# must fail here, by name, rather than at the provider API.
+run "the_unedited_example_placeholder_is_refused" {
+  command = plan
+  variables {
+    admin_ip = ["YOUR_IP/32"]
+  }
+  expect_failures = [var.admin_ip]
+}

--- a/infrastructure/opentofu/cluster/variables.tf
+++ b/infrastructure/opentofu/cluster/variables.tf
@@ -274,6 +274,30 @@ variable "worker_storage" {
 variable "admin_ip" {
   description = "Allowed source IPs/CIDRs for admin access (SSH, K8s API LB ACL)"
   type        = list(string)
+
+  # This list is the ONLY thing between the internet and two doors: bastion
+  # sshd, and the 6443 ACL in front of a `system:masters` kubeconfig that
+  # Kubernetes cannot revoke. It reaches all four providers from here
+  # (main.tf), so one block covers what four modules would repeat.
+
+  validation {
+    condition     = length(var.admin_ip) > 0
+    error_message = "admin_ip must not be empty: with no allowed source the bastion is unreachable and the deploy is wasted."
+  }
+
+  validation {
+    # Rejects a bare address, and the `YOUR_IP/32` left in a copied example.
+    condition     = alltrue([for c in var.admin_ip : can(cidrhost(c, 0))])
+    error_message = "Every admin_ip entry must be a CIDR with its prefix, e.g. 203.0.113.4/32 — not a bare address."
+  }
+
+  validation {
+    # Prefix, not string match: catches 0.0.0.0/0, ::/0 and 198.51.100.7/0
+    # alike. Guarded by can(), so a malformed entry fails the rule above
+    # rather than blowing up on split()[1] here.
+    condition     = alltrue([for c in var.admin_ip : can(cidrhost(c, 0)) ? tonumber(split("/", c)[1]) > 0 : true])
+    error_message = "admin_ip must not contain a /0: that opens bastion SSH and the Kubernetes API ACL to the whole internet."
+  }
 }
 
 variable "bastion_ssh_keys" {

--- a/scripts/dev/test-talos-local.sh
+++ b/scripts/dev/test-talos-local.sh
@@ -74,7 +74,10 @@ if [[ "${1:-}" == "--destroy" ]]; then
     docker volume rm "$vol" 2>/dev/null || true
   done
   docker network rm "${CLUSTER_NAME}-net" 2>/dev/null || true
-  rm -f "${TOFU_DIR}/kubeconfig" "${TOFU_DIR}/talosconfig"
+  # The glob matters: `talosconfig-new.sh` writes role-scoped siblings
+  # (talosconfig.reader), and naming only the two files left one behind — a
+  # live credential on disk under a teardown that reported clean.
+  rm -f "${TOFU_DIR}/kubeconfig" "${TOFU_DIR}"/talosconfig*
   # Wipe the ephemeral local state too: `tofu destroy` leaves it populated
   # (machine_secrets is prevent_destroy'd), and a stale state breaks the next
   # fresh apply (CA mismatch / skipped bootstrap). No backend, so this is safe.
@@ -86,18 +89,28 @@ if [[ "${1:-}" == "--destroy" ]]; then
   # emptied, so "0 resources in the state" afterwards proves only that the file
   # is gone. Until this check, `✓ Local cluster destroyed` printed whatever
   # happened; a sweep that removed nothing looked exactly like a clean teardown.
+  # Credentials count as "left behind" too. The sweep above is `rm -f`, which
+  # cannot fail and so cannot report — and the whole point of this block is
+  # that best-effort cleanup must still be ASKED whether it worked.
+  cred=0
+  for f in "${TOFU_DIR}/kubeconfig" "${TOFU_DIR}"/talosconfig*; do
+    [ -e "$f" ] && cred=$((cred + 1))
+  done
   left=""
   for kind in "container:$(docker ps -aq --filter "name=${CLUSTER_NAME}-" 2>/dev/null | wc -l)" \
     "volume:$(docker volume ls -q --filter "name=${CLUSTER_NAME}-" 2>/dev/null | wc -l)" \
-    "network:$(docker network ls -q --filter "name=${CLUSTER_NAME}-net" 2>/dev/null | wc -l)"; do
+    "network:$(docker network ls -q --filter "name=${CLUSTER_NAME}-net" 2>/dev/null | wc -l)" \
+    "credential:${cred}"; do
     [ "${kind##*:}" -gt 0 ] && left="${left}${kind%%:*}=${kind##*:} "
   done
   if [ -n "$left" ]; then
-    echo "✗ still present after the teardown: ${left}— remove them by hand, or the next" >&2
-    echo "  deploy inherits half a cluster (a stale container answers, and the bootstrap skips)." >&2
+    echo "✗ still present after the teardown: ${left}— remove them by hand." >&2
+    echo "  A docker leftover means the next deploy inherits half a cluster (a stale" >&2
+    echo "  container answers and the bootstrap skips); a credential leftover means a" >&2
+    echo "  key to a cluster that no longer exists is sitting on this disk." >&2
     exit 1
   fi
-  success "Local cluster destroyed — docker reports no container, volume or network left"
+  success "Local cluster destroyed — no container, volume or network in docker, no credential on disk"
   exit 0
 fi
 

--- a/scripts/dev/test-talos-rbac.sh
+++ b/scripts/dev/test-talos-rbac.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Does Talos actually ENFORCE the roles in a talosconfig?
+#
+# The answer decides whether scoping the day-to-day credential is worth
+# anything, and it was unknown here until 2026-08-24: `machine.features.rbac`
+# appears nowhere in this repository, and the assumption was that it would have
+# to be added. It does not — RBAC is on without it.
+#
+# The control matters as much as the denials: the SAME command with the admin
+# config must succeed. Without it a broken command reads as a refused one, and
+# the harness would pass on a cluster where nothing is enforced at all.
+#
+# Runs against the Docker lane, which needs no cloud account: task local-up
+# Usage: test-talos-rbac.sh [provider|local]
+set -uo pipefail
+
+LANE="${1:-local}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+[ "$LANE" = local ] && CLUSTER_DIR="$ROOT/infrastructure/opentofu-local" \
+                    || CLUSTER_DIR="$ROOT/infrastructure/opentofu/cluster"
+ADMIN="${TALOSCONFIG:-$CLUSTER_DIR/talosconfig}"
+READER="$(mktemp -u)/reader.talosconfig"
+mkdir -p "$(dirname "$READER")"
+trap 'rm -rf "$(dirname "$READER")"' EXIT
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+# No cluster is not a failure, it is a missing prerequisite — and saying so is
+# the point. Its sibling test-talos-local.sh hangs here instead (backlog).
+if [ ! -s "$ADMIN" ] || ! TALOSCONFIG="$ADMIN" talosctl config info >/dev/null 2>&1; then
+  echo "✗ no cluster to ask: $ADMIN is empty or has no context." >&2
+  [ "$LANE" = local ] && echo "  task local-up" >&2 || echo "  task cluster-up PROVIDER=$LANE" >&2
+  exit 1
+fi
+
+NODE="$(tofu -chdir="$CLUSTER_DIR" output -json control_plane_ips 2>/dev/null |
+        sed -nE 's/^\["([^"]+)".*/\1/p')"
+if [ -z "$NODE" ]; then
+  echo "✗ could not read a control-plane IP from $CLUSTER_DIR" >&2
+  exit 1
+fi
+
+echo "--- what the cluster grants, asked of the cluster ---"
+
+TALOSCONFIG="$ADMIN" talosctl -n "$NODE" version 2>/dev/null | grep -q 'Enabled:.*RBAC' \
+  && ok "the node reports RBAC enabled — with no machine.features.rbac in this repo" \
+  || bad "the node does not report RBAC: a scoped talosconfig would be decoration"
+
+ADMIN_ROLES="$(TALOSCONFIG="$ADMIN" talosctl config info 2>/dev/null | sed -nE 's/^Roles:[[:space:]]+//p')"
+[ "$ADMIN_ROLES" = "os:admin" ] \
+  && ok "the config this repository issues is os:admin (the starting point, not the target)" \
+  || bad "expected os:admin from the deploy, got '${ADMIN_ROLES:-nothing}'"
+
+"$ROOT/scripts/ops/talosconfig-new.sh" "$LANE" --roles os:reader --ttl 8h --out "$READER" --node "$NODE" >/dev/null 2>&1
+READER_ROLES="$(TALOSCONFIG="$READER" talosctl config info 2>/dev/null | sed -nE 's/^Roles:[[:space:]]+//p')"
+[ "$READER_ROLES" = "os:reader" ] \
+  && ok "talosconfig-new.sh issued an os:reader config" \
+  || { bad "talosconfig-new.sh did not produce an os:reader config (got '${READER_ROLES:-nothing}')"; \
+       printf '\n\033[31m✗ %s passed, %s FAILED\033[0m\n' "$PASS" "$((FAIL + 1))" >&2; exit 1; }
+
+TALOSCONFIG="$READER" talosctl config info 2>/dev/null | grep -qE 'Certificate expires:[[:space:]]+[0-9]+ hours? from now' \
+  && ok "and it expires in hours, not the admin config's year" \
+  || bad "the reader config does not expire within hours — the TTL did not take"
+
+echo "--- the denials, each with the admin control beside it ---"
+
+TALOSCONFIG="$READER" talosctl -n "$NODE" read /etc/hosts >/dev/null 2>&1
+[ $? -ne 0 ] \
+  && ok "os:reader is REFUSED reading a host file (rc≠0)" \
+  || bad "os:reader read a host file: the role is not enforced"
+
+TALOSCONFIG="$ADMIN" talosctl -n "$NODE" read /etc/hosts >/dev/null 2>&1
+[ $? -eq 0 ] \
+  && ok "…and os:admin reads the same file (rc=0) — so the refusal is the ROLE, not the command" \
+  || bad "os:admin cannot read it either: this harness proves nothing about roles"
+
+ESC="$(dirname "$READER")/escalated.talosconfig"
+rm -f "$ESC"
+TALOSCONFIG="$READER" talosctl -n "$NODE" config new "$ESC" --roles os:admin >/dev/null 2>&1
+{ [ $? -ne 0 ] && [ ! -f "$ESC" ]; } \
+  && ok "os:reader cannot mint itself an os:admin config — scoping does not escalate back" \
+  || bad "os:reader minted an os:admin config: the scoped credential is worthless"
+
+if [ "$FAIL" -eq 0 ]; then
+  printf '\n\033[32m✓ %s assertions passed — roles are enforced on %s\033[0m\n' "$PASS" "$LANE"
+else
+  printf '\n\033[31m✗ %s passed, %s FAILED\033[0m\n' "$PASS" "$FAIL" >&2
+  exit 1
+fi

--- a/scripts/ops/talosconfig-new.sh
+++ b/scripts/ops/talosconfig-new.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Issue a SHORT-LIVED, role-scoped talosconfig from the admin one.
+#
+# What this repository hands an operator today is `os:admin`, valid one year,
+# and it is the same file for every task and every person. Talos enforces its
+# roles with nothing added to the machine config (measured on the Docker lane,
+# 2026-08-24: an os:reader config is refused `read` and cannot mint an os:admin
+# one), so the day-to-day credential can be smaller and expire on its own.
+#
+# The admin config stays where it is — this does not replace it, it gives the
+# read-only work something cheaper to lose.
+#
+# Usage:
+#   talosconfig-new.sh <provider|local> [--roles os:reader] [--ttl 8h] [--out PATH] [--node IP]
+set -euo pipefail
+
+LANE="${1:?usage: talosconfig-new.sh <provider|local> [--roles R] [--ttl D] [--out PATH] [--node IP]}"
+shift
+ROLES="os:reader"
+TTL="8h"
+OUT=""
+NODE="${NODE:-}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --roles) ROLES="$2"; shift 2 ;;
+    --ttl)   TTL="$2";   shift 2 ;;
+    --out)   OUT="$2";   shift 2 ;;
+    --node)  NODE="$2";  shift 2 ;;
+    *) echo "✗ unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Same lane resolution as scripts/dev/infra-verify.sh — two spellings of "where
+# does this cluster keep its credentials" would drift.
+if [ "$LANE" = local ]; then
+  CLUSTER_DIR="$ROOT/infrastructure/opentofu-local"
+else
+  CLUSTER_DIR="$ROOT/infrastructure/opentofu/cluster"
+fi
+SRC="${TALOSCONFIG:-$CLUSTER_DIR/talosconfig}"
+OUT="${OUT:-$CLUSTER_DIR/talosconfig.${ROLES#os:}}"
+
+# A talosconfig with no context is the 25-byte stub a fresh clone carries, not a
+# cluster. `talosctl` answers "no context is set", which reads like a flag
+# mistake; say what is actually missing instead of forwarding that.
+if [ ! -s "$SRC" ] || ! TALOSCONFIG="$SRC" talosctl config info >/dev/null 2>&1; then
+  echo "✗ no usable talosconfig at $SRC" >&2
+  echo "  That file is empty or has no context: there is no cluster to ask." >&2
+  [ "$LANE" = local ] && echo "  Bring one up:  task local-up" >&2 \
+                      || echo "  Deploy one:    task cluster-up PROVIDER=$LANE" >&2
+  exit 1
+fi
+
+if [ -z "$NODE" ]; then
+  NODE="$(tofu -chdir="$CLUSTER_DIR" output -json control_plane_ips 2>/dev/null |
+          sed -nE 's/^\["([^"]+)".*/\1/p')" || true
+fi
+if [ -z "$NODE" ]; then
+  echo "✗ no node to ask, and the state did not answer." >&2
+  echo "  Pass one:  $0 $LANE --node <control-plane private IP>" >&2
+  [ "$LANE" != local ] && echo "  On a cloud lane the Talos API is reached through the bastion:" >&2 \
+                       && echo "    task tunnels-up PROVIDER=$LANE" >&2
+  exit 1
+fi
+
+rm -f "$OUT"
+TALOSCONFIG="$SRC" talosctl -n "$NODE" config new "$OUT" --roles "$ROLES" --crt-ttl "$TTL"
+
+# Report what came back, not what was requested: the roles are granted by the
+# node, and asking for one it will not give is a silent downgrade otherwise.
+GOT="$(TALOSCONFIG="$OUT" talosctl config info 2>/dev/null | sed -nE 's/^Roles:[[:space:]]+(.*)$/\1/p')"
+EXP="$(TALOSCONFIG="$OUT" talosctl config info 2>/dev/null | sed -nE 's/^Certificate expires:[[:space:]]+(.*)$/\1/p')"
+if [ "$GOT" != "$ROLES" ]; then
+  echo "✗ asked for '$ROLES', the node issued '$GOT' — not using it." >&2
+  rm -f "$OUT"
+  exit 1
+fi
+printf '✓ %s\n  roles:   %s\n  expires: %s\n  use it:  TALOSCONFIG=%s talosctl -n %s <read-only command>\n' \
+  "$OUT" "$GOT" "$EXP" "$OUT" "$NODE"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,10 +59,14 @@ install_tofu() {
                 return 1
             fi
         fi
-        curl -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh
-        chmod +x install-opentofu.sh
-        ./install-opentofu.sh --install-method standalone
-        rm -f install-opentofu.sh
+        # Downloads to $TMPDIR, not to the CWD: the `rm` this replaced sat
+        # AFTER the installer, so under `set -e` a failed install left a 50 KB
+        # third-party script in the root of a public repository.
+        local tmp
+        tmp="$(mktemp)"
+        trap 'rm -f "$tmp"' RETURN
+        curl -fsSL https://get.opentofu.org/install-opentofu.sh -o "$tmp"
+        sh "$tmp" --install-method standalone
     fi
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -111,8 +111,10 @@ install_shellcheck() {
 
 install_yamllint() {
     echo "Installing yamllint..."
-    if command -v pip3 &> /dev/null; then
-        pip3 install --user yamllint
+    # `python3 -m pip`, not `command -v pip3` — see install_checkov for why:
+    # Python without a pip3 BINARY is the normal case on Ubuntu 24.04.
+    if python3 -m pip --version &> /dev/null; then
+        python3 -m pip install --user yamllint
     elif command -v apt-get &> /dev/null; then
         $SUDO apt-get update && $SUDO apt-get install -y yamllint
     else
@@ -127,10 +129,23 @@ install_checkov() {
     # `pip3` is not always a binary even where Python is: prefer pipx, fall back
     # to `python3 -m pip`, and say so rather than leaving `task security` to die
     # with "executable file not found".
+    # Kept in this order on purpose: the first three need no sudo, the fourth does.
+    local venv="$HOME/.local/share/openaether/checkov-venv"
     if command -v pipx &> /dev/null; then
         pipx install checkov
     elif python3 -m pip --version &> /dev/null; then
         python3 -m pip install --user checkov
+    elif mkdir -p "$(dirname "$venv")" && python3 -m venv "$venv" &> /dev/null && [ -x "$venv/bin/pip" ]; then
+        # Ubuntu 24.04 ships python3 with NEITHER pip nor pipx, so the two
+        # branches above miss and the apt one below wants sudo. A venv needs
+        # neither and carries its own pip. Measured 2026-08-24 on exactly that
+        # machine, where `task security` could not be completed at all.
+        # The condition CREATES the venv rather than probing with `--help`:
+        # `import venv` succeeds without python3-venv installed and only the
+        # creation fails, so anything cheaper would answer the wrong question.
+        "$venv/bin/pip" install --quiet checkov
+        mkdir -p "$HOME/.local/bin"
+        ln -sf "$venv/bin/checkov" "$HOME/.local/bin/checkov"
     elif command -v apt-get &> /dev/null; then
         $SUDO apt-get update && $SUDO apt-get install -y pipx && pipx install checkov
     else


### PR DESCRIPTION
A review of how an operator actually reaches this cluster — SSH bastion,
`admin_ip` allowlist, `ssh -L` to Talos:50000, 6443 on a public LB — compared
against current practice, ANSSI-PA-022, NIST SP 800-207 and NIS2. Then the two
findings that could be closed without a cloud account, and three defects the
work itself uncovered.

## The verdict, since it decides what is NOT in this PR

**The bastion is not the problem.** Measured against the appliance-compromise
record (Fortinet, CitrixBleed, Ivanti), what gets stolen is the credentials the
edge box concentrates — and this one holds none: no user database, no session
store, nothing secret at rest. Nor is source-IP filtering obsolete: NIST
SP 800-207 rejects network location *alone*, and ANSSI-PA-022 §13.6 lists it
first among its cloud-admin measures. **So nothing here replaces the bastion,
and no VPN overlay is introduced.**

The defect is credential lifetime. Every credential in the admin path lasted a
year and none was revocable, behind an allowlist that accepted `0.0.0.0/0` in
silence.

## What this changes

**`admin_ip` can no longer open the cluster to the internet.** It had no
`validation` and feeds bastion sshd *and* the 6443 ACL on all four providers
from one place. Three rules now: non-empty, prefix required, no `/0` — read
from the prefix rather than matched as a string, so `198.51.100.7/0` is caught
too. Nine cases in `cluster/tests/admin-ip-validation.tftest.hcl`, and **each
rule was deleted in turn and the suite watched to go red** before it was kept.
It plans with `node_distribution = {}`, so no provider activates and it needs
none of the ~15 `override_resource` blocks `scaleway.tftest.hcl` carries.

**Credentials can now expire.** `task talosconfig-new` issues a role-scoped
talosconfig with a TTL, refusing to report success if the node grants roles
other than those asked. `task local-rbac` then asks the cluster whether roles
mean anything — which nothing here had ever established. On Talos v1.13.3:

```
node                            → Enabled: RBAC   (no machine.features.rbac anywhere here)
config the deploy writes        → os:admin, 1 year
config new --roles os:reader    → os:reader, 7 hours
  os:reader read /etc/hosts     → PermissionDenied, rc=1
  os:admin  read /etc/hosts     → rc=0
  os:reader config new os:admin → PermissionDenied, rc=1, no file
```

Every denial carries its admin control beside it: without the rc=0 line a broken
command reads as a refused one. RBAC turned out to be on by **default** — the
`machine.features.rbac` this was expected to need is not needed at all.

`docs/admin-access.md` (and its French twin) now states plainly that the
kubeconfig cannot be revoked: `O=system:masters` bypasses RBAC and Kubernetes
has no revocation for client certificates.

## Three defects found by doing the work

- **`.gitignore` was swallowing scripts.** `talosconfig*` carries no slash, so
  it matched `scripts/ops/talosconfig-new.sh` at any depth. `git add` took it in
  silence; the commit would have pushed a Taskfile calling a file absent from
  the repository. The globs stay broad — they guard a public repo — and the code
  is exempted by name.
- **`local-down` swept credentials by name, and a third had appeared.** A live
  `talosconfig.reader` survived a teardown printing `✓ Local cluster destroyed`.
  The sweep now globs, and the verification loop *counts credentials* — that
  block was written to ASK docker instead of assuming, and asked it about
  containers, volumes and networks only. A file on disk was outside the question.
- **`task security` could not be completed on a machine set up by
  `scripts/setup.sh`.** Ubuntu 24.04 ships python3 with neither pip nor pipx, so
  `install_checkov`'s first two branches miss and the only one left wants sudo.
  A venv needs neither. Its sibling `install_yamllint` finally receives the
  "`pip3` is not always a binary" lesson written in the comment ten lines above it.

Also on this branch, from the same session: a failed OpenTofu install used to
leave its 50 KB third-party installer in the root of this **public** repository,
because the `rm` sat after the installer under `set -e`.

## Rungs

**Reached — mocked, and the local Docker lane.**

```
task lint                    10 passed
task validate ROOT=cluster   valid        task validate ROOT=talos-image  valid
task test                    52 passed
task security                rc=0   trivy 0 · checkov 16/0 · gitleaks no leaks · rules 6+8
task local-rbac              7 assertions
```

**Skipped — real cloud. No cloud account was touched by this branch.** Two
consequences stated rather than hidden:

- `talosconfig-new`'s **cloud path has never been run** — it needs the bastion
  tunnels open. The task says so in its own comment.
- Nothing yet *uses* the reader config: `cluster-verify` and friends still run
  on the year-long `os:admin`. Wiring them touches paths proven on three clouds
  and raises a question this PR deliberately leaves open — re-mint per run, or
  cache until expiry? It is a **Decide:** entry, not a task.

## Backlog

Five entries added from the review, one of them a `Decide:` on whether OpenAether
operates an always-on host outside every cluster — the question every ambitious
answer (OIDC issuer, SSH CA service, WireGuard control plane) collapses into.
The `admin_ip` entry is closed and removed; the credential entry is rewritten to
what is actually left. Header rung counts recomputed twice as the work moved
them, and one of those counts was already stale before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vwXETPHGDRiBPwThyFhmj
