### PR TITLE
feat(clea): watch every version this repository pins, and prove a bump before it lands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Install Helm (pinned + checksum-verified)
         env:
           # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
-          HELM_VERSION: "4.2.3"
+          HELM_VERSION: "4.2.4"
         run: |
           set -euo pipefail
           asset="helm-v${HELM_VERSION}-linux-amd64.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
       - name: Setup TFLint
         run: ./scripts/internal/install-tflint.sh
 
+      # Same installer as setup.sh, for the same reason as TFLint above.
+      - name: Setup actionlint
+        run: ./scripts/internal/install-actionlint.sh
+
       # Not `arduino/setup-task`: that action asks the releases API for the
       # version, UNAUTHENTICATED, from a runner IP shared with every other GitHub
       # customer — which is what took `main` red on 2026-08-13 with nothing wrong

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Install Helm (pinned + checksum-verified)
         env:
           # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
-          HELM_VERSION: "4.2.4"
+          HELM_VERSION: "4.2.3"
         run: |
           set -euo pipefail
           asset="helm-v${HELM_VERSION}-linux-amd64.tar.gz"

--- a/.github/workflows/clea.yml
+++ b/.github/workflows/clea.yml
@@ -1,0 +1,407 @@
+# Cléa — what this repository pins, what upstream published, and whether the gap
+# survives being installed.
+#
+# Nothing here can reach a cloud: no provider credential is passed, and the lane
+# must fail rather than acquire one. Renovate still owns proposing the bumps —
+# Cléa watches, probes and reports. Two systems opening PRs for the same
+# dependency is a collision this repository has already paid for once (see
+# .github/dependabot.yml).
+#
+# ⚠️ GitHub disables a scheduled workflow after 60 days with no repository
+# activity. A silent Cléa is what this file exists to notice in others; check
+# the report issue's date before trusting it.
+name: Clea
+
+on:
+  schedule:
+    # Daily, tools only. Deliberately not on the hour: a shared runner pool is
+    # busiest at :00, and nothing here is time-critical.
+    - cron: "17 4 * * *"
+    # Weekly, the local Talos cluster on Docker plus the heavy installers.
+    - cron: "41 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: "daily (tools) | weekly (local cluster + heavy installers)"
+        type: choice
+        options: [daily, weekly]
+        default: daily
+
+# One Cléa at a time: two runs would race on the same probe branches.
+concurrency:
+  group: clea
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # push clea/probe/* branches
+  issues: write     # rewrite the report issue
+
+env:
+  WEEKLY: ${{ github.event.schedule == '41 3 * * 0' || inputs.lane == 'weekly' }}
+
+jobs:
+  scan:
+    name: Scan upstream
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      state: ${{ steps.scan.outputs.state }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      issue: ${{ steps.issue.outputs.number }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      # The report issue is also the state store: `clea report` embeds the state
+      # in an HTML comment at the end of its body. No artifact, no cache, and
+      # the durable record is the thing a human already reads.
+      - name: Previous state, from the report issue
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          LABEL="$(python3 scripts/clea/clea.py config report.label)"
+          api="https://api.github.com/repos/${{ github.repository }}"
+          curl -sS -H "Authorization: Bearer $GH_TOKEN" \
+               -H "Accept: application/vnd.github+json" \
+               "$api/issues?labels=${LABEL}&state=open&per_page=1" > issues.json
+          number="$(python3 -c 'import json;d=json.load(open("issues.json"));print(d[0]["number"] if d else "")')"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          if [ -n "$number" ]; then
+            python3 -c 'import json;print(json.load(open("issues.json"))[0]["body"] or "")' > previous.md
+          else
+            : > previous.md
+          fi
+
+      # Authenticated, always. Unauthenticated the API allows 60 requests an
+      # hour from an IP shared with every other GitHub customer — which is what
+      # took `main` red on 2026-08-13 with nothing wrong in the code.
+      - name: clea scan
+        id: scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/clea/clea.py scan --previous previous.md --state clea-state.json
+          {
+            echo "state<<CLEA_EOF"
+            cat clea-state.json
+            echo "CLEA_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: What to probe
+        id: matrix
+        run: |
+          set -euo pipefail
+          # if/then, not `[ … ] && flag=…`: under `set -e` a false test is a
+          # failing command and takes the step with it. That shape has cost this
+          # repository a whole lane before.
+          if [ "${WEEKLY}" = "true" ]; then flag=--heavy-only; else flag=--daily; fi
+          matrix="$(python3 scripts/clea/clea.py matrix --state clea-state.json "$flag")"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "${matrix}" >> "$GITHUB_STEP_SUMMARY"
+
+      # Offline, and it gates: a pin no inventory watches is a pin nobody bumps.
+      # It runs here too, not only in `task lint`, because the state of the tree
+      # on a schedule is what the report is about.
+      - name: clea coverage
+        continue-on-error: true
+        run: python3 scripts/clea/clea.py coverage | tee -a "$GITHUB_STEP_SUMMARY"
+
+  probe:
+    name: Probe ${{ matrix.entry.dep }}
+    needs: scan
+    if: needs.scan.outputs.matrix != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        entry: ${{ fromJSON(needs.scan.outputs.matrix) }}
+    # Through the environment, never interpolated into a shell or a heredoc: a
+    # dependency name reaches a `run:` block as data, and ${{ }} would make it
+    # code. Trusted today, and the rule costs nothing.
+    env:
+      DEP: ${{ matrix.entry.dep }}
+      VERSION: ${{ matrix.entry.version }}
+      SLUG: ${{ matrix.entry.slug }}
+      INSTALLER: ${{ matrix.entry.installer }}
+      VERSION_CMD: ${{ matrix.entry.version_cmd }}
+      INSTALLER_STDIN: ${{ matrix.entry.installer_stdin }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          fetch-depth: 0
+
+      # First, and on the untouched tree: probe.sh installs the CURRENT pin so
+      # there is something to upgrade over, and restores the tree when it is
+      # done. Bumping before this would leave nothing to upgrade from.
+      - name: Install from cold, then upgrade over the old version
+        id: probe
+        if: matrix.entry.installer != ''
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          ./scripts/clea/probe.sh "$DEP" "$VERSION" "$INSTALLER" "$VERSION_CMD" \
+            "$INSTALLER_STDIN" 2>&1 | tee probe.log
+
+      - name: Apply the bump
+        run: |
+          set -euo pipefail
+          git checkout -- .
+          python3 scripts/clea/clea.py bump "$DEP" "$VERSION"
+
+      # The repository's own installer, not a hand-written list of steps: a
+      # second list is a second pin to drift, and this is also the only place
+      # anything continuously exercises setup.sh.
+      - name: The toolchain this repository ships
+        run: printf 'y\n' | ./scripts/setup.sh
+
+      # Cilium and Flux are pinned in a generator whose OUTPUT is committed.
+      # Bumping the pin without re-rendering leaves the two disagreeing, which
+      # is a real failure — so render here and let the branch carry both halves.
+      - name: Regenerate what the bump makes stale
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' > regen.sh
+          import tomllib
+          with open("clea.toml", "rb") as handle:
+              for command in tomllib.load(handle).get("lane", {}).get("regen", []):
+                  print(command)
+          PY
+          bash -x regen.sh
+
+      # For a dependency whose only consumer is a CI job, this is the whole
+      # probe: a push carrying GITHUB_TOKEN does not trigger a workflow, so
+      # whatever must run on a probe branch runs here or nowhere.
+      - name: The repository's own gates, with the bump applied
+        id: gates
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python3 - <<'PY' > gates.sh
+          import tomllib
+          with open("clea.toml", "rb") as handle:
+              for command in tomllib.load(handle).get("lane", {}).get("repo", []):
+                  print(f'echo "=== {command} ==="')
+                  print(command)
+          PY
+          bash -e gates.sh 2>&1 | tee gates.log
+
+      - name: Verdict, and the branch that carries it
+        env:
+          GREEN: ${{ steps.probe.outcome != 'failure' && steps.gates.outcome != 'failure' }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, pathlib
+          log = ""
+          for name in ("probe.log", "gates.log"):
+              path = pathlib.Path(name)
+              if path.is_file():
+                  log += path.read_text(errors="replace")[-2000:]
+          json.dump({
+              "dep": os.environ["DEP"],
+              "version": os.environ["VERSION"],
+              "green": os.environ["GREEN"] == "true",
+              "branch": "clea/probe/" + os.environ["SLUG"],
+              "run": os.environ["RUN_URL"],
+              "log": log,
+          }, open("clea-probe.json", "w"), indent=2)
+          PY
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # -u and one explicit path, never -A: setup.sh leaves install-opentofu.sh
+          # in the root when its download fails, and a probe branch is not the
+          # place to publish a vendored installer.
+          git add -u
+          git add clea-probe.json
+          git commit -q -m "chore(clea): probe ${DEP} ${VERSION}"
+          # Pushed green or red on purpose: a red branch is the reproduction, and
+          # deleting it leaves a report describing something nobody can re-run.
+          git push --force-with-lease origin "HEAD:clea/probe/${SLUG}"
+
+  cluster:
+    name: Local Talos cluster
+    needs: scan
+    if: |
+      always() && needs.scan.result == 'success' &&
+      (github.event.schedule == '41 3 * * 0' || inputs.lane == 'weekly')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      # One control plane, one worker. This repository's own default is 3 + 3,
+      # which is six Talos containers on a shared runner; the topology below is
+      # supported (non-HA, control plane tainted) and this lane asks whether the
+      # Talos/Kubernetes pair BOOTS, not whether it is highly available.
+      TF_VAR_control_plane_count: "1"
+      TF_VAR_worker_count: "1"
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      # Also the cold-install probe for helm and flux, which have no installer
+      # of their own — they are steps inside this script.
+      - name: The toolchain this repository ships
+        run: printf 'y\n' | ./scripts/setup.sh
+
+      - name: Bump Talos and Kubernetes to what upstream publishes
+        continue-on-error: true
+        env:
+          STATE: ${{ needs.scan.outputs.state }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$STATE" > clea-state.json
+          python3 - <<'PY' > bumps.sh
+          import json
+          state = json.load(open("clea-state.json"))
+          wanted = ("siderolabs/talos", "kubernetes/kubernetes")
+          for dep in state["deps"]:
+              if dep["dep"] in wanted and dep.get("behind") and dep.get("pinned"):
+                  print(f'python3 scripts/clea/clea.py bump {dep["dep"]} {dep["latest"]}')
+          PY
+          bash -x bumps.sh
+          git --no-pager diff --stat
+
+      - name: task local-up
+        id: up
+        run: |
+          ./scripts/bootstrap/render-bootstrap-manifests.sh --local
+          task local-up
+
+      - name: task local-verify
+        id: verify
+        run: task local-verify
+
+      - name: task local-down
+        if: always()
+        run: task local-down || true
+
+      - name: Verdict
+        if: always()
+        env:
+          UP: ${{ steps.up.outcome }}
+          VERIFY: ${{ steps.verify.outcome }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import datetime, json, os, re, pathlib
+          text = pathlib.Path("infrastructure/opentofu-local/variables.tf").read_text()
+
+          def pin(name):
+              m = re.search(r'variable "%s"[\s\S]*?default\s*=\s*"([^"]+)"' % name, text)
+              return m.group(1) if m else "?"
+
+          green = os.environ["UP"] == "success" and os.environ["VERIFY"] == "success"
+          json.dump({
+              "dep": "local-cluster",
+              "version": pin("talos_version"),
+              "green": green,
+              "branch": "clea/probe/local-cluster",
+              "run": os.environ["RUN_URL"],
+              "cluster_lane": {
+                  "verdict": "deployed and verified" if green else
+                             f'up={os.environ["UP"]}, verify={os.environ["VERIFY"]}',
+                  "at": datetime.datetime.now(datetime.timezone.utc)
+                        .isoformat(timespec="seconds"),
+                  "talos": pin("talos_version"),
+                  "k8s": pin("kubernetes_version"),
+              },
+          }, open("clea-probe.json", "w"), indent=2)
+          PY
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -u
+          git add clea-probe.json
+          git commit -q -m "chore(clea): local cluster lane"
+          git push --force-with-lease origin HEAD:clea/probe/local-cluster
+
+  report:
+    name: Report
+    needs: [scan, probe, cluster]
+    if: always() && needs.scan.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          fetch-depth: 0
+
+      - name: Collect the probe verdicts from their own branches
+        env:
+          STATE: ${{ needs.scan.outputs.state }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$STATE" > clea-state.json
+          git fetch -q origin "+refs/heads/clea/probe/*:refs/remotes/origin/clea/probe/*" || true
+          python3 - <<'PY'
+          import json, subprocess
+          state = json.load(open("clea-state.json"))
+          refs = subprocess.run(["git", "for-each-ref", "--format=%(refname:short)",
+                                 "refs/remotes/origin/clea/probe/*"],
+                                capture_output=True, text=True).stdout.split()
+          probes, cluster = [], None
+          for ref in refs:
+              blob = subprocess.run(["git", "show", f"{ref}:clea-probe.json"],
+                                    capture_output=True, text=True)
+              if blob.returncode:
+                  continue
+              try:
+                  probe = json.loads(blob.stdout)
+              except ValueError:
+                  continue
+              if probe.get("cluster_lane"):
+                  cluster = probe["cluster_lane"]
+              else:
+                  probes.append(probe)
+          state["probes"] = probes
+          if cluster:
+              state["cluster_lane"] = cluster
+          json.dump(state, open("clea-state.json", "w"), indent=2)
+          print(f"{len(probes)} probe verdict(s), cluster lane: {bool(cluster)}")
+          PY
+
+      - name: Rewrite the report issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ needs.scan.outputs.issue }}
+        run: |
+          set -euo pipefail
+          python3 scripts/clea/clea.py report --state clea-state.json --out report.md
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+          api="https://api.github.com/repos/${{ github.repository }}"
+          # The label may not exist yet; 422 means it already does.
+          label="$(python3 scripts/clea/clea.py config report.label)"
+          curl -sS -o /dev/null -X POST -H "Authorization: Bearer $GH_TOKEN" \
+               "$api/labels" \
+               -d "{\"name\":\"${label}\",\"color\":\"0e8a16\",\"description\":\"Clea dependency report\"}" || true
+          python3 - <<'PY' > payload.json
+          import json, sys, tomllib
+          with open("clea.toml", "rb") as handle:
+              report = tomllib.load(handle).get("report", {})
+          json.dump({"title": report.get("title", "Clea"),
+                     "body": open("report.md").read(),
+                     "labels": [report.get("label", "clea")]}, sys.stdout)
+          PY
+          if [ -n "${NUMBER}" ]; then
+            curl -sS -o /dev/null -X PATCH -H "Authorization: Bearer $GH_TOKEN" \
+                 "$api/issues/${NUMBER}" --data @payload.json
+            echo "report issue #${NUMBER} rewritten"
+          else
+            curl -sS -o /dev/null -X POST -H "Authorization: Bearer $GH_TOKEN" \
+                 "$api/issues" --data @payload.json
+            echo "report issue created"
+          fi
+
+      - name: Probe branches whose bump already landed
+        run: |
+          set -euo pipefail
+          python3 scripts/clea/clea.py prune > stale.txt || true
+          while read -r branch; do
+            [ -n "$branch" ] || continue
+            echo "pruning ${branch}"
+            git push -q origin --delete "$branch" || true
+          done < stale.txt

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ __pycache__/
 
 # Probe samples from a roll — kept so the next investigation has a baseline.
 .upgrade-probe-*.log
+
+# Cléa writes this on a local `task clea-scan`; on a probe branch the committed
+# artefact is clea-probe.json, not this.
+clea-state.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,9 +149,10 @@ in git. 0.1.0 is the first entry describing something proven.
 - **`infrastructure/opentofu-local/variables.tf` carried no anchor at all**, so
   the credential-free lane drifted to Talos `v1.13.3` / Kubernetes `v1.35.3`
   against `v1.13.9` / `v1.36.3` in the cloud root. Anchored, so a proposal now
-  reaches it; the pins themselves are not moved here because nothing has yet
-  proven the newer pair boots — `docs/backlog.md` holds the entry and the weekly
-  lane is what will close it.
+  reaches it; the pins themselves are not moved here. Measured 2026-08-24 on the
+  Docker lane: the newer pair (`v1.13.9` / `v1.36.4`) boots, 6/6 on
+  `task local-verify`. Unifying the two roots and a real-cloud upgrade are
+  [#87](https://github.com/dis-bzh/OpenAether-infra/issues/87).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,31 +14,6 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ## [Unreleased]
 
-### Security
-
-- **`admin_ip` refuses to open the cluster to the internet.** The variable had
-  no `validation`, so `["0.0.0.0/0"]` was accepted in silence — and it feeds
-  bastion sshd *and* the 6443 LB ACL on all four providers at once. Behind that
-  ACL sits a `system:masters` kubeconfig Kubernetes cannot revoke. Three rules
-  now reject an empty list, an entry without a prefix (including the `YOUR_IP/32`
-  of a copied example) and any `/0` — read from the prefix, so `198.51.100.7/0`
-  is caught too. Nine cases in
-  `cluster/tests/admin-ip-validation.tftest.hcl`; each rule was deleted in turn
-  and the suite watched to go red before it was kept.
-- **Admin access is documented as unrevocable where it is unrevocable.**
-  [`docs/admin-access.md`](docs/admin-access.md) now says what a leaked
-  kubeconfig costs, instead of leaving the reader to find out.
-
-### Fixed
-
-- **`task security` could not be completed on a machine set up by
-  `scripts/setup.sh`.** `install_checkov` tried pipx, then `python3 -m pip`,
-  then apt — and Ubuntu 24.04 ships python3 with neither pip nor pipx, so the
-  only branch left wanted sudo. A venv needs neither and carries its own pip;
-  it now sits between them, and `install_yamllint` finally gets the
-  "`pip3` is not always a binary" lesson its neighbour documented and never
-  received.
-
 ### Added
 
 - **`task talosconfig-new`** — issues a role-scoped talosconfig with a TTL
@@ -54,6 +29,77 @@ in git. 0.1.0 is the first entry describing something proven.
   `Enabled: RBAC` with no `machine.features.rbac` anywhere in this repository,
   an `os:reader` config is refused a host read the admin config gets, and it
   cannot mint itself an `os:admin` one.
+
+- **Cléa — a daily watch on what this repository pins, and a probe that installs
+  the bump before anyone merges it.** `scripts/clea/` holds a generic engine
+  (Python, standard library only, no knowledge of this project); `clea.toml`
+  holds everything specific to it; `.github/workflows/clea.yml` runs it. Renovate
+  keeps proposing the bumps — Cléa watches, probes and reports, and no lane of it
+  can reach a cloud.
+  - **Daily**: resolve every pin against upstream, then for each tool that moved,
+    install it from cold and upgrade it over the old version in a bare
+    `ubuntu:24.04`, then run `task lint`, `task render-check` and
+    `task test-scripts` on the bumped tree. The upgrade half is the one that
+    finds things: an installer that checks whether a binary exists, rather than
+    which version it is, installs correctly once and refuses every upgrade after
+    that — which is exactly what `scripts/dev/feint.sh` had done until
+    2026-08-21.
+  - **Weekly**: `task local-up` on the Talos and Kubernetes pair upstream
+    publishes, then `task local-verify`. Real cloud stays manual.
+  - **One report issue**, rewritten in place, which also carries the previous
+    run's state so "this moved since yesterday" needs no artifact store.
+  - What it refuses to do: a datasource that answers nothing, a tree with no
+    anchors and a writer that writes nothing all exit 1. An unauthenticated
+    GitHub API answer is an error naming `GITHUB_TOKEN`, never "up to date" —
+    60 requests an hour from a shared runner IP is what took `main` red on
+    2026-08-13. Documented in [`docs/clea.md`](docs/clea.md).
+
+### Fixed
+
+- **`task security` could not be completed on a machine set up by
+  `scripts/setup.sh`.** `install_checkov` tried pipx, then `python3 -m pip`,
+  then apt — and Ubuntu 24.04 ships python3 with neither pip nor pipx, so the
+  only branch left wanted sudo. A venv needs neither and carries its own pip;
+  it now sits between them, and `install_yamllint` finally gets the
+  "`pip3` is not always a binary" lesson its neighbour documented and never
+  received.
+
+- **Nine of twenty-one version anchors were inert, and nothing said so.** The
+  `# renovate:` comment was there and Renovate had never been told to read the
+  file or the key, so the pin looked watched and was not: `go-task/task`,
+  `terraform-linters/tflint`, `cloudnative-pg/cloudnative-pg`,
+  `stephrobert/feint`, and `commitizen`, `gitleaks` and `helm` inside
+  `ci.yml`. The two anchors in `Taskfile.yml` marked no version at all — the
+  value moved into `talos-version.sh` and the anchors stayed behind. The six
+  custom managers are now three, matched on the **shape** of a value rather than
+  on the names of the keys that hold it, and written in the current
+  `managerFilePatterns` spelling rather than the deprecated `fileMatch`.
+  `task lint` now runs `clea coverage`, which fails on the next one.
+
+- **`infrastructure/opentofu-local/variables.tf` carried no anchor at all**, so
+  the credential-free lane drifted to Talos `v1.13.3` / Kubernetes `v1.35.3`
+  against `v1.13.9` / `v1.36.3` in the cloud root. Anchored, so a proposal now
+  reaches it; the pins themselves are not moved here because nothing has yet
+  proven the newer pair boots — `docs/backlog.md` holds the entry and the weekly
+  lane is what will close it.
+
+---
+
+### Security
+
+- **`admin_ip` refuses to open the cluster to the internet.** The variable had
+  no `validation`, so `["0.0.0.0/0"]` was accepted in silence — and it feeds
+  bastion sshd *and* the 6443 LB ACL on all four providers at once. Behind that
+  ACL sits a `system:masters` kubeconfig Kubernetes cannot revoke. Three rules
+  now reject an empty list, an entry without a prefix (including the `YOUR_IP/32`
+  of a copied example) and any `/0` — read from the prefix, so `198.51.100.7/0`
+  is caught too. Nine cases in
+  `cluster/tests/admin-ip-validation.tftest.hcl`; each rule was deleted in turn
+  and the suite watched to go red before it was kept.
+- **Admin access is documented as unrevocable where it is unrevocable.**
+  [`docs/admin-access.md`](docs/admin-access.md) now says what a leaked
+  kubeconfig costs, instead of leaving the reader to find out.
+
 
 ## [0.1.0] — 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ in git. 0.1.0 is the first entry describing something proven.
     GitHub API answer is an error naming `GITHUB_TOKEN`, never "up to date" —
     60 requests an hour from a shared runner IP is what took `main` red on
     2026-08-13. Documented in [`docs/clea.md`](docs/clea.md).
+  - **What the first real scan found**, running against live upstreams:
+    `commitizen` pinned at 4.9.1 against 4.18.0 — nine minor versions, on one of
+    the anchors that was inert — and the Cilium chart one patch behind at 1.20.0
+    against 1.20.1. A Cilium bump was then walked through by hand: `task
+    render-check` goes red on the stale manifest, the render lane closes it, and
+    both go green. The GitHub datasources answered 403 in that session and were
+    reported as failures, which is the behaviour that matters most: a
+    datasource that did not answer is not a dependency that is up to date.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ in git. 0.1.0 is the first entry describing something proven.
     publishes, then `task local-verify`. Real cloud stays manual.
   - **One report issue**, rewritten in place, which also carries the previous
     run's state so "this moved since yesterday" needs no artifact store.
+  - **A heartbeat on the bot that proposes the bumps.** The scan records when
+    `renovate[bot]` last opened a pull request, and crosses it with what Cléa
+    found: a dependency behind *and* visible to the bot's own inventory, with no
+    proposal for days, means the bot is not running. Silence on its own raises
+    nothing — a bot with nothing to propose is silent and correct.
   - What it refuses to do: a datasource that answers nothing, a tree with no
     anchors and a writer that writes nothing all exit 1. An unauthenticated
     GitHub API answer is an error naming `GITHUB_TOKEN`, never "up to date" —
@@ -61,6 +66,21 @@ in git. 0.1.0 is the first entry describing something proven.
     both go green. The GitHub datasources answered 403 in that session and were
     reported as failures, which is the behaviour that matters most: a
     datasource that did not answer is not a dependency that is up to date.
+
+### Changed
+
+- **Renovate moves from a six-hour weekly window to a daily one**, and
+  `dependencyDashboard` becomes explicit. It has proposed nothing since its
+  config landed on 2026-07-30 — its nine pull requests were created three hours
+  *before* that file existed — and one measurement rules the schedule out as the
+  explanation: helm 4.2.4 was published 2026-08-13, `setup.sh:225` pins 4.2.3,
+  that anchor is one Renovate could always see, and the window of 2026-08-17
+  passed four days later with nothing. The weekly window existed to batch noise;
+  Cléa's daily report does that now, so it cost a week of latency and bought
+  nothing. The dashboard is the visible heartbeat: issues were disabled on this
+  repository until 2026-08-21, so Renovate had nowhere to report a configuration
+  problem or its own state, and three weeks of silence looked exactly like three
+  weeks of nothing to do.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,25 @@ in git. 0.1.0 is the first entry describing something proven.
   "`pip3` is not always a binary" lesson its neighbour documented and never
   received.
 
+- **`command -v sudo` asks whether sudo EXISTS, not whether it can be USED**,
+  and eight places asked it. On a workstation where `/usr/local/bin` is not
+  writable and sudo wants a password, that answers yes, the installer then dies
+  on a prompt nobody can answer, and `set -e` ends the bootstrap. The rule is
+  now one function in `scripts/lib/common.sh` — `oa_sudo_usable`, `oa_bin_dir`,
+  `oa_sudo_for` — used by `setup.sh` and by the four pinned installers instead
+  of the same six lines repeated: passwordless sudo, or a terminal to be asked
+  on, or neither, and a directory that does not exist yet is judged by its
+  parent.
+
+- **`install_tofu` preferred snap and brew, and neither can install a NAMED
+  version.** `snap install --classic opentofu` serves whatever the channel
+  holds, so on any machine with snap the pin was decorative — which is how this
+  repository's own workstation ran 1.12.6 against a pinned 1.12.5. A pin an
+  installer cannot honour is a pin that guarantees drift, and
+  `check-version-drift.sh` now compares this one. Only the standalone installer
+  remains: it takes `--opentofu-version`, and `--install-path` /
+  `--symlink-path` let it install without root.
+
 - **`scripts/setup.sh` asked whether a tool was present, never which version it
   was** — so it installed the pin on a fresh machine and refused every upgrade
   afterwards, in silence, on every machine that had run it once. Found by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ in git. 0.1.0 is the first entry describing something proven.
     GitHub API answer is an error naming `GITHUB_TOKEN`, never "up to date" —
     60 requests an hour from a shared runner IP is what took `main` red on
     2026-08-13. Documented in [`docs/clea.md`](docs/clea.md).
+  - **The probe found its first defect, and the same probe proved the fix.**
+    `setup.sh` installed helm 4.2.4 from cold and left 4.2.3 in place when
+    upgrading over it — the exact shape the upgrade lane exists to catch. After
+    the fix, three lanes of three green. That loop, not the daily report, is
+    what this is for.
   - **What the first real scan found**, running against live upstreams:
     `commitizen` pinned at 4.9.1 against 4.18.0 — nine minor versions, on one of
     the anchors that was inert — and the Cilium chart one patch behind at 1.20.0
@@ -91,6 +96,24 @@ in git. 0.1.0 is the first entry describing something proven.
   it now sits between them, and `install_yamllint` finally gets the
   "`pip3` is not always a binary" lesson its neighbour documented and never
   received.
+
+- **`scripts/setup.sh` asked whether a tool was present, never which version it
+  was** — so it installed the pin on a fresh machine and refused every upgrade
+  afterwards, in silence, on every machine that had run it once. Found by the
+  Cléa probe on a real bump: a cold install reached helm 4.2.4 while upgrading
+  over 4.2.3 left 4.2.3. `check_cmd` now takes the pin and compares, bounded on
+  both sides, for the three tools this file pins; the others have no version to
+  compare against and pinning them is a separate decision.
+  `scripts/dev/test-setup-checks.sh` guards it offline, so it does not need
+  Docker to stay fixed.
+
+- **The OpenTofu install asked the GitHub API which version was newest** —
+  unauthenticated, 60 requests an hour from a shared IP, and it is the FIRST
+  step, so a 403 there took the whole bootstrap down with `set -e` and nothing
+  at all got installed. Exit 2 on a bare `ubuntu:24.04`, measured 2026-08-23.
+  OpenTofu was the last tool here neither pinned nor verified; it now carries
+  the same pin as `ci.yml`, passed to the installer explicitly, and
+  `check-version-drift.sh` compares the two.
 
 - **Nine of twenty-one version anchors were inert, and nothing said so.** The
   `# renovate:` comment was there and Renovate had never been told to read the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ hand and in what order.
 
 ## Before opening a PR
 
-    task lint         # tofu fmt, yamllint (infrastructure/ + .github/workflows/ + root configs), tflint
+    task lint         # tofu fmt, yamllint, tflint, actionlint, language, version drift, pin coverage
     task validate ROOT=cluster
     task validate ROOT=talos-image
     task test
@@ -105,7 +105,11 @@ same tool: the `commit-msg` hook refuses a subject as you write it, and the
   actions, pre-commit hooks) are proposed by Renovate and never auto-merged —
   review the diff, especially anything labeled `needs-regen` (the pinned version
   bumped but a vendored manifest needs regenerating by hand) or
-  `vendored-manifest`.
+  `vendored-manifest`. **A new pin needs an anchor**: the
+  `# renovate: datasource=… depName=…` comment on the line above the value.
+  `task lint` fails on a pin no inventory watches — nine of them were inert
+  once, and an unwatched pin looks exactly like a healthy one. See
+  [`docs/clea.md`](docs/clea.md).
 
 ## AI-assisted contributions
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -114,6 +114,11 @@ tasks:
       # it installed. `task lint` now matches what pre-commit checks.
       - yamllint -c infrastructure/.yamllint .github/ .pre-commit-config.yaml Taskfile.yml .checkov.yaml
       - tflint --chdir=infrastructure/opentofu --recursive
+      # yamllint says a workflow is well-formed YAML; it cannot say that a
+      # `${{ needs.x.outputs.y }}` names an output that exists, and a scheduled
+      # workflow cannot be dry-run — its first execution is production. This
+      # also runs shellcheck over every `run:` block.
+      - actionlint
       # The detector CLAUDE.md asks for and the repository did not have.
       # English is canonical; French belongs in *.fr.md, and .languageignore
       # lists what is French on purpose, one reason per entry.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -125,6 +125,12 @@ tasks:
       # One tool, one version, everywhere it is claimed. Four instances of that
       # defect landed in one week and every one was mechanically checkable.
       - ./scripts/dev/check-version-drift.sh
+      # And one version, watched by something. check-version-drift.sh compares
+      # the pins to each other; this compares them to the inventory that is
+      # supposed to bump them. Nine anchors were inert when it was written —
+      # a pin nothing watches is a pin nobody bumps, and it looks identical to
+      # a healthy one. Offline, milliseconds.
+      - python3 scripts/clea/clea.py coverage
       # Required inputs must be named where the operator will look. A variable
       # with no default that no document mentions is a deploy that works for us
       # and fails for a stranger — the release criterion is that the docs are
@@ -304,6 +310,10 @@ tasks:
       # graph; this does.
       - ./scripts/dev/test-unattended.sh
       - ./scripts/dev/test-talos-image.sh
+      # Cléa reads every version this repository claims and rewrites it on a
+      # probe branch. Its reader, its writer and its comparator are all places a
+      # silent wrong answer would produce a confident report.
+      - ./scripts/dev/test-clea.sh
 
   test:
     desc: Run OpenTofu tests (cluster root)
@@ -327,6 +337,16 @@ tasks:
       # providers and modules resolved first. -upgrade: see `validate`.
       - tofu init -backend=false -upgrade
       - tofu test
+
+  clea-scan:
+    desc: >-
+      Ask upstream what it has published, offline-safe except for the calls it
+      makes: writes clea-state.json and prints the report. Needs GITHUB_TOKEN —
+      unauthenticated the API allows 60 requests an hour from a shared IP.
+      Usage: task clea-scan
+    cmds:
+      - python3 scripts/clea/clea.py scan --state clea-state.json
+      - python3 scripts/clea/clea.py report --state clea-state.json
 
   cluster-security:
     desc: "Run runtime security validation tests on the cluster"
@@ -364,7 +384,8 @@ tasks:
       # A task-level `vars:` entry SHADOWS the value passed on the command line,
       # so `task talos-image VERSION=v1.13.7` built v1.13.8 and said nothing.
       # Resolve the fallback under its own name and let VERSION win explicitly.
-      # renovate: datasource=github-releases depName=siderolabs/talos
+      # Not an anchor site: talos-version.sh reads the pin from the env's tfvars
+      # or cluster/variables.tf, which is where the only anchor belongs.
       PINNED_VERSION:
         sh: ./scripts/internal/talos-version.sh {{.ROLE}}-{{.PROVIDER}}.tfvars
       IMAGE_VERSION: '{{.VERSION | default .PINNED_VERSION}}'
@@ -392,7 +413,7 @@ tasks:
       # ask | auto — the value names WHO answers the approval, never whether
       # there is one: every apply still plans, then applies that saved plan.
       APPROVE: '{{.APPROVE | default "ask"}}'
-      # renovate: datasource=github-releases depName=siderolabs/talos
+      # Not an anchor site: see talos-image above.
       VERSION:
         sh: ./scripts/internal/talos-version.sh {{.ROLE}}-{{.PROVIDER}}.tfvars
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -314,6 +314,10 @@ tasks:
       # probe branch. Its reader, its writer and its comparator are all places a
       # silent wrong answer would produce a confident report.
       - ./scripts/dev/test-clea.sh
+      # setup.sh asked whether a tool was present, never which version it was —
+      # so it installed the pin once and refused every upgrade after that. Found
+      # by the Cléa probe, guarded here so it does not need Docker to stay fixed.
+      - ./scripts/dev/test-setup-checks.sh
 
   test:
     desc: Run OpenTofu tests (cluster root)

--- a/clea.toml
+++ b/clea.toml
@@ -11,6 +11,13 @@ exclude = ["CHANGELOG.md", "docs/**", "**/testdata/**"]
 [report]
 title = "Cléa — dependency report"
 label = "clea"
+# The bot that is supposed to propose the bumps. Its silence alone proves
+# nothing; crossed with a dependency it CAN see being behind, it proves it is
+# not running. That crossing went unmade here for three weeks: helm 4.2.4 was
+# published 2026-08-13, the Monday window of 2026-08-17 passed, and no proposal
+# ever came.
+watch_bot = "renovate[bot]"
+silent_after_days = 8
 
 # Inventories cross-checked against Cléa's own scan. An anchor Cléa can read and
 # an inventory here cannot see is a pin nothing is watching — `clea coverage`

--- a/clea.toml
+++ b/clea.toml
@@ -1,0 +1,129 @@
+# Cléa's inventory for this repository. The engine (scripts/clea/) knows nothing
+# about OpenAether; everything specific is here. Dropping Cléa into another
+# project is copying that directory and rewriting this file.
+
+[scan]
+# The same anchor Renovate reads, deliberately: one convention, not two. A
+# second inventory is a second thing to drift.
+marker = "# renovate:"
+exclude = ["CHANGELOG.md", "docs/**", "**/testdata/**"]
+
+[report]
+title = "Cléa — dependency report"
+label = "clea"
+
+# Inventories cross-checked against Cléa's own scan. An anchor Cléa can read and
+# an inventory here cannot see is a pin nothing is watching — `clea coverage`
+# fails on it.
+[[inventory]]
+kind = "renovate"
+config = "renovate.json5"
+# Its own matchStrings quote the anchor text verbatim; without this it matches
+# itself and reports anchors that do not exist.
+exclude = ["renovate.json5"]
+
+# --- Tools this repository installs itself -----------------------------------
+# Two probes are derived from each row, and the engine needs nothing else:
+#   install : bare container, bump first, run the installer once
+#   upgrade : bare container, installer at the OLD pin, bump, installer again
+# The second one is the interesting one. `scripts/dev/feint.sh:310` records why:
+# the pin moved to 0.10.0 on 2026-08-21 and every machine that had already run
+# the lane kept 0.9.0, because presence was checked and version was not.
+
+[[tool]]
+name = "go-task/task"
+installer = "scripts/internal/install-task.sh"
+version_cmd = "task --version"
+
+[[tool]]
+name = "terraform-linters/tflint"
+installer = "scripts/internal/install-tflint.sh"
+version_cmd = "tflint --version"
+
+[[tool]]
+name = "cloudnative-pg/cloudnative-pg"
+installer = "scripts/internal/install-kubectl-cnpg.sh"
+version_cmd = "kubectl-cnpg version"
+
+[[tool]]
+name = "stephrobert/feint"
+installer = "scripts/dev/feint.sh install"
+version_cmd = "feint version"
+
+# helm and flux have no installer of their own: they are steps inside setup.sh,
+# which installs the whole toolchain. Too slow for a daily matrix entry, so they
+# ride the weekly lane. `daily = false` is the only thing that says so.
+[[tool]]
+name = "helm/helm"
+installer = "scripts/setup.sh"
+installer_stdin = "y\n"
+version_cmd = "helm version --short"
+daily = false
+
+[[tool]]
+name = "fluxcd/flux2"
+installer = "scripts/setup.sh"
+installer_stdin = "y\n"
+version_cmd = "flux --version"
+daily = false
+
+# --- What the repository consumes without pinning it -------------------------
+# No version is written down anywhere, so no two machines are guaranteed the
+# same tool. Cléa cannot bump these — it can only make the movement visible,
+# which is more than exists today.
+
+[[unpinned]]
+name = "kubernetes/kubernetes"
+datasource = "url-text"
+url = "https://dl.k8s.io/release/stable.txt"
+extract = "^(?P<v>v[0-9][0-9A-Za-z.-]*)$"
+consumed_by = "scripts/setup.sh (install_kubectl)"
+
+[[unpinned]]
+name = "siderolabs/talos"
+datasource = "github-releases"
+consumed_by = "scripts/setup.sh (install_talosctl, via talos.dev/install)"
+
+[[unpinned]]
+name = "aws/aws-cli"
+datasource = "github-releases"
+consumed_by = "scripts/setup.sh (install_awscli_bundle)"
+
+[[unpinned]]
+name = "checkov"
+datasource = "pypi"
+consumed_by = "scripts/setup.sh (install_checkov)"
+
+[[unpinned]]
+name = "yamllint"
+datasource = "pypi"
+consumed_by = "scripts/setup.sh (install_yamllint), .github/workflows/ci.yml"
+
+[[unpinned]]
+name = "pre-commit"
+datasource = "pypi"
+consumed_by = "scripts/setup.sh (install_precommit)"
+
+[[unpinned]]
+name = "koalaman/shellcheck"
+datasource = "github-releases"
+consumed_by = "scripts/setup.sh (install_shellcheck), .github/workflows/ci.yml"
+
+# --- The repository's own gates, run on every probe branch -------------------
+# Not a copy of CI: a bot push carries GITHUB_TOKEN, and GitHub does not trigger
+# workflows from one. Whatever must run on a probe branch runs here or nowhere.
+[lane]
+# Run after the bump, before the gates. Cilium and Flux are pinned in a
+# generator whose output is committed; bumping the pin without re-rendering
+# leaves the two disagreeing, and `task render-check` is what says so. Rendering
+# here means the probe branch carries both halves — the bump and its artifact.
+regen = ["./scripts/bootstrap/render-bootstrap-manifests.sh"]
+
+# The gates, on the bumped tree. `task lint` is the one that earns its place:
+# it runs check-version-drift.sh, which is exactly the "did the bump leave a
+# second copy behind" question.
+repo = [
+  "task lint",
+  "task render-check",
+  "task test-scripts",
+]

--- a/clea.toml
+++ b/clea.toml
@@ -92,8 +92,11 @@ datasource = "github-releases"
 consumed_by = "scripts/setup.sh (install_talosctl, via talos.dev/install)"
 
 [[unpinned]]
+# github-TAGS, not releases: aws/aws-cli tags every version and publishes no
+# GitHub release, so `releases/latest` answers 404. A 404 is reported as a
+# failure rather than as "up to date", which is how this was noticed.
 name = "aws/aws-cli"
-datasource = "github-releases"
+datasource = "github-tags"
 consumed_by = "scripts/setup.sh (install_awscli_bundle)"
 
 [[unpinned]]

--- a/docs/clea.fr.md
+++ b/docs/clea.fr.md
@@ -35,6 +35,16 @@ deux bots se disputent une même dépendance.
 | cluster local | toutes les semaines, dimanche 03:41 UTC | `task local-up` sur le couple Talos / Kubernetes publié en amont, puis `task local-verify`, en 1 plan de contrôle + 1 worker |
 | cloud réel | jamais | à la main, par quelqu'un qui regarde — voir [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
 
+Le scan demande aussi quand `renovate[bot]` a proposé quelque chose pour la
+dernière fois. **Ce nombre seul ne veut rien dire** — un bot qui n'a rien à
+proposer se tait, et il a raison. Il ne devient un signal que croisé avec ce que
+Cléa a trouvé : une dépendance en retard *et* visible par l'inventaire du bot,
+sans proposition depuis des jours, signifie que le bot ne tourne pas. Ce
+croisement n'a pas été fait ici pendant trois semaines : helm 4.2.4 est sorti le
+2026-08-13, la fenêtre planifiée du 2026-08-17 est passée, et personne ne l'a vu
+avant l'écriture de Cléa. `[report] watch_bot` et `silent_after_days` dans
+`clea.toml` sont toute la configuration.
+
 `.github/workflows/clea.yml` est tout le câblage. Il ne porte aucune
 identification de provider et doit échouer plutôt que d'en acquérir une.
 

--- a/docs/clea.fr.md
+++ b/docs/clea.fr.md
@@ -77,10 +77,11 @@ supprime une branche dès que sa montée de version a atterri sur `main`.
   committée. La lane re-génère avant de lancer les vérifications, pour que la
   branche de sonde porte les deux moitiés — mais si la génération échoue,
   `task render-check` est ce qui le dit.
-- **helm et flux n'ont pas d'installeur propre** : ce sont des étapes dans
-  `scripts/setup.sh`, qui vérifie qu'un binaire est présent et non quelle version
-  il porte. Leur lane de mise à jour est censée échouer tant que cela n'aura pas
-  changé ; `docs/backlog.md` porte l'entrée.
+- **Un outil que ce dépôt n'épingle pas** n'a aucune version à laquelle se
+  comparer : sa lane de mise à jour ne peut que rapporter ce qu'elle a trouvé.
+  `talosctl`, `kubectl`, l'AWS CLI, shellcheck, yamllint, checkov et pre-commit
+  sont dans cet état — `docs/backlog.md` porte l'entrée, et les épingler est une
+  décision à part.
 
 ## Le lancer à la main
 

--- a/docs/clea.fr.md
+++ b/docs/clea.fr.md
@@ -1,0 +1,84 @@
+# Cléa — ce que ce dépôt épingle, et si la version suivante y survit
+
+🇬🇧 [English version](clea.md)
+
+> L'outil lui-même est documenté là où il vit :
+> [`scripts/clea/README.md`](../scripts/clea/README.md). Cette page ne parle que
+> de l'usage qu'en fait ce dépôt — ce qui tourne, quand, et ce qu'un rapport vert
+> a le droit d'affirmer.
+
+## Pourquoi il existe
+
+Renovate propose les montées de version ici, et n'en fusionne jamais aucune
+automatiquement. Deux choses qu'il ne fait pas, et que rien d'autre ne couvrait :
+
+- **Il ne peut pas dire ce qu'il ne surveille pas.** Neuf des vingt et une ancres
+  de version de ce dépôt étaient inertes quand Cléa a été écrit : le commentaire
+  était là, le bot ne le lisait pas, et rien ne le signalait. `task lint` échoue
+  désormais là-dessus.
+- **Il n'installe rien.** Une montée de version fusionnée est une montée de
+  version que personne n'a vue s'installer. `scripts/dev/feint.sh` en porte la
+  preuve : le pin est passé à 0.10.0 et toutes les machines ayant déjà exécuté la
+  lane sont restées en 0.9.0, parce que la présence était vérifiée et la version
+  non.
+
+Cléa répond aux deux, et rapporte tous les jours. Renovate garde la main sur les
+propositions — `.github/dependabot.yml` garde la trace de ce qui arrive quand
+deux bots se disputent une même dépendance.
+
+## Ce qui tourne, et quand
+
+| lane | quand | ce qu'elle exerce |
+|---|---|---|
+| scan + couverture | tous les jours, 04:17 UTC | chaque ancre lue, résolue en amont, et comparée à `renovate.json5` |
+| sondes outils | tous les jours | installation à froid et mise à jour sur place de chaque outil qui a bougé, dans un `ubuntu:24.04` nu, puis `task lint`, `task render-check`, `task test-scripts` sur l'arbre modifié |
+| cluster local | toutes les semaines, dimanche 03:41 UTC | `task local-up` sur le couple Talos / Kubernetes publié en amont, puis `task local-verify`, en 1 plan de contrôle + 1 worker |
+| cloud réel | jamais | à la main, par quelqu'un qui regarde — voir [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
+
+`.github/workflows/clea.yml` est tout le câblage. Il ne porte aucune
+identification de provider et doit échouer plutôt que d'en acquérir une.
+
+## Où est le rapport
+
+Une issue GitHub, étiquetée `clea`, **réécrite sur place** à chaque exécution —
+jamais une nouvelle. Son corps porte aussi l'état de l'exécution précédente, dans
+un commentaire HTML en fin de page : c'est ainsi qu'« ceci a bougé depuis hier »
+se calcule sans stockage d'artefacts.
+
+Une sonde pousse sa branche `clea/probe/<dépendance>` qu'elle soit verte **ou**
+rouge : une branche rouge est la reproduction, et la supprimer laisserait un
+rapport décrivant quelque chose que personne ne peut rejouer. `clea prune`
+supprime une branche dès que sa montée de version a atterri sur `main`.
+
+## Ce qu'un rapport vert ne dit pas
+
+- **Rien ici n'a jamais touché un cloud réel.** Un déploiement sur Scaleway, OVH
+  ou Outscale coûte de l'argent et se lance à la main.
+- **Une sonde verte signifie que l'outil s'installe et se met à jour, et que les
+  vérifications du dépôt passent toujours.** Elle ne dit pas que la nouvelle
+  version se comporte pareil sur un cluster vivant. Pour Talos et Kubernetes,
+  c'est le rôle de [`upgrade.fr.md`](upgrade.fr.md).
+- **La lane hebdomadaire prouve qu'un couple démarre sur Docker en 1 + 1**, Cilium
+  levé. Ce n'est ni un test de haute disponibilité ni une mise à jour tournante.
+
+## Deux choses qui rougiront exprès
+
+- **Une montée de Cilium ou de Flux** déplace un pin dont la *sortie* est
+  committée. La lane re-génère avant de lancer les vérifications, pour que la
+  branche de sonde porte les deux moitiés — mais si la génération échoue,
+  `task render-check` est ce qui le dit.
+- **helm et flux n'ont pas d'installeur propre** : ce sont des étapes dans
+  `scripts/setup.sh`, qui vérifie qu'un binaire est présent et non quelle version
+  il porte. Leur lane de mise à jour est censée échouer tant que cela n'aura pas
+  changé ; `docs/backlog.md` porte l'entrée.
+
+## Le lancer à la main
+
+    task clea-scan                         # nécessite GITHUB_TOKEN
+    python3 scripts/clea/clea.py coverage  # hors-ligne, et inclus dans task lint
+
+`task lint` lance `coverage` ; `task test-scripts` lance les assertions de Cléa.
+
+⚠️ GitHub désactive un workflow planifié après 60 jours sans activité sur le
+dépôt. Un Cléa silencieux est précisément le défaut dont parle cette page :
+vérifier la date de l'issue de rapport avant de lui faire confiance.

--- a/docs/clea.fr.md
+++ b/docs/clea.fr.md
@@ -80,8 +80,8 @@ supprime une branche dès que sa montée de version a atterri sur `main`.
 - **Un outil que ce dépôt n'épingle pas** n'a aucune version à laquelle se
   comparer : sa lane de mise à jour ne peut que rapporter ce qu'elle a trouvé.
   `talosctl`, `kubectl`, l'AWS CLI, shellcheck, yamllint, checkov et pre-commit
-  sont dans cet état — `docs/backlog.md` porte l'entrée, et les épingler est une
-  décision à part.
+  sont dans cet état, et les épingler est une décision à part — ouvrir une issue
+  pour qui la prend.
 
 ## Le lancer à la main
 

--- a/docs/clea.md
+++ b/docs/clea.md
@@ -73,10 +73,10 @@ landed on `main`.
 - **A Cilium or Flux bump** moves a pin whose *output* is committed. The lane
   re-renders before running the gates, so the probe branch carries both halves —
   but if the render fails, `task render-check` is what says so.
-- **helm and flux have no installer of their own**: they are steps inside
-  `scripts/setup.sh`, which checks whether a binary is present and not which
-  version it is. Their upgrade lane is expected to fail until that changes;
-  `docs/backlog.md` holds the entry.
+- **A tool this repository does not pin** has no version to compare against, so
+  its upgrade lane can only report what it found. `talosctl`, `kubectl`, the AWS
+  CLI, shellcheck, yamllint, checkov and pre-commit are all in that state —
+  `docs/backlog.md` holds the entry, and pinning them is a separate decision.
 
 ## Running it by hand
 

--- a/docs/clea.md
+++ b/docs/clea.md
@@ -33,6 +33,15 @@ dependency.
 | local cluster | weekly, Sunday 03:41 UTC | `task local-up` on the Talos and Kubernetes pair upstream publishes, then `task local-verify`, at 1 control plane + 1 worker |
 | real cloud | never | by hand, by someone watching — see [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
 
+The scan also asks when `renovate[bot]` last proposed anything. **That number
+alone means nothing** — a bot with nothing to propose is silent and correct. It
+becomes a signal only when crossed with what Cléa found: a dependency that is
+behind *and* that the bot's own inventory can see, with no proposal for days,
+means the bot is not running. That crossing went unmade here for three weeks:
+helm 4.2.4 was published 2026-08-13, the scheduled window of 2026-08-17 came and
+went, and nobody noticed until Cléa was written. `[report] watch_bot` and
+`silent_after_days` in `clea.toml` are the whole configuration.
+
 `.github/workflows/clea.yml` is the whole wiring. It carries no provider
 credential and must fail rather than acquire one.
 

--- a/docs/clea.md
+++ b/docs/clea.md
@@ -75,8 +75,8 @@ landed on `main`.
   but if the render fails, `task render-check` is what says so.
 - **A tool this repository does not pin** has no version to compare against, so
   its upgrade lane can only report what it found. `talosctl`, `kubectl`, the AWS
-  CLI, shellcheck, yamllint, checkov and pre-commit are all in that state —
-  `docs/backlog.md` holds the entry, and pinning them is a separate decision.
+  CLI, shellcheck, yamllint, checkov and pre-commit are all in that state, and
+  pinning them is a separate decision — open one if you take it.
 
 ## Running it by hand
 

--- a/docs/clea.md
+++ b/docs/clea.md
@@ -1,0 +1,81 @@
+# Cléa — what this repository pins, and whether the next version survives
+
+🇫🇷 [Version française](clea.fr.md)
+
+> The tool itself is documented where it lives:
+> [`scripts/clea/README.md`](../scripts/clea/README.md). This page is only about
+> how this repository uses it — what runs, when, and what a green report is
+> allowed to claim.
+
+## Why it exists
+
+Renovate proposes bumps here and never auto-merges them. Two things it does not
+do, and neither was covered by anything else:
+
+- **It cannot say what it is not watching.** Nine of this repository's twenty-one
+  version anchors were inert when Cléa was written: the comment was there, the
+  bot never read it, and nothing said so. `task lint` now fails on that.
+- **It does not install anything.** A bump that lands is a bump nobody watched
+  install. `scripts/dev/feint.sh` carries the evidence: the pin moved to 0.10.0
+  and every machine that had already run the lane kept 0.9.0, because presence
+  was checked and version was not.
+
+Cléa answers both, and reports daily. Renovate keeps proposing the bumps —
+`.github/dependabot.yml` records what happens when two bots fight over one
+dependency.
+
+## What runs, and when
+
+| lane | when | what it exercises |
+|---|---|---|
+| scan + coverage | daily, 04:17 UTC | every anchor read, resolved upstream, and compared against `renovate.json5` |
+| tool probes | daily | cold install and in-place upgrade of each tool that moved, in a bare `ubuntu:24.04`, then `task lint`, `task render-check`, `task test-scripts` on the bumped tree |
+| local cluster | weekly, Sunday 03:41 UTC | `task local-up` on the Talos and Kubernetes pair upstream publishes, then `task local-verify`, at 1 control plane + 1 worker |
+| real cloud | never | by hand, by someone watching — see [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
+
+`.github/workflows/clea.yml` is the whole wiring. It carries no provider
+credential and must fail rather than acquire one.
+
+## Where the report is
+
+One GitHub issue, labelled `clea`, **rewritten in place** every run — never a
+new one. Its body also holds the previous run's state, in an HTML comment at the
+end, which is how "this moved since yesterday" is computed without an artifact
+store.
+
+A probe pushes its branch `clea/probe/<dependency>` green **or** red: a red
+branch is the reproduction, and deleting it would leave a report describing
+something nobody can re-run. `clea prune` removes a branch once its bump has
+landed on `main`.
+
+## What a green report does not say
+
+- **Nothing here has ever touched a real cloud.** A deploy on Scaleway, OVH or
+  Outscale costs money and is run by hand.
+- **A green probe means the tool installs and upgrades, and the repository's own
+  checks still pass.** It does not mean the new version behaves the same on a
+  running cluster. For Talos and Kubernetes, that is what
+  [`upgrade.md`](upgrade.md) is for.
+- **The weekly lane proves a pair boots on Docker at 1 + 1**, with Cilium up. It
+  is not an HA test and it is not a rolling upgrade.
+
+## Two things that will go red on purpose
+
+- **A Cilium or Flux bump** moves a pin whose *output* is committed. The lane
+  re-renders before running the gates, so the probe branch carries both halves —
+  but if the render fails, `task render-check` is what says so.
+- **helm and flux have no installer of their own**: they are steps inside
+  `scripts/setup.sh`, which checks whether a binary is present and not which
+  version it is. Their upgrade lane is expected to fail until that changes;
+  `docs/backlog.md` holds the entry.
+
+## Running it by hand
+
+    task clea-scan                         # needs GITHUB_TOKEN
+    python3 scripts/clea/clea.py coverage  # offline, and part of task lint
+
+`task lint` runs `coverage`; `task test-scripts` runs Cléa's own assertions.
+
+⚠️ GitHub disables a scheduled workflow after 60 days with no activity on the
+repository. A silent Cléa is the failure this whole page is about: check the
+report issue's date before trusting it.

--- a/docs/status.md
+++ b/docs/status.md
@@ -52,9 +52,10 @@ every apply plans to a file and applies THAT file, and a saved plan never prompt
 Destroy always takes two commands and no flag collapses them. S3 credentials are
 namespaced by the cloud that HOLDS the bucket, and a cross-provider backup is
 proven — an encrypted tfstate at Outscale while the cluster runs on Scaleway.
-333 offline assertions across 11 harnesses, every one mutation-tested; the
-emulated lane runs feint 0.10.0 against Scaleway provider 2.81.0, the version the
-clusters run.
+406 offline assertions across 13 harnesses, every one mutation-tested — 330 of
+them from the eleven harnesses that existed before Cléa, three fewer than the
+333 this page claimed and nothing had re-counted since; the emulated lane runs
+feint 0.10.0 against Scaleway provider 2.81.0, the version the clusters run.
 
 **The root cause behind a week of upgrade failures is fixed**, and it was ours:
 the shared schematic shipped `siderolabs/qemu-guest-agent`, which never starts on
@@ -72,6 +73,33 @@ further LBU in that Net and use a new one — a redeploy on a fresh Net succeede
 on 2026-08-20, the new LBU `active` with 3 backends, and **request 399530 is
 closed**. One Net from before the fix still refuses deletion on a dependency no
 read returns; only Outscale can clear that, and a second request is open for it.
+
+**Dependency watch, since 2026-08-24.** Cléa (`scripts/clea/`, `docs/clea.md`)
+reads every version this repository claims, resolves what upstream published,
+and probes a bump by installing it from cold and upgrading over the old one in
+a bare container — daily for tools, weekly for the local Talos/Kubernetes pair,
+never for a cloud. Renovate keeps proposing the bumps; Cléa watches, probes and
+reports into one issue, rewritten in place.
+
+It found nine of twenty-one version anchors inert (Renovate had never been told
+to read them, now fixed), and that Renovate had proposed nothing since its
+config landed — its nine pull requests predate `renovate.json5` by three hours,
+and helm 4.2.4 (published 2026-08-13) and flux 2.9.4 (2026-08-07) both sat
+unproposed through their scheduled windows. The schedule is now daily; whether
+that alone was the cause is [#88](https://github.com/dis-bzh/OpenAether-infra/issues/88).
+
+Running it, on a workstation rather than only in CI, found five more defects
+that a green pipeline never showed: `command -v sudo` asking whether sudo
+*exists* rather than whether it can be *used* (eight sites); `install_tofu`
+preferring snap, which cannot install a named version; a tool's version
+assembled from two commands; the CoreDNS readiness gate failing on a cluster it
+had just watched come up; and the teardown proof printing nothing on a clean
+account, indistinguishable from a check that never ran. All five are fixed.
+
+**The local lane's pin mismatch is measured, not yet closed.** Talos `v1.13.9` /
+Kubernetes `v1.36.4` — upstream's current pair — boots on the Docker lane:
+`task local-verify` 6/6. The two roots still pin different versions, and no
+real cloud has run the newer pair — [#87](https://github.com/dis-bzh/OpenAether-infra/issues/87).
 
 **Not proven**: no lane has ever run unattended to completion; nobody has
 deployed under a non-empty `bucket_suffix`; and the failover — provider A treated

--- a/infrastructure/opentofu-local/variables.tf
+++ b/infrastructure/opentofu-local/variables.tf
@@ -8,13 +8,20 @@ variable "environment" {
   default = "dev"
 }
 
+# ⚠️ These two are BEHIND the cloud root (infrastructure/opentofu/cluster/
+# variables.tf), and nothing compared them until they were anchored: the
+# credential-free lane the README calls the best first step was exercising a
+# different Talos/Kubernetes pair than the one that ships. Anchored here so a
+# bot proposes the move and the weekly local lane is what proves it boots.
 variable "talos_version" {
-  type    = string
+  type = string
+  # renovate: datasource=github-releases depName=siderolabs/talos
   default = "v1.13.3"
 }
 
 variable "kubernetes_version" {
-  type    = string
+  type = string
+  # renovate: datasource=github-releases depName=kubernetes/kubernetes
   default = "v1.35.3"
 }
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,10 +5,17 @@
 // Native managers cover OpenTofu providers (`terraform`), CI pins
 // (`github-actions`) and pre-commit hook revs (`pre-commit`). Everything
 // else — Talos, Kubernetes, the OpenTofu CLI itself, Cilium, Flux — lives in
-// a bash var, a Taskfile default or a Terraform variable default, which
+// a bash var, a workflow env key or a Terraform variable default, which
 // Renovate can't see on its own. Those are tracked with the standard
 // `# renovate: datasource=... depName=...` anchor comment placed one line
 // above the value; see customManagers below.
+//
+// The three custom managers below match on the SHAPE of a value, not on the
+// names of the keys that hold it: nine anchors were once inert because their
+// file or their key had never been named here, and Renovate ignores an anchor
+// it was not told to read without saying anything. `clea coverage`
+// (scripts/clea/) now compares this file against every anchor in the tree and
+// fails on the difference — `task lint` runs it.
 //
 // GitHub Actions and pre-commit hooks are both pinned to a commit SHA (with
 // the tag kept as a trailing comment) rather than a mutable tag — a tag can
@@ -59,51 +66,28 @@
   customManagers: [
     {
       customType: "regex",
-      description: "Terraform variable defaults (talos_version, kubernetes_version) — the `terraform` manager only reads required_providers, not variable defaults.",
-      fileMatch: ["^infrastructure/opentofu/cluster/variables\\.tf$"],
+      description: "Terraform variable defaults — talos_version and kubernetes_version, in the cloud root AND in the local Docker lane. The `terraform` manager reads required_providers, never a variable default.",
+      managerFilePatterns: ["/^infrastructure/.*variables\\.tf$/"],
       matchStrings: [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*default\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
       ],
     },
     {
       customType: "regex",
-      description: "Taskfile.yml VERSION defaults (talos-image, up) — same Talos pin, kept in sync with cluster/variables.tf by this same tracker.",
-      fileMatch: ["^Taskfile\\.yml$"],
+      description: "Every version pinned in a shell script: VAR=\"x\", local VAR=\"x\", VAR=\"${VAR:-x}\". One manager for all of them, matched on the SHAPE. Four anchors — feint, task, tflint, kubectl-cnpg — sat in files no fileMatch named, and Renovate ignores an anchor it was not told to read, in silence. `clea coverage` now fails on that.",
+      managerFilePatterns: ["/^scripts/.*\\.sh$/"],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*VERSION: '\\{\\{\\.VERSION \\| default \"(?<currentValue>[^\"]+)\"\\}\\}'",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?(?: registryUrl=(?<registryUrl>\\S+))?\\s*\\n\\s*(?:local |export )?\\w+=\"\\$\\{\\w+:-(?<currentValue>[^}\"]+)\\}\"",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?(?: registryUrl=(?<registryUrl>\\S+))?\\s*\\n\\s*(?:local |export )?\\w+=\"(?<currentValue>[^\"$]+)\"",
       ],
     },
     {
       customType: "regex",
-      description: "render-bootstrap-manifests.sh: CILIUM_VERSION and FLUX_VERSION, bash `VAR=\"${VAR:-default}\"` form.",
-      fileMatch: ["^scripts/bootstrap/render-bootstrap-manifests\\.sh$"],
+      description: "Workflow values the github-actions manager cannot see: an action input, an env pin, a pip install. Matched on the shape rather than on named keys — GITLEAKS_VERSION and HELM_VERSION in ci.yml were invisible because only tofu_version and TALOS_VERSION had ever been named, and nothing said so.",
+      managerFilePatterns: ["/^\\.github/workflows/.*\\.ya?ml$/"],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: registryUrl=(?<registryUrl>\\S+))?\\s*\\n\\w+=\"\\$\\{\\w+:-(?<currentValue>[^}]+)\\}\"",
-      ],
-    },
-    {
-      customType: "regex",
-      description: "setup.sh install_flux(): the Flux CLI version for local dev, `local VAR=\"value\"` form (no leading v — extractVersion strips it from the fetched tag).",
-      fileMatch: ["^scripts/setup\\.sh$"],
-      matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*local \\w+=\"(?<currentValue>[^\"]+)\"",
-      ],
-    },
-    {
-      customType: "regex",
-      description: "ci.yml: values fed to CLI tools the github-actions manager can't see — the OpenTofu CLI version (opentofu/setup-opentofu's `with:` input) and talosctl (downloaded + checksum-verified directly in the talos job, not via an action).",
-      fileMatch: ["^\\.github/workflows/ci\\.yml$"],
-      matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*tofu_version:\\s*\"(?<currentValue>[^\"]+)\"",
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*TALOS_VERSION:\\s*\"(?<currentValue>[^\"]+)\"",
-      ],
-    },
-    {
-      customType: "regex",
-      description: "security.yml: gitleaks CLI, downloaded + checksum-verified directly — gitleaks/gitleaks-action requires a paid org license (dis-bzh is an org), so we run the (always free) CLI instead of the Action github-actions would have tracked.",
-      fileMatch: ["^\\.github/workflows/security\\.yml$"],
-      matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*GITLEAKS_VERSION:\\s*\"(?<currentValue>[^\"]+)\"",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*[\\w.-]+:\\s*\"(?<currentValue>[^\"]+)\"",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*run: pip install \\S+==(?<currentValue>\\S+)",
       ],
     },
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,8 +28,19 @@
   extends: ["config:recommended", "helpers:pinGitHubActionDigests"],
   automerge: false,
   platformAutomerge: false,
-  schedule: ["before 6am on monday"],
+  // Daily, not weekly. "before 6am on monday" is a six-hour window once a week
+  // — the narrowest useful schedule there is — and it was chosen to batch the
+  // noise. Cléa's daily report does that job now, so the weekly window bought
+  // nothing and cost a week of latency each time one was missed: helm 4.2.4
+  // was published 2026-08-13, the window of 2026-08-17 came and went, and no
+  // proposal ever arrived.
+  schedule: ["before 6am"],
   timezone: "Europe/Paris",
+  // Explicit, and it is the heartbeat. Issues were disabled on this repository
+  // until 2026-08-21, so Renovate had nowhere to report a configuration problem
+  // or its own state — three weeks of silence looked exactly like three weeks
+  // of nothing to do. If this issue does not appear, the App is not running.
+  dependencyDashboard: true,
   labels: ["dependencies"],
 
   "pre-commit": { enabled: true },

--- a/scripts/clea/README.md
+++ b/scripts/clea/README.md
@@ -1,0 +1,148 @@
+# Cléa
+
+Watch what a repository pins, and prove a bump before anyone merges it.
+
+Cléa answers three questions every day, and it answers them about **any**
+repository — it holds no knowledge of the project it runs in:
+
+1. **What has moved upstream** since the pins in this tree were written.
+2. **Is anything pinned that nothing watches** — an anchor a bot cannot read is
+   a pin nobody will ever bump, and it looks exactly like a healthy one.
+3. **Does the bump survive** being installed from cold, and being upgraded over
+   the version that was already there.
+
+It does **not** open bump pull requests. Renovate or Dependabot already do that,
+and two bots proposing the same bump is a collision worth avoiding. Cléa
+watches, probes, and reports.
+
+## Dropping it into another repository
+
+Copy `scripts/clea/`, write a `clea.toml`, and wire the workflow. Python 3.11 or
+newer, standard library only — no `pip install` anywhere in the path, which is
+what lets the probes run inside a bare container.
+
+```
+scripts/clea/clea.py      the engine
+scripts/clea/probe.sh     the two container lanes
+clea.toml                 the only file that knows about your project
+```
+
+## The inventory is the tree
+
+Cléa reads the same anchor comment Renovate does:
+
+```bash
+# renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.*)$
+TASK_VERSION="3.52.0"
+```
+
+One convention, not two. A second inventory is a second thing to drift.
+
+The difference is what happens to a shape nobody declared. Renovate asks you to
+write a regex per file and silently ignores any anchor no regex reaches. Cléa
+**recognises** a fixed set of value shapes and **fails** on an anchor it cannot
+read, or on one whose value is not version-shaped at all:
+
+| shape | example |
+|---|---|
+| `bash` | `TASK_VERSION="3.52.0"`, `local HELM_VERSION="4.2.3"` |
+| `bash-default` | `CILIUM_VERSION="${CILIUM_VERSION:-1.20.0}"` |
+| `hcl-default` | `default = "v1.13.9"` |
+| `yaml` | `GITLEAKS_VERSION: "8.30.1"`, `tofu_version: "1.12.5"` |
+| `pip` | `run: pip install commitizen==4.9.1` |
+| `task-default` | `V: '{{.V \| default "1.2.3"}}'` |
+| `precommit-rev` | `rev: <sha>  # v4.9.1` |
+| `action-sha` | `uses: owner/action@<sha>  # v7` |
+
+Because Cléa's list is a superset of what any one declared inventory reaches,
+the difference between the two **is** the set of pins nothing is watching. That
+is `clea coverage`, and it is the check worth having even if you run nothing
+else here.
+
+The marker is configurable (`[scan] marker`), and it has to be: Cléa's own test
+fixtures carry anchors, so a hard-coded word makes the scanner report its own
+fixtures as dependencies of the repository under test.
+
+## Commands
+
+| command | needs the network | what it does |
+|---|---|---|
+| `clea coverage` | no | every anchor readable, and seen by every declared inventory. Exits 1 otherwise. Put it in your lint target. |
+| `clea scan` | yes | resolve the newest upstream version of everything; write `clea-state.json`. |
+| `clea matrix` | no | what the probe lanes should run, as a GitHub Actions matrix. |
+| `clea bump <dep> <version>` | no | rewrite the pin, at **every** site, by the exact inverse of the reader. Exits 1 if nothing changed. |
+| `clea report` | no | render Markdown, with the state embedded in an HTML comment at the end. |
+| `clea prune` | no | name the probe branches whose bump has already landed. |
+
+Datasources: `github-releases`, `github-tags`, `pypi`, `helm`,
+`terraform-provider`, and `url-text` for a tool installed from a moving target
+such as `https://dl.k8s.io/release/stable.txt`.
+
+## Two rules it will not bend
+
+**Zero floor.** An extractor that matched nothing, a datasource that returned no
+version, a tree with no anchors: all exit 1. A green run that checked nothing is
+worse than no check, because it reads as an answer.
+
+**Loud on rate limits.** Unauthenticated, the GitHub API allows 60 requests an
+hour from an IP shared with every other customer of the platform. A 401, 403 or
+429 raises and names `GITHUB_TOKEN`; it is never reported as "up to date".
+
+## The probe
+
+`probe.sh` runs two lanes in a bare `ubuntu:24.04`, never on the runner image —
+a machine that already carries the tool hides the defect.
+
+- **Cold install.** Bump first, run the installer once, assert the version.
+- **Upgrade in place.** Install at the *current* pin, bump, run the installer
+  again, assert the *new* version.
+
+The second lane is the one that finds things. An installer that checks whether
+the binary exists, rather than which version it is, installs correctly on a
+fresh machine and refuses every upgrade afterwards — silently, on every machine
+that has already run it once.
+
+Only `curl` and `ca-certificates` are added to the container. Anything else the
+installer needs and does not install is a finding, not a prerequisite to paper
+over.
+
+## Configuration
+
+```toml
+[scan]
+marker = "# renovate:"          # share the bot's anchors, or use your own
+exclude = ["docs/**"]
+
+[report]
+title = "Cléa — dependency report"
+label = "clea"
+
+[[inventory]]                   # what to cross-check against
+kind = "renovate"
+config = "renovate.json5"
+exclude = ["renovate.json5"]    # its own matchStrings quote the anchor verbatim
+
+[[tool]]                        # both probe lanes are derived from these three
+name = "go-task/task"           # fields; the engine needs nothing else
+installer = "scripts/internal/install-task.sh"
+version_cmd = "task --version"
+daily = true                    # false: weekly, for an installer that is slow
+
+[[unpinned]]                    # consumed at whatever upstream serves today
+name = "kubernetes/kubernetes"
+datasource = "url-text"
+url = "https://dl.k8s.io/release/stable.txt"
+extract = "^(?P<v>v[0-9][0-9A-Za-z.-]*)$"
+consumed_by = "scripts/setup.sh (install_kubectl)"
+
+[lane]
+regen = ["./scripts/render.sh"] # after the bump, before the gates
+repo  = ["task lint"]           # the gates, on the bumped tree
+```
+
+## Its own assertions
+
+`scripts/dev/test-clea.sh` — offline, on synthetic fixtures, and every check has
+a twin that must fail: a reader that matches nothing, a writer that writes
+nothing, a datasource that answers 403, a comparator that would put 1.13.9 above
+1.13.10. A check only ever seen to pass is a check nobody has tested.

--- a/scripts/clea/README.md
+++ b/scripts/clea/README.md
@@ -106,6 +106,12 @@ Only `curl` and `ca-certificates` are added to the container. Anything else the
 installer needs and does not install is a finding, not a prerequisite to paper
 over.
 
+Set `CLEA_CA_BUNDLE` to a PEM wherever TLS is intercepted — a corporate proxy,
+or a sandbox. Without it every download inside the container fails with
+`self-signed certificate in certificate chain`, and the probe reports red for a
+reason that is not the bump. A bundle that cannot be read is refused rather than
+ignored, for the same reason.
+
 ## Configuration
 
 ```toml

--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -437,7 +437,7 @@ def http_get(url: str, token: str | None = None, accept: str | None = None) -> b
     except urllib.error.HTTPError as exc:
         body = ""
         try:
-            body = exc.read().decode("utf-8", "replace")[:400]
+            body = exc.read().decode("utf-8", "replace")[:200]
         except Exception:  # pragma: no cover - the status alone is enough
             pass
         if exc.code in (401, 403, 429):
@@ -494,31 +494,53 @@ def latest_helm(dep: str, _token: str | None, registry_url: str | None = None, *
     """Newest chart version in a Helm repository index.
 
     Line-scanned rather than YAML-parsed: PyYAML is not in the standard library
-    and this file refuses a dependency for one field.
+    and this file refuses a dependency for one field. That makes INDENT the only
+    structure available, and it has to be used — cilium's index is 1.7 MB and
+    embeds Kubernetes CRD listings inside an annotation, where `version: v2`
+    appears at depth 10. Reading every `version:` line collected 1673 of those
+    against 651 real ones, and `v2` outranks every 1.x, so the answer was v2.
+    Two guards, both needed: the key must sit at the chart item's own indent,
+    and a chart version is semver, which mandates MAJOR.MINOR.PATCH.
     """
     if not registry_url:
         raise CleaError(f"helm {dep}: no registryUrl on the anchor")
     text = http_get(registry_url.rstrip("/") + "/index.yaml").decode("utf-8", "replace")
+    semver = re.compile(r"(?:-\s+)?version:\s*[\"']?(\d+\.\d+\.\d+[0-9A-Za-z.+-]*)[\"']?$")
     versions: list[str] = []
     entry_indent: int | None = None
+    item_indent: int | None = None
+    key_indent: int | None = None
     inside = False
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
         indent = len(line) - len(line.lstrip())
-        if re.match(rf"^{re.escape(dep)}:\s*$", stripped) and not inside:
-            inside, entry_indent = True, indent
+        if not inside:
+            if re.match(rf"^{re.escape(dep)}:\s*$", stripped):
+                inside, entry_indent = True, indent
             continue
-        if inside:
-            if indent <= entry_indent and not stripped.startswith("-"):
-                break
-            m = re.match(r"-?\s*version:\s*\"?([^\"\s]+)\"?$", stripped)
-            if m:
-                versions.append(m.group(1))
+        if indent <= entry_indent and not stripped.startswith("-"):
+            break
+        # Locked on the FIRST list item and never moved: the annotations block
+        # inside a chart entry contains its own `- ` items at greater depth, and
+        # following those re-based the whole scan below the real keys — which is
+        # how 1.8.13 came back as the newest chart of a repository serving 1.20.
+        dashed = stripped.startswith("- ")
+        if dashed and item_indent is None:
+            item_indent, key_indent = indent, indent + 2
+        if key_indent is None:
+            key_indent = entry_indent + 2
+        if dashed and indent != item_indent:
+            continue
+        if (indent + 2 if dashed else indent) != key_indent:
+            continue
+        m = semver.match(stripped)
+        if m:
+            versions.append(m.group(1))
     versions = [v for v in versions if not is_prerelease(v)]
     if not versions:
-        raise CleaError(f"helm {dep}: no version under entries in {registry_url}")
+        raise CleaError(f"helm {dep}: no chart version under entries in {registry_url}")
     tag = max(versions, key=version_key)
     return {"tag": tag, "released_at": None, "notes_url": registry_url}
 
@@ -677,6 +699,16 @@ def _load_previous(path: str | None) -> dict:
         return {}
 
 
+def mark_movement(entry: dict, previous: dict[str, dict]) -> dict:
+    """Did upstream move since the last scan? Keyed on dependency AND file, so
+    the same tool pinned in two places is two rows, which is how a drift between
+    them shows up at all."""
+    was = previous.get(entry["dep"] + "@" + entry["file"], {})
+    entry["moved_since_last_scan"] = bool(
+        was.get("latest") and entry.get("latest") and was["latest"] != entry["latest"])
+    return entry
+
+
 def cmd_scan(args) -> int:
     root = repo_root(args.root)
     cfg = load_config(root / args.config)
@@ -738,10 +770,7 @@ def cmd_scan(args) -> int:
         tool = next((t for t in cfg["tool"] if t["name"] == anchor.dep), None)
         if tool:
             entry["tool"] = tool
-        was = prev_by_key.get(entry["dep"] + "@" + entry["file"], {})
-        entry["moved_since_last_scan"] = bool(
-            was.get("latest") and entry.get("latest") and was["latest"] != entry["latest"])
-        deps.append(entry)
+        deps.append(mark_movement(entry, prev_by_key))
 
     for item in cfg["unpinned"]:
         entry = {"dep": item["name"], "datasource": item["datasource"],
@@ -756,10 +785,7 @@ def cmd_scan(args) -> int:
         except CleaError as exc:
             entry.update(latest=None, error=str(exc), behind=False)
             errors.append(str(exc))
-        was = prev_by_key.get(entry["dep"] + "@" + entry["file"], {})
-        entry["moved_since_last_scan"] = bool(
-            was.get("latest") and entry.get("latest") and was["latest"] != entry["latest"])
-        deps.append(entry)
+        deps.append(mark_movement(entry, prev_by_key))
 
     state = {
         "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
@@ -767,7 +793,9 @@ def cmd_scan(args) -> int:
         "novalue": [{"dep": a.dep, "file": a.path, "line": a.line,
                      "reason": a.reason} for a in novalue],
         "unwatched": [],
-        "errors": errors,
+        # Deduplicated: one rate limit fails once per anchor, and the state is
+        # carried in an issue body with a hard size limit.
+        "errors": list(dict.fromkeys(errors)),
         "probes": previous.get("probes", []),
     }
 
@@ -788,11 +816,12 @@ def cmd_scan(args) -> int:
     Path(args.state).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
     behind = [d for d in deps if d.get("behind")]
     print(f"{len(deps)} dependencies, {len(behind)} behind, "
-          f"{len(state['unwatched'])} unwatched, {len(errors)} error(s)")
+          f"{len(state['unwatched'])} unwatched, "
+          f"{len(state['errors'])} distinct error(s)")
 
     # A datasource that answered nothing is not a dependency that is up to date.
-    if errors and args.strict:
-        for message in errors:
+    if state["errors"] and args.strict:
+        for message in state["errors"]:
             print(f"  ✗ {message}", file=sys.stderr)
         return 1
     return 0
@@ -930,9 +959,23 @@ def render_report(state: dict) -> str:
                       "```", probe.get("log", "(no log captured)").strip(), "```", ""]
 
     if state.get("errors"):
+        # Grouped on the message with its URL removed: one rate limit produces
+        # one failure per dependency, and twenty copies of the same sentence is
+        # not twenty pieces of information.
+        grouped: dict[str, list[str]] = {}
+        for message in state["errors"]:
+            url, _, rest = message.partition(" -> ")
+            grouped.setdefault(rest or message, []).append(url)
         lines += ["## Datasources that did not answer", "",
                   "Not the same thing as up to date:", ""]
-        lines += [f"- {e}" for e in state["errors"]] + [""]
+        for message, urls in list(grouped.items())[:8]:
+            names = list(dict.fromkeys(u.rsplit("/repos/", 1)[-1] for u in urls))
+            shown = ", ".join(f"`{n}`" for n in names[:6])
+            more = f" and {len(names) - 6} more" if len(names) > 6 else ""
+            lines += [f"- **{len(names)}×** {message}", f"  — {shown}{more}"]
+        if len(grouped) > 8:
+            lines += [f"- …and {len(grouped) - 8} other failure(s)"]
+        lines += [""]
 
     lines += ["## What this did not test", "",
               "- **No real cloud, ever.** This lane carries no provider credential and "
@@ -949,7 +992,16 @@ def render_report(state: dict) -> str:
     else:
         lines += ["- The weekly local cluster lane has not reported yet."]
 
-    lines += ["", "<!-- clea-state " + json.dumps(state, separators=(",", ":")) + " -->"]
+    # A GitHub issue body caps at 65536 characters. The probe logs are already
+    # rendered above, so they are the first thing to drop from the copy carried
+    # forward — a state that makes the write fail loses the state entirely.
+    embedded = json.dumps(state, separators=(",", ":"))
+    if len(embedded) > 40000:
+        trimmed = dict(state)
+        trimmed["probes"] = [{k: v for k, v in p.items() if k != "log"}
+                             for p in state.get("probes", [])]
+        embedded = json.dumps(trimmed, separators=(",", ":"))
+    lines += ["", "<!-- clea-state " + embedded + " -->"]
     return "\n".join(lines) + "\n"
 
 

--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -784,7 +784,13 @@ def cmd_scan(args) -> int:
             upstream = resolve(anchor.datasource, anchor.dep,
                                registry_url=anchor.attrs.get("registryUrl"))
             latest = apply_extract(upstream["tag"], anchor.attrs.get("extractVersion"))
-            entry.update(latest=latest, released_at=upstream.get("released_at"),
+            # The RAW tag is kept beside the extracted one. `bump` re-applies
+            # extractVersion per site, so it must be handed the tag: this
+            # repository pins fluxcd/flux2 as `v2.9.3` where the value builds a
+            # release URL and as `2.9.3` where it builds a filename, and only
+            # the tag can become both.
+            entry.update(tag=upstream["tag"],
+                         latest=latest, released_at=upstream.get("released_at"),
                          notes_url=upstream.get("notes_url"),
                          behind=is_newer(anchor.value, latest),
                          shape_ok=same_shape(anchor.value, latest))
@@ -922,7 +928,12 @@ def cmd_matrix(args) -> int:
             continue
         seen[key] = {
             "dep": key,
-            "version": dep["latest"],
+            # The tag, not one anchor's extracted form. Deduplicating by
+            # dependency kept whichever file sorted first, so a dependency
+            # pinned in two shapes was bumped with the shape of whichever
+            # happened to come first — right by luck here, wrong the moment a
+            # path changed.
+            "version": dep.get("tag") or dep["latest"],
             "slug": slugify(key),
             "installer": tool.get("installer", ""),
             "version_cmd": tool.get("version_cmd", ""),

--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -1,0 +1,1105 @@
+#!/usr/bin/env python3
+"""Cléa — watch what a repository pins, and prove a bump before anyone merges it.
+
+Generic on purpose: this file knows nothing about the repository it runs in.
+Everything specific arrives through `clea.toml` and through the host repository's
+own commands. Dropping it into another project is copying this directory and
+writing a new `clea.toml`.
+
+Standard library only — no `pip install` anywhere in the path, so it also runs
+inside the bare container the probe lanes use.
+
+Commands
+--------
+  coverage   offline. Every version anchor in the tree must be readable, and
+             seen by every inventory declared in clea.toml. Exits 1 otherwise.
+  scan       online. Resolve the latest upstream version of every dependency and
+             write the state file plus a Markdown report.
+  bump       rewrite one pin in place, by the exact inverse of the reader.
+  report     render Markdown from a state file.
+  prune      name the probe branches whose pin already landed on the base branch.
+
+The two rules this file will not bend
+-------------------------------------
+* **Zero floor.** An extractor that matches nothing, a datasource that returns
+  no version, a tree with no anchors: all exit 1. A green run that checked
+  nothing is worse than no check, and it is the shape this repository keeps
+  meeting.
+* **Loud on rate limits.** An unauthenticated GitHub API call gets 60 requests
+  an hour from a shared runner IP, which is what took a `main` branch red once
+  here. A 401/403/429 is an error, never "no new version".
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - only on very old interpreters
+    print("clea needs Python 3.11 or newer (tomllib)", file=sys.stderr)
+    raise SystemExit(1)
+
+USER_AGENT = "clea/1 (+https://github.com/dis-bzh/OpenAether-infra)"
+SKIP_DIRS = {".git", "node_modules", ".terraform", ".terraform-validate", "vendor"}
+
+
+class CleaError(Exception):
+    """Anything that must stop the run rather than degrade into a green report."""
+
+
+# ---------------------------------------------------------------------------
+# JSON5, enough of it to read a Renovate config
+# ---------------------------------------------------------------------------
+# Renovate's own file is JSON5: comments, bare keys, single quotes, trailing
+# commas. Parsing it matters because it is one of the inventories `coverage`
+# compares against, and a parse that silently yields nothing would mark every
+# anchor in the tree as unwatched — noise, which is how a checker gets muted.
+# So this raises instead.
+
+_J5_TOKEN = re.compile(
+    r"""
+      "(?:\\.|[^"\\])*"      # double-quoted string
+    | '(?:\\.|[^'\\])*'      # single-quoted string
+    | //[^\n]*               # line comment
+    | /\*.*?\*/              # block comment
+    | [\s\S]                 # anything else, one character
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _requote(tok: str) -> str:
+    """A single-quoted JSON5 string as a double-quoted JSON one."""
+    body = tok[1:-1]
+    out, i = [], 0
+    while i < len(body):
+        c = body[i]
+        if c == "\\" and i + 1 < len(body):
+            nxt = body[i + 1]
+            out.append(nxt if nxt == "'" else c + nxt)
+            i += 2
+            continue
+        out.append('\\"' if c == '"' else c)
+        i += 1
+    return '"' + "".join(out) + '"'
+
+
+def json5_to_json(text: str) -> str:
+    """Rewrite JSON5 as JSON, leaving string contents untouched.
+
+    Comments become a space so the characters around them stay in one run —
+    otherwise a key introduced by `{` on one line and commented on the next
+    would lose the `{` that identifies it as a key.
+    """
+    parts: list[str] = []
+    run: list[str] = []
+
+    def flush() -> None:
+        if not run:
+            return
+        chunk = "".join(run)
+        # bare keys -> quoted keys
+        chunk = re.sub(r"([{,]\s*)([A-Za-z_$][\w$-]*)(\s*):", r'\1"\2"\3:', chunk)
+        # trailing commas
+        chunk = re.sub(r",(\s*[}\]])", r"\1", chunk)
+        parts.append(chunk)
+        run.clear()
+
+    for m in _J5_TOKEN.finditer(text):
+        tok = m.group(0)
+        if tok.startswith("//") or tok.startswith("/*"):
+            run.append(" ")
+        elif tok.startswith('"'):
+            flush()
+            parts.append(tok)
+        elif tok.startswith("'"):
+            flush()
+            parts.append(_requote(tok))
+        else:
+            run.append(tok)
+    flush()
+    return "".join(parts)
+
+
+def load_json5(path: Path) -> dict:
+    try:
+        return json.loads(json5_to_json(path.read_text(encoding="utf-8")))
+    except (OSError, ValueError) as exc:
+        raise CleaError(f"cannot read {path} as JSON5: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Anchors
+# ---------------------------------------------------------------------------
+# The inventory is the tree itself: the same `# renovate: datasource=… depName=…`
+# comment Renovate reads, with the pinned value on one of the lines below it.
+# One convention, not two — a second inventory is a second thing to drift.
+#
+# Where Renovate asks you to DECLARE the shape of the value (and ignores in
+# silence anything you forgot to declare), Cléa RECOGNISES a fixed set of shapes
+# and fails on one it cannot read. That difference is the whole point of
+# `coverage`: Cléa's list is a superset, so what it sees and Renovate does not
+# is exactly the set of pins nothing is watching.
+
+# Built from the configured marker rather than hard-coded, and not only for
+# other repositories: Cléa's own test fixtures carry anchors, so a hard-coded
+# word makes the scanner find them and report acme/one as an unwatched
+# dependency of this repository. A detector that matches its own fixtures is the
+# defect this file is written against — silencing it by path would have hidden
+# it instead of removing it.
+def anchor_re(marker: str) -> re.Pattern[str]:
+    token = marker.strip().lstrip("#/ ").rstrip(":").strip()
+    if not token:
+        raise CleaError("clea.toml: [scan] marker is empty")
+    return re.compile(rf"^\s*(?:#|//)\s*{re.escape(token)}:\s*(?P<attrs>.*\S)\s*$")
+
+
+ATTR_RE = re.compile(r"(\w+)=(\S+)")
+
+# Ordered: the first form that matches the line wins, so the more specific
+# shapes come first. `task-default` before the YAML forms, or a Taskfile's
+# `KEY: '{{.KEY | default "1.2.3"}}'` reads back as the whole template.
+VALUE_FORMS: list[tuple[str, re.Pattern[str]]] = [
+    ("task-default", re.compile(r"\|\s*default\s+\"(?P<v>[^\"]+)\"")),
+    ("bash-default", re.compile(
+        r"^\s*(?:local\s+|export\s+)?[A-Za-z_]\w*=\"\$\{[A-Za-z_]\w*:-(?P<v>[^}\"]+)\}\"")),
+    ("bash", re.compile(r"^\s*(?:local\s+|export\s+)?[A-Za-z_]\w*=\"(?P<v>[^\"]+)\"")),
+    ("hcl-default", re.compile(r"^\s*default\s*=\s*\"(?P<v>[^\"]+)\"")),
+    ("pip", re.compile(r"pip install\s+[A-Za-z0-9_.\-\[\]]+==(?P<v>[^\s\"']+)")),
+    ("precommit-rev", re.compile(r"^\s*rev:\s*\S+\s*#\s*(?P<v>\S+)")),
+    ("yaml-dq", re.compile(r"^\s*[A-Za-z_][\w.\-]*:\s*\"(?P<v>[^\"]+)\"")),
+    ("yaml-sq", re.compile(r"^\s*[A-Za-z_][\w.\-]*:\s*'(?P<v>[^']+)'")),
+    ("action-sha", re.compile(r"^\s*(?:-\s*)?uses:\s*\S+@\S+\s*#\s*(?P<v>\S+)")),
+]
+
+# How far below the anchor the value may sit. Renovate's own regexes allow one
+# line; three covers a YAML `env:` key that opens its block on the next line.
+VALUE_WINDOW = 3
+
+# What a version is allowed to look like. Without this the YAML form reads a
+# Taskfile's `KEY: '{{.VERSION | default .PINNED}}'` back as the version itself,
+# and the anchor looks healthy while marking a template. A form that matches is
+# not the same as a value that means something.
+VERSION_LIKE = re.compile(r"^v?\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.+-]+)?$")
+
+
+class Anchor:
+    __slots__ = ("path", "line", "attrs", "value", "value_line", "form", "span",
+                 "reason")
+
+    def __init__(self, path: str, line: int, attrs: dict[str, str]) -> None:
+        self.path = path
+        self.line = line
+        self.attrs = attrs
+        self.value: str | None = None
+        self.value_line: int | None = None
+        self.form: str | None = None
+        self.span: tuple[int, int] | None = None  # column span of the value
+        self.reason: str = ""
+
+    @property
+    def dep(self) -> str:
+        return self.attrs.get("depName", "?")
+
+    @property
+    def datasource(self) -> str:
+        return self.attrs.get("datasource", "?")
+
+    @property
+    def key(self) -> tuple[str, int]:
+        return (self.path, self.line)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<Anchor {self.path}:{self.line} {self.dep}={self.value}>"
+
+
+def _read_value(lines: list[str], start: int):
+    """First recognised version in the window under the anchor at index `start`.
+
+    Returns (value, line, form, span) or (None, reason) — the reason names what
+    was read instead, because "no value here" and "this line reads
+    `{{.VERSION | default .PINNED}}`" send a reader to two different places.
+    """
+    rejected: list[str] = []
+    for offset in range(1, VALUE_WINDOW + 1):
+        idx = start + offset
+        if idx >= len(lines):
+            break
+        line = lines[idx]
+        if not line.strip():
+            continue
+        for form, pattern in VALUE_FORMS:
+            m = pattern.search(line)
+            if not m:
+                continue
+            value = m.group("v")
+            if VERSION_LIKE.match(value):
+                return value, idx + 1, form, m.span("v")
+            rejected.append(f"line {idx + 1} reads {value!r} ({form}), which is not a version")
+    return None, ("; ".join(rejected) if rejected
+                  else f"nothing version-shaped in the {VALUE_WINDOW} lines below")
+
+
+def _walk(root: Path, include: list[str], exclude: list[str]):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for name in filenames:
+            full = Path(dirpath) / name
+            rel = full.relative_to(root).as_posix()
+            if any(fnmatch.fnmatch(rel, pat) for pat in exclude):
+                continue
+            if include and not any(fnmatch.fnmatch(rel, pat) for pat in include):
+                continue
+            yield rel, full
+
+
+def scan_anchors(root: Path, marker: str, exclude: list[str],
+                 include: list[str] | None = None) -> tuple[list[Anchor], list[Anchor]]:
+    """Every anchor in the tree, split into readable and value-less.
+
+    A value-less anchor is not a warning. It marks a version that is not there —
+    a leftover from when the value was a literal, or a pin that moved elsewhere
+    — so it can never be bumped and reads to a human as if it could.
+    """
+    found: list[Anchor] = []
+    novalue: list[Anchor] = []
+    pattern = anchor_re(marker)
+    token = marker.strip().lstrip("#/ ").rstrip(":").strip()
+    for rel, full in _walk(root, include or [], exclude):
+        try:
+            text = full.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if token not in text:
+            continue
+        lines = text.splitlines()
+        # An anchor inside a fenced block of a Markdown file is an EXAMPLE, not
+        # a pin — the same rule check-language.sh applies to prose. Without it
+        # Cléa reports the anchor in its own README as an unwatched dependency
+        # of the repository, which is the class of defect it exists to find.
+        markdown = rel.endswith((".md", ".markdown"))
+        fenced = False
+        for i, line in enumerate(lines):
+            if markdown and line.lstrip().startswith(("```", "~~~")):
+                fenced = not fenced
+                continue
+            if fenced:
+                continue
+            m = pattern.match(line)
+            if not m:
+                continue
+            attrs = dict(ATTR_RE.findall(m.group("attrs")))
+            if "depName" not in attrs:
+                continue
+            anchor = Anchor(rel, i + 1, attrs)
+            got = _read_value(lines, i)
+            if got[0] is None:
+                anchor.reason = got[1]
+                novalue.append(anchor)
+                continue
+            anchor.value, anchor.value_line, anchor.form, anchor.span = got
+            found.append(anchor)
+    found.sort(key=lambda a: a.key)
+    novalue.sort(key=lambda a: a.key)
+    return found, novalue
+
+
+# ---------------------------------------------------------------------------
+# Inventories to cross-check against
+# ---------------------------------------------------------------------------
+
+def _file_matcher(pattern: str):
+    """Renovate's managerFilePatterns rule: /…/ is a regex, anything else a glob."""
+    if len(pattern) > 1 and pattern.startswith("/") and pattern.endswith("/"):
+        compiled = re.compile(pattern[1:-1])
+        return compiled.search
+    return lambda rel: fnmatch.fnmatch(rel, pattern)
+
+
+def renovate_coverage(root: Path, config: str, exclude: list[str]) -> set[tuple[str, int]]:
+    """Anchor positions a Renovate config's customManagers can actually reach.
+
+    Its own `matchStrings` contain the anchor text verbatim, so the config file
+    has to be excluded from the scan or it matches itself and reports a dozen
+    anchors that do not exist.
+    """
+    cfg = load_json5(root / config)
+    managers = cfg.get("customManagers", [])
+    if not managers:
+        raise CleaError(
+            f"{config} declares no customManagers — either the inventory is wrong "
+            "or this repository does not use Renovate; say so in clea.toml"
+        )
+    covered: set[tuple[str, int]] = set()
+    for manager in managers:
+        # Renovate renamed fileMatch to managerFilePatterns, and the two are not
+        # spelled the same: fileMatch was always a regex, while a
+        # managerFilePatterns entry is a regex only when it is delimited by
+        # slashes and a glob otherwise. Reading a glob as a regex matches almost
+        # nothing and would report every anchor as unwatched.
+        modern = manager.get("managerFilePatterns")
+        matchers = ([_file_matcher(p) for p in modern] if modern
+                    else [_file_matcher("/%s/" % p) for p in manager.get("fileMatch", [])])
+        for rel, full in _walk(root, [], exclude + [config]):
+            if not any(match(rel) for match in matchers):
+                continue
+            try:
+                text = full.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            for match_string in manager.get("matchStrings", []):
+                # Renovate uses JavaScript named groups; Python spells them (?P<…>).
+                pattern = match_string.replace("(?<", "(?P<")
+                try:
+                    rx = re.compile(pattern, re.MULTILINE)
+                except re.error as exc:
+                    raise CleaError(f"{config}: unusable matchString {match_string!r}: {exc}")
+                for m in rx.finditer(text):
+                    covered.add((rel, text[: m.start()].count("\n") + 1))
+    return covered
+
+
+# ---------------------------------------------------------------------------
+# Versions
+# ---------------------------------------------------------------------------
+
+_NUM = re.compile(r"\d+")
+
+
+def version_key(value: str) -> tuple:
+    """Sortable key. Numeric segments compare as numbers, so 1.13.10 > 1.13.9.
+
+    A string comparison gets that pair backwards, which is the one version bug
+    every hand-rolled comparator ships with.
+    """
+    core, _, pre = value.lstrip("vV").partition("-")
+    parts: list[int] = []
+    for chunk in core.split("."):
+        m = _NUM.match(chunk)
+        parts.append(int(m.group(0)) if m else 0)
+    # A release outranks any prerelease of the same number: (1,) beats (0, …).
+    return (tuple(parts), (1,) if not pre else (0, pre))
+
+
+def is_prerelease(value: str) -> bool:
+    return bool(re.search(r"-(?:alpha|beta|rc|pre|dev|next)", value, re.I))
+
+
+def is_newer(current: str, candidate: str) -> bool:
+    return version_key(candidate) > version_key(current)
+
+
+def same_shape(current: str, candidate: str) -> bool:
+    """Both carry a leading v, or neither does.
+
+    Writing `v1.2.3` where `1.2.3` was expected is how a pin becomes a download
+    URL that 404s, and every consumer of that value reads it differently.
+    """
+    return current.startswith("v") == candidate.startswith("v")
+
+
+def apply_extract(tag: str, extract_version: str | None) -> str:
+    if not extract_version:
+        return tag
+    rx = re.compile(extract_version.replace("(?<", "(?P<"))
+    m = rx.search(tag)
+    if not m:
+        return tag
+    if "version" in rx.groupindex:
+        return m.group("version")
+    return m.group(1) if rx.groups else m.group(0)
+
+
+# ---------------------------------------------------------------------------
+# Datasources
+# ---------------------------------------------------------------------------
+
+def http_get(url: str, token: str | None = None, accept: str | None = None) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    if accept:
+        request.add_header("Accept", accept)
+    if token and urllib.parse.urlparse(url).hostname == "api.github.com":
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read().decode("utf-8", "replace")[:400]
+        except Exception:  # pragma: no cover - the status alone is enough
+            pass
+        if exc.code in (401, 403, 429):
+            # Never let this read as "no new version". Unauthenticated GitHub
+            # allows 60 requests an hour from an IP shared with every other
+            # runner, and a silent 403 here is a report that says all is well.
+            raise CleaError(
+                f"{url} -> HTTP {exc.code}. Rate limited or unauthorised — export "
+                f"GITHUB_TOKEN. Body: {body}"
+            ) from exc
+        raise CleaError(f"{url} -> HTTP {exc.code}: {body}") from exc
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise CleaError(f"{url} -> {exc}") from exc
+
+
+def _gh_json(path: str, token: str | None):
+    raw = http_get(f"https://api.github.com{path}", token,
+                   accept="application/vnd.github+json")
+    return json.loads(raw)
+
+
+def latest_github_releases(dep: str, token: str | None, **_) -> dict:
+    data = _gh_json(f"/repos/{dep}/releases/latest", token)
+    tag = data.get("tag_name")
+    if not tag:
+        raise CleaError(f"github-releases {dep}: no tag_name in the answer")
+    return {
+        "tag": tag,
+        "released_at": data.get("published_at"),
+        "notes_url": data.get("html_url"),
+    }
+
+
+def latest_github_tags(dep: str, token: str | None, **_) -> dict:
+    data = _gh_json(f"/repos/{dep}/tags?per_page=100", token)
+    tags = [t["name"] for t in data if not is_prerelease(t["name"])]
+    if not tags:
+        raise CleaError(f"github-tags {dep}: no usable tag")
+    tag = max(tags, key=version_key)
+    return {"tag": tag, "released_at": None,
+            "notes_url": f"https://github.com/{dep}/releases/tag/{tag}"}
+
+
+def latest_pypi(dep: str, _token: str | None, **_) -> dict:
+    data = json.loads(http_get(f"https://pypi.org/pypi/{dep}/json"))
+    version = data.get("info", {}).get("version")
+    if not version:
+        raise CleaError(f"pypi {dep}: no info.version")
+    return {"tag": version, "released_at": None,
+            "notes_url": f"https://pypi.org/project/{dep}/{version}/"}
+
+
+def latest_helm(dep: str, _token: str | None, registry_url: str | None = None, **_) -> dict:
+    """Newest chart version in a Helm repository index.
+
+    Line-scanned rather than YAML-parsed: PyYAML is not in the standard library
+    and this file refuses a dependency for one field.
+    """
+    if not registry_url:
+        raise CleaError(f"helm {dep}: no registryUrl on the anchor")
+    text = http_get(registry_url.rstrip("/") + "/index.yaml").decode("utf-8", "replace")
+    versions: list[str] = []
+    entry_indent: int | None = None
+    inside = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if re.match(rf"^{re.escape(dep)}:\s*$", stripped) and not inside:
+            inside, entry_indent = True, indent
+            continue
+        if inside:
+            if indent <= entry_indent and not stripped.startswith("-"):
+                break
+            m = re.match(r"-?\s*version:\s*\"?([^\"\s]+)\"?$", stripped)
+            if m:
+                versions.append(m.group(1))
+    versions = [v for v in versions if not is_prerelease(v)]
+    if not versions:
+        raise CleaError(f"helm {dep}: no version under entries in {registry_url}")
+    tag = max(versions, key=version_key)
+    return {"tag": tag, "released_at": None, "notes_url": registry_url}
+
+
+def latest_terraform_provider(dep: str, _token: str | None,
+                              registry_url: str | None = None, **_) -> dict:
+    base = (registry_url or "https://registry.opentofu.org").rstrip("/")
+    data = json.loads(http_get(f"{base}/v1/providers/{dep}/versions"))
+    versions = [v["version"] for v in data.get("versions", [])
+                if not is_prerelease(v["version"])]
+    if not versions:
+        raise CleaError(f"terraform-provider {dep}: no version at {base}")
+    tag = max(versions, key=version_key)
+    return {"tag": tag, "released_at": None,
+            "notes_url": f"https://github.com/{dep.split('/')[0]}/terraform-provider-{dep.split('/')[-1]}/releases/tag/v{tag}"}
+
+
+def latest_url_text(dep: str, _token: str | None, url: str | None = None,
+                    extract: str | None = None, **_) -> dict:
+    """A plain URL whose body is (or contains) the version.
+
+    This is what covers a tool installed from a moving target — the kind of pin
+    that is not a pin at all, like `dl.k8s.io/release/stable.txt`.
+    """
+    if not url:
+        raise CleaError(f"url-text {dep}: no url")
+    body = http_get(url).decode("utf-8", "replace").strip()
+    if extract:
+        m = re.search(extract.replace("(?<", "(?P<"), body, re.MULTILINE)
+        if not m:
+            raise CleaError(f"url-text {dep}: {extract!r} matched nothing at {url}")
+        body = m.groupdict().get("v") or m.group(0)
+    if not body:
+        raise CleaError(f"url-text {dep}: {url} answered nothing")
+    return {"tag": body.strip(), "released_at": None, "notes_url": url}
+
+
+DATASOURCES = {
+    "github-releases": latest_github_releases,
+    "github-tags": latest_github_tags,
+    "pypi": latest_pypi,
+    "helm": latest_helm,
+    "terraform-provider": latest_terraform_provider,
+    "url-text": latest_url_text,
+}
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_CONFIG = {
+    "scan": {"marker": "# renovate:", "exclude": [], "include": []},
+    "report": {"title": "Cléa — dependency report", "label": "clea"},
+    "inventory": [],
+    "tool": [],
+    "unpinned": [],
+    "lane": {},
+}
+
+
+def load_config(path: Path) -> dict:
+    if not path.is_file():
+        raise CleaError(f"no {path} — Cléa needs one, it is the only thing it knows")
+    with path.open("rb") as handle:
+        raw = tomllib.load(handle)
+    cfg = json.loads(json.dumps(DEFAULT_CONFIG))
+    for key, value in raw.items():
+        if isinstance(value, dict) and isinstance(cfg.get(key), dict):
+            cfg[key].update(value)
+        else:
+            cfg[key] = value
+    return cfg
+
+
+def repo_root(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    try:
+        out = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                             capture_output=True, text=True, check=True)
+        return Path(out.stdout.strip())
+    except (OSError, subprocess.CalledProcessError):
+        return Path.cwd()
+
+
+# ---------------------------------------------------------------------------
+# coverage
+# ---------------------------------------------------------------------------
+
+def cmd_coverage(args) -> int:
+    root = repo_root(args.root)
+    cfg = load_config(root / args.config)
+    scan = cfg["scan"]
+    anchors, novalue = scan_anchors(root, scan["marker"], scan["exclude"], scan["include"])
+
+    # Zero floor. "0 anchors, none unwatched" and "every anchor is watched" look
+    # identical in a green run, and only one of them is true.
+    if not anchors and not novalue:
+        print(f"✗ no version anchor found under {root} — the scanner is broken, "
+              "not the repository", file=sys.stderr)
+        return 1
+
+    seen: dict[str, set[tuple[str, int]]] = {}
+    for inventory in cfg["inventory"]:
+        kind = inventory.get("kind")
+        if kind == "renovate":
+            seen["renovate"] = renovate_coverage(
+                root, inventory["config"], scan["exclude"] + inventory.get("exclude", []))
+        else:
+            raise CleaError(f"clea.toml: unknown inventory kind {kind!r}")
+
+    failures = 0
+    print(f"=== {len(anchors)} anchors read, {len(novalue)} carrying no version ===")
+
+    for anchor in novalue:
+        print(f"  ✗ {anchor.path}:{anchor.line} — {anchor.dep}: the anchor marks no "
+              f"version ({anchor.reason}). Nothing can bump it, and it reads as if "
+              "something could.")
+        failures += 1
+
+    for name, covered in seen.items():
+        missing = [a for a in anchors if a.key not in covered]
+        if missing:
+            print(f"\n  {name} cannot see {len(missing)} of {len(anchors)}:")
+            for anchor in missing:
+                print(f"  ✗ {anchor.path}:{anchor.line} — {anchor.dep} = {anchor.value} "
+                      f"({anchor.form})")
+            failures += len(missing)
+        else:
+            print(f"  ✓ {name} sees all {len(anchors)}")
+
+    print()
+    if failures:
+        print(f"{failures} unwatched pin(s). A pin nothing watches is a pin nobody bumps.")
+        return 1
+    print(f"{len(anchors)} anchors, every one watched.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# scan
+# ---------------------------------------------------------------------------
+
+def _load_previous(path: str | None) -> dict:
+    """Previous state, from a state file or from a report that embeds one."""
+    if not path:
+        return {}
+    text = Path(path).read_text(encoding="utf-8")
+    m = re.search(r"<!--\s*clea-state\s+(\{.*?\})\s*-->", text, re.DOTALL)
+    if m:
+        text = m.group(1)
+    try:
+        return json.loads(text)
+    except ValueError:
+        return {}
+
+
+def cmd_scan(args) -> int:
+    root = repo_root(args.root)
+    cfg = load_config(root / args.config)
+    scan = cfg["scan"]
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    anchors, novalue = scan_anchors(root, scan["marker"], scan["exclude"], scan["include"])
+    if not anchors:
+        print("✗ no readable anchor — nothing to scan", file=sys.stderr)
+        return 1
+    if not token:
+        print("⚠ no GITHUB_TOKEN: 60 requests an hour from a shared runner IP. "
+              "This will rate-limit, loudly.", file=sys.stderr)
+
+    previous = _load_previous(args.previous)
+    prev_by_key = {d["dep"] + "@" + d["file"]: d for d in previous.get("deps", [])}
+
+    # One upstream call per (datasource, dep), not per anchor: helm is pinned in
+    # two files here and the API does not need asking twice.
+    cache: dict[tuple[str, str], dict | str] = {}
+    deps, errors = [], []
+
+    def resolve(datasource: str, name: str, **kwargs) -> dict:
+        key = (datasource, name)
+        if key not in cache:
+            fetch = DATASOURCES.get(datasource)
+            if fetch is None:
+                cache[key] = CleaError(f"unknown datasource {datasource!r} for {name}")
+            else:
+                try:
+                    cache[key] = fetch(name, token, **kwargs)
+                except CleaError as exc:
+                    cache[key] = exc
+        got = cache[key]
+        if isinstance(got, CleaError):
+            raise got
+        return got
+
+    for anchor in anchors:
+        entry = {
+            "dep": anchor.dep,
+            "datasource": anchor.datasource,
+            "file": anchor.path,
+            "line": anchor.line,
+            "form": anchor.form,
+            "current": anchor.value,
+            "pinned": True,
+        }
+        try:
+            upstream = resolve(anchor.datasource, anchor.dep,
+                               registry_url=anchor.attrs.get("registryUrl"))
+            latest = apply_extract(upstream["tag"], anchor.attrs.get("extractVersion"))
+            entry.update(latest=latest, released_at=upstream.get("released_at"),
+                         notes_url=upstream.get("notes_url"),
+                         behind=is_newer(anchor.value, latest),
+                         shape_ok=same_shape(anchor.value, latest))
+        except CleaError as exc:
+            entry.update(latest=None, error=str(exc), behind=False)
+            errors.append(str(exc))
+        tool = next((t for t in cfg["tool"] if t["name"] == anchor.dep), None)
+        if tool:
+            entry["tool"] = tool
+        was = prev_by_key.get(entry["dep"] + "@" + entry["file"], {})
+        entry["moved_since_last_scan"] = bool(
+            was.get("latest") and entry.get("latest") and was["latest"] != entry["latest"])
+        deps.append(entry)
+
+    for item in cfg["unpinned"]:
+        entry = {"dep": item["name"], "datasource": item["datasource"],
+                 "file": item.get("consumed_by", ""), "line": 0, "form": "unpinned",
+                 "current": None, "pinned": False}
+        try:
+            upstream = resolve(item["datasource"], item["name"],
+                               url=item.get("url"), extract=item.get("extract"),
+                               registry_url=item.get("registry_url"))
+            entry.update(latest=upstream["tag"], notes_url=upstream.get("notes_url"),
+                         released_at=upstream.get("released_at"), behind=False)
+        except CleaError as exc:
+            entry.update(latest=None, error=str(exc), behind=False)
+            errors.append(str(exc))
+        was = prev_by_key.get(entry["dep"] + "@" + entry["file"], {})
+        entry["moved_since_last_scan"] = bool(
+            was.get("latest") and entry.get("latest") and was["latest"] != entry["latest"])
+        deps.append(entry)
+
+    state = {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "deps": deps,
+        "novalue": [{"dep": a.dep, "file": a.path, "line": a.line,
+                     "reason": a.reason} for a in novalue],
+        "unwatched": [],
+        "errors": errors,
+        "probes": previous.get("probes", []),
+    }
+
+    for inventory in cfg["inventory"]:
+        if inventory.get("kind") != "renovate":
+            continue
+        try:
+            covered = renovate_coverage(
+                root, inventory["config"],
+                scan["exclude"] + inventory.get("exclude", []))
+            state["unwatched"] = [
+                {"dep": a.dep, "file": a.path, "line": a.line,
+                 "current": a.value, "inventory": "renovate"}
+                for a in anchors if a.key not in covered]
+        except CleaError as exc:
+            errors.append(str(exc))
+
+    Path(args.state).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    behind = [d for d in deps if d.get("behind")]
+    print(f"{len(deps)} dependencies, {len(behind)} behind, "
+          f"{len(state['unwatched'])} unwatched, {len(errors)} error(s)")
+
+    # A datasource that answered nothing is not a dependency that is up to date.
+    if errors and args.strict:
+        for message in errors:
+            print(f"  ✗ {message}", file=sys.stderr)
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# config — one value, for the shell around Cléa
+# ---------------------------------------------------------------------------
+
+def cmd_config(args) -> int:
+    """Print one dotted key from clea.toml, so a workflow reads the config
+    rather than repeating it. A second copy of a value is a second thing to
+    drift, and this repository already has the scars."""
+    node = load_config(repo_root(args.root) / args.config)
+    for part in args.key.split("."):
+        if not isinstance(node, dict) or part not in node:
+            raise CleaError(f"clea.toml has no {args.key}")
+        node = node[part]
+    print(node if not isinstance(node, (dict, list)) else json.dumps(node))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# matrix — what the probe lanes should run
+# ---------------------------------------------------------------------------
+
+def slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+def cmd_matrix(args) -> int:
+    """One entry per dependency to probe, as a GitHub Actions matrix.
+
+    Keyed on the dependency, not on the anchor: a bump rewrites every site at
+    once, so probing helm twice because it is pinned in two files would test the
+    same tree twice.
+    """
+    state = json.loads(Path(args.state).read_text(encoding="utf-8"))
+    seen: dict[str, dict] = {}
+    for dep in state.get("deps", []):
+        if not (dep.get("behind") and dep.get("pinned")):
+            continue
+        if not dep.get("shape_ok", True):
+            continue  # bumping it would write a value its consumers read differently
+        tool = dep.get("tool") or {}
+        if args.daily and tool and tool.get("daily") is False:
+            continue
+        if args.heavy_only and not (tool and tool.get("daily") is False):
+            continue
+        key = dep["dep"]
+        if key in seen:
+            continue
+        seen[key] = {
+            "dep": key,
+            "version": dep["latest"],
+            "slug": slugify(key),
+            "installer": tool.get("installer", ""),
+            "version_cmd": tool.get("version_cmd", ""),
+            "installer_stdin": tool.get("installer_stdin", ""),
+        }
+    entries = sorted(seen.values(), key=lambda e: e["dep"])
+    print(json.dumps(entries, separators=(",", ":")))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+def _table(rows: list[list[str]], head: list[str]) -> str:
+    out = ["| " + " | ".join(head) + " |",
+           "|" + "|".join(["---"] * len(head)) + "|"]
+    out += ["| " + " | ".join(r) + " |" for r in rows]
+    return "\n".join(out)
+
+
+def render_report(state: dict) -> str:
+    deps = state.get("deps", [])
+    behind = [d for d in deps if d.get("behind")]
+    unpinned = [d for d in deps if not d.get("pinned")]
+    lines = [f"_Generated {state.get('generated_at', '?')} by "
+             "[Cléa](../blob/main/scripts/clea/README.md). "
+             "This issue is rewritten in place; do not open another._", ""]
+
+    lines += ["## Behind upstream", ""]
+    if behind:
+        rows = []
+        for d in behind:
+            probe = next((p for p in state.get("probes", [])
+                          if p["dep"] == d["dep"] and p["version"] == d["latest"]), None)
+            verdict = "not probed"
+            if probe:
+                verdict = ("✅ probed green — `%s`" % probe["branch"]) if probe["green"] \
+                    else "❌ probe failed"
+            notes = f"[notes]({d['notes_url']})" if d.get("notes_url") else "—"
+            shape = "" if d.get("shape_ok", True) else " ⚠️ prefix differs"
+            rows.append([f"`{d['dep']}`", f"`{d['current']}`", f"`{d['latest']}`{shape}",
+                         f"`{d['file']}:{d['line']}`", verdict, notes])
+        lines += [_table(rows, ["dependency", "pinned", "upstream", "where",
+                                "probe", "release"]), ""]
+    else:
+        lines += ["Nothing is behind. Every pin matches its upstream.", ""]
+
+    unwatched = state.get("unwatched", [])
+    novalue = state.get("novalue", [])
+    lines += ["## Not watched", ""]
+    if unwatched or novalue or unpinned:
+        if unwatched:
+            lines += ["**Anchored, but no inventory can see it** — the pin exists, "
+                      "the bot that should propose the bump never reads it:", ""]
+            lines += [f"- `{u['file']}:{u['line']}` — `{u['dep']}` = `{u['current']}`"
+                      for u in unwatched] + [""]
+        if novalue:
+            lines += ["**Anchor marking no version** — it can never be bumped, and it "
+                      "reads to a human as if it could:", ""]
+            lines += [f"- `{n['file']}:{n['line']}` — `{n['dep']}`: {n.get('reason', '')}"
+                      for n in novalue] + [""]
+        if unpinned:
+            rows = [[f"`{d['dep']}`", f"`{d.get('latest') or '?'}`",
+                     f"`{d['file']}`" if d["file"] else "—",
+                     "moved since last scan" if d.get("moved_since_last_scan") else ""]
+                    for d in unpinned]
+            lines += ["**Consumed at whatever upstream serves today** — no pin, so no "
+                      "two machines are guaranteed the same tool:", "",
+                      _table(rows, ["dependency", "upstream today", "consumed by",
+                                    "note"]), ""]
+    else:
+        lines += ["Every pin is anchored, readable and watched.", ""]
+
+    failed = [p for p in state.get("probes", []) if not p["green"]]
+    if failed:
+        lines += ["## Probe failures", ""]
+        for probe in failed:
+            lines += [f"### `{probe['dep']}` → `{probe['version']}`", "",
+                      "```", probe.get("log", "(no log captured)").strip(), "```", ""]
+
+    if state.get("errors"):
+        lines += ["## Datasources that did not answer", "",
+                  "Not the same thing as up to date:", ""]
+        lines += [f"- {e}" for e in state["errors"]] + [""]
+
+    lines += ["## What this did not test", "",
+              "- **No real cloud, ever.** This lane carries no provider credential and "
+              "must fail if it ever needs one. A deploy on Scaleway, OVH or Outscale is "
+              "run by hand, by someone watching — see `CONTRIBUTING.md`.",
+              "- A green probe means the tool installs from cold, upgrades over its "
+              "previous version, and the repository's own checks still pass. It does not "
+              "mean the new version behaves the same on a running cluster."]
+    cluster = state.get("cluster_lane")
+    if cluster:
+        lines += [f"- Weekly local cluster lane: **{cluster.get('verdict', '?')}**, "
+                  f"last run {cluster.get('at', '?')} on Talos "
+                  f"`{cluster.get('talos', '?')}` / Kubernetes `{cluster.get('k8s', '?')}`."]
+    else:
+        lines += ["- The weekly local cluster lane has not reported yet."]
+
+    lines += ["", "<!-- clea-state " + json.dumps(state, separators=(",", ":")) + " -->"]
+    return "\n".join(lines) + "\n"
+
+
+def cmd_report(args) -> int:
+    state = json.loads(Path(args.state).read_text(encoding="utf-8"))
+    text = render_report(state)
+    if args.out:
+        Path(args.out).write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# bump
+# ---------------------------------------------------------------------------
+
+def cmd_bump(args) -> int:
+    root = repo_root(args.root)
+    cfg = load_config(root / args.config)
+    scan = cfg["scan"]
+    anchors, _ = scan_anchors(root, scan["marker"], scan["exclude"], scan["include"])
+    targets = [a for a in anchors if a.dep == args.dep]
+    if not targets:
+        print(f"✗ no readable anchor for {args.dep}", file=sys.stderr)
+        return 1
+
+    # Every site, not the first: one tool, one version, everywhere it is claimed.
+    # Leaving a second copy behind is the drift this repository has paid for four
+    # times in a week.
+    changed = 0
+    for anchor in targets:
+        new_value = apply_extract(args.version, anchor.attrs.get("extractVersion"))
+        if not same_shape(anchor.value or "", new_value):
+            print(f"✗ {anchor.path}:{anchor.value_line} — {anchor.value!r} and "
+                  f"{new_value!r} do not carry the same v prefix; the consumers of "
+                  "this value read them differently", file=sys.stderr)
+            return 1
+        if anchor.value == new_value:
+            continue
+        path = root / anchor.path
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        idx = (anchor.value_line or 1) - 1
+        start, end = anchor.span or (0, 0)
+        line = lines[idx]
+        lines[idx] = line[:start] + new_value + line[end:]
+        path.write_text("".join(lines), encoding="utf-8")
+        print(f"  {anchor.path}:{anchor.value_line}  {anchor.value} -> {new_value}")
+        changed += 1
+
+    # A writer that writes nothing is the false-green this whole file exists
+    # against: the probe would then test the version already in the tree and
+    # report the bump as proven.
+    if not changed:
+        print(f"✗ {args.dep} is already at {args.version} everywhere — nothing to "
+              "probe", file=sys.stderr)
+        return 1
+    print(f"{changed} site(s) rewritten")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# prune
+# ---------------------------------------------------------------------------
+
+def cmd_prune(args) -> int:
+    """Probe branches whose bump has already landed on the base branch.
+
+    Compared on the PIN, not on the diff: a probe branch also carries its own
+    verdict file, so it never becomes byte-identical to the base and a diff test
+    would prune nothing, ever.
+    """
+    root = repo_root(args.root)
+    cfg = load_config(root / args.config)
+    scan = cfg["scan"]
+    anchors, _ = scan_anchors(root, scan["marker"], scan["exclude"], scan["include"])
+    current: dict[str, str] = {}
+    for anchor in anchors:
+        # The lowest of a dependency's sites: while one file is still behind,
+        # the bump has not fully landed and the branch is still worth keeping.
+        if anchor.dep not in current or version_key(anchor.value or "") < version_key(current[anchor.dep]):
+            current[anchor.dep] = anchor.value or ""
+
+    refs = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname:short)",
+         f"refs/remotes/origin/{args.prefix}*"],
+        capture_output=True, text=True, check=False).stdout.split()
+    for ref in refs:
+        blob = subprocess.run(["git", "show", f"{ref}:clea-probe.json"],
+                              capture_output=True, text=True, check=False)
+        if blob.returncode != 0:
+            continue  # not one of ours, or pushed before the verdict file existed
+        try:
+            probe = json.loads(blob.stdout)
+        except ValueError:
+            continue
+        landed = current.get(probe.get("dep", ""))
+        if landed and not is_newer(landed, probe.get("version", "")):
+            print(ref.removeprefix("origin/"))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="clea", description=__doc__.splitlines()[0])
+    parser.add_argument("--root", help="repository root (default: git toplevel)")
+    parser.add_argument("--config", default="clea.toml")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("coverage", help="offline: every pin readable and watched")
+
+    p_scan = sub.add_parser("scan", help="online: resolve upstream versions")
+    p_scan.add_argument("--state", default="clea-state.json")
+    p_scan.add_argument("--previous", help="last state file, or a report embedding one")
+    p_scan.add_argument("--strict", action="store_true",
+                        help="exit 1 if any datasource failed to answer")
+
+    p_config = sub.add_parser("config", help="print one dotted key from clea.toml")
+    p_config.add_argument("key")
+
+    p_matrix = sub.add_parser("matrix", help="GitHub Actions matrix of what to probe")
+    p_matrix.add_argument("--state", default="clea-state.json")
+    p_matrix.add_argument("--daily", action="store_true",
+                          help="skip anything a tool row marked daily = false")
+    p_matrix.add_argument("--heavy-only", action="store_true",
+                          help="only what daily skips")
+
+    p_report = sub.add_parser("report", help="render Markdown from a state file")
+    p_report.add_argument("--state", default="clea-state.json")
+    p_report.add_argument("--out")
+
+    p_bump = sub.add_parser("bump", help="rewrite a pin in place")
+    p_bump.add_argument("dep")
+    p_bump.add_argument("version")
+
+    p_prune = sub.add_parser("prune", help="name probe branches already landed")
+    p_prune.add_argument("--base", default="main")
+    p_prune.add_argument("--prefix", default="clea/probe/")
+
+    args = parser.parse_args(argv)
+    handlers = {"coverage": cmd_coverage, "scan": cmd_scan, "report": cmd_report,
+                "bump": cmd_bump, "prune": cmd_prune, "matrix": cmd_matrix,
+                "config": cmd_config}
+    try:
+        return handlers[args.command](args)
+    except CleaError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -578,6 +578,30 @@ def latest_url_text(dep: str, _token: str | None, url: str | None = None,
     return {"tag": body.strip(), "released_at": None, "notes_url": url}
 
 
+def bot_activity(repo: str, bot: str, token: str | None) -> dict:
+    """When did the bot that proposes the bumps last propose one?
+
+    On its own this says little — a bot with nothing to propose is silent and
+    correct. It becomes a signal when crossed with what Cléa found: a
+    dependency that IS behind and that the bot's own inventory CAN see, with no
+    proposal for days, means the bot is not running. That crossing is what went
+    unmade here for three weeks.
+    """
+    prs = _gh_json(f"/repos/{repo}/pulls?state=all&per_page=100"
+                   f"&sort=created&direction=desc", token)
+    for pr in prs:
+        if (pr.get("user") or {}).get("login") == bot:
+            at = pr.get("created_at")
+            days = None
+            if at:
+                seen = datetime.fromisoformat(at.replace("Z", "+00:00"))
+                days = (datetime.now(timezone.utc) - seen).days
+            return {"bot": bot, "number": pr.get("number"), "at": at,
+                    "days": days, "scanned": len(prs)}
+    return {"bot": bot, "number": None, "at": None, "days": None,
+            "scanned": len(prs)}
+
+
 DATASOURCES = {
     "github-releases": latest_github_releases,
     "github-tags": latest_github_tags,
@@ -810,8 +834,30 @@ def cmd_scan(args) -> int:
                 {"dep": a.dep, "file": a.path, "line": a.line,
                  "current": a.value, "inventory": "renovate"}
                 for a in anchors if a.key not in covered]
+            watched = {(a.path, a.line) for a in anchors if a.key in covered}
+            for entry in deps:
+                entry["watched"] = (entry["file"], entry["line"]) in watched
         except CleaError as exc:
             errors.append(str(exc))
+
+    # The bot's heartbeat. Skipped loudly rather than quietly: "we did not ask"
+    # and "the bot is fine" must not look the same in the report.
+    bot = cfg["report"].get("watch_bot")
+    slug = cfg["report"].get("repo") or os.environ.get("GITHUB_REPOSITORY")
+    if bot and slug:
+        try:
+            state["bot"] = bot_activity(slug, bot, token)
+            state["bot"]["silent_after_days"] = cfg["report"].get("silent_after_days", 8)
+        except CleaError as exc:
+            errors.append(f"{bot} activity on {slug}: {exc}")
+    elif bot:
+        errors.append(f"{bot}: no repository to ask about — set GITHUB_REPOSITORY "
+                      "or [report] repo in clea.toml")
+
+    # Re-taken here, not at construction: the inventory and the heartbeat run
+    # after the state dict is built, and a copy made earlier would silently drop
+    # exactly the failures this report exists to show.
+    state["errors"] = list(dict.fromkeys(errors))
 
     Path(args.state).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
     behind = [d for d in deps if d.get("behind")]
@@ -950,6 +996,37 @@ def render_report(state: dict) -> str:
                                     "note"]), ""]
     else:
         lines += ["Every pin is anchored, readable and watched.", ""]
+
+    bot = state.get("bot")
+    if bot:
+        actionable = [d for d in deps
+                      if d.get("behind") and d.get("pinned") and d.get("watched")]
+        limit = bot.get("silent_after_days", 8)
+        days = bot.get("days")
+        lines += [f"## {bot['bot']}", ""]
+        if bot.get("number") is None:
+            lines += [f"No pull request from `{bot['bot']}` in the last "
+                      f"{bot.get('scanned', 0)} on this repository.", ""]
+        else:
+            lines += [f"Last proposal: [#{bot['number']}]"
+                      f"(../pull/{bot['number']}), {bot.get('at', '?')} "
+                      f"({days} days ago).", ""]
+        if actionable and (days is None or days > limit):
+            lines += [f"> ⚠️ **{len(actionable)} dependency(ies) are behind that "
+                      f"`{bot['bot']}` can see, and it has proposed nothing for "
+                      f"{days if days is not None else 'longer than that list'} "
+                      "days.** Silence alone means nothing — a bot with nothing "
+                      "to propose is silent and correct. Silence *while* "
+                      "something it watches is behind means it is not running.",
+                      ""]
+            lines += [f"> - `{d['dep']}` {d['current']} → {d['latest']} "
+                      f"(`{d['file']}:{d['line']}`)" for d in actionable] + [""]
+        elif actionable:
+            lines += [f"{len(actionable)} behind and within its window — nothing "
+                      "to conclude yet.", ""]
+        else:
+            lines += ["Nothing it watches is behind, so its silence proves "
+                      "nothing either way.", ""]
 
     failed = [p for p in state.get("probes", []) if not p["green"]]
     if failed:

--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -227,9 +227,12 @@ class Anchor:
 def _read_value(lines: list[str], start: int):
     """First recognised version in the window under the anchor at index `start`.
 
-    Returns (value, line, form, span) or (None, reason) — the reason names what
-    was read instead, because "no value here" and "this line reads
-    `{{.VERSION | default .PINNED}}`" send a reader to two different places.
+    Returns (found, reason): `found` is (value, line, form, span) or None;
+    `reason` is set only when `found` is None, and names what was read instead
+    — "no value here" and "this line reads `{{.VERSION | default .PINNED}}`"
+    send a reader to two different places. Always a 2-tuple: a return whose
+    ARITY depends on which branch ran is its own kind of landmine for whatever
+    reads it next.
     """
     rejected: list[str] = []
     for offset in range(1, VALUE_WINDOW + 1):
@@ -245,10 +248,11 @@ def _read_value(lines: list[str], start: int):
                 continue
             value = m.group("v")
             if VERSION_LIKE.match(value):
-                return value, idx + 1, form, m.span("v")
+                return (value, idx + 1, form, m.span("v")), None
             rejected.append(f"line {idx + 1} reads {value!r} ({form}), which is not a version")
-    return None, ("; ".join(rejected) if rejected
-                  else f"nothing version-shaped in the {VALUE_WINDOW} lines below")
+    reason = ("; ".join(rejected) if rejected
+              else f"nothing version-shaped in the {VALUE_WINDOW} lines below")
+    return None, reason
 
 
 def _walk(root: Path, include: list[str], exclude: list[str]):
@@ -303,9 +307,9 @@ def scan_anchors(root: Path, marker: str, exclude: list[str],
             if "depName" not in attrs:
                 continue
             anchor = Anchor(rel, i + 1, attrs)
-            got = _read_value(lines, i)
-            if got[0] is None:
-                anchor.reason = got[1]
+            got, reason = _read_value(lines, i)
+            if got is None:
+                anchor.reason = reason
                 novalue.append(anchor)
                 continue
             anchor.value, anchor.value_line, anchor.form, anchor.span = got

--- a/scripts/clea/probe.sh
+++ b/scripts/clea/probe.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Prove a bump before anyone merges it: install it from cold, then upgrade over
+# the version that was there.
+#
+# The second half is the one that finds things. `scripts/dev/feint.sh:310`
+# records what it would have caught: the pin moved to 0.10.0 and every machine
+# that had already run the lane kept 0.9.0, because the installer checked that
+# the binary existed and never asked which version it was.
+#
+# Bare ubuntu:24.04, not the runner image: a machine that already has the tool
+# hides the defect. Only curl and ca-certificates are added — anything else the
+# installer needs and does not install is a finding, not a prerequisite to
+# paper over.
+#
+# Usage: probe.sh <dep> <version> <installer> <version-cmd> [stdin-for-installer]
+#   CLEA_IMAGE  base image           (default: ubuntu:24.04)
+#   CLEA_ROOT   repository to mount  (default: git toplevel)
+set -uo pipefail
+
+DEP="${1:?dep}"; VERSION="${2:?version}"; INSTALLER="${3:?installer}"
+VERSION_CMD="${4:?version command}"; STDIN="${5:-}"
+IMAGE="${CLEA_IMAGE:-ubuntu:24.04}"
+ROOT="${CLEA_ROOT:-$(git rev-parse --show-toplevel)}"
+CLEA="$ROOT/scripts/clea/clea.py"
+NAME="clea-probe-$(printf '%s' "$DEP" | tr -c 'a-zA-Z0-9' '-')-$$"
+
+# This script bumps a pin and restores the tree with `git checkout -- .`, which
+# would take uncommitted work with it. Refuse rather than find out.
+if [ -n "$(git -C "$ROOT" status --porcelain --untracked-files=no)" ]; then
+  echo "✗ ${ROOT} has uncommitted changes; this script restores the tree by discarding them" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  git -C "$ROOT" checkout -- . 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Bounded on both sides, so 3.52.0 does not match 3.52.01 and 1.13.9 does not
+# match 1.13.90. The leading v is optional because half the tools print it.
+version_re() { printf '(^|[^0-9.])v?%s([^0-9.]|$)' "$(printf '%s' "${1#v}" | sed 's/\./\\./g')"; }
+
+in_box() {
+  if [ -n "$STDIN" ]; then
+    printf '%b' "$STDIN" | docker exec -i -w /repo "$NAME" bash -lc "$1"
+  else
+    docker exec -w /repo "$NAME" bash -lc "$1"
+  fi
+}
+
+echo "=== ${DEP} -> ${VERSION} ==="
+
+docker run -d --name "$NAME" -v "$ROOT:/repo" -w /repo "$IMAGE" sleep 3600 >/dev/null || {
+  echo "✗ could not start ${IMAGE}" >&2; exit 1; }
+in_box 'apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null' \
+  || { echo "✗ could not add curl to the container" >&2; exit 1; }
+
+# --- 1. upgrade: the OLD pin first, so there is something to upgrade over -----
+OLD_OUT="$(in_box "$INSTALLER >/dev/null 2>&1; $VERSION_CMD" 2>&1)"
+OLD_VERSION="$(printf '%s' "$OLD_OUT" | grep -oE 'v?[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)"
+if [ -n "$OLD_VERSION" ]; then
+  ok "installed at the current pin first: ${OLD_VERSION}"
+else
+  bad "the installer at the current pin reported no version — cannot upgrade over nothing"
+  printf '%s\n' "$OLD_OUT" | tail -20
+fi
+
+# --- 2. the bump itself, on the host: the container has no Python -------------
+if ! python3 "$CLEA" --root "$ROOT" bump "$DEP" "$VERSION"; then
+  bad "clea bump refused — nothing was rewritten, so a probe here would test the tree it started with"
+  echo; printf '%s passed, %s failed\n' "$PASS" "$FAIL"; exit 1
+fi
+
+# --- 3. upgrade in place -----------------------------------------------------
+UP_OUT="$(in_box "$INSTALLER 2>&1; echo ---; $VERSION_CMD" 2>&1)"
+if printf '%s' "$UP_OUT" | grep -qE "$(version_re "$VERSION")"; then
+  ok "upgrade over ${OLD_VERSION:-an existing install} reached ${VERSION}"
+else
+  bad "upgrade did not reach ${VERSION} — the installer left ${OLD_VERSION:-what was there}"
+  printf '%s\n' "$UP_OUT" | tail -25
+fi
+
+# --- 4. install from cold, in a container that never had it ------------------
+docker rm -f "$NAME" >/dev/null 2>&1
+docker run -d --name "$NAME" -v "$ROOT:/repo" -w /repo "$IMAGE" sleep 3600 >/dev/null
+in_box 'apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null'
+COLD_OUT="$(in_box "$INSTALLER 2>&1; echo ---; $VERSION_CMD" 2>&1)"
+if printf '%s' "$COLD_OUT" | grep -qE "$(version_re "$VERSION")"; then
+  ok "cold install on a machine that never had it reached ${VERSION}"
+else
+  bad "cold install did not reach ${VERSION}"
+  printf '%s\n' "$COLD_OUT" | tail -25
+fi
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/clea/probe.sh
+++ b/scripts/clea/probe.sh
@@ -13,8 +13,13 @@
 # paper over.
 #
 # Usage: probe.sh <dep> <version> <installer> <version-cmd> [stdin-for-installer]
-#   CLEA_IMAGE  base image           (default: ubuntu:24.04)
-#   CLEA_ROOT   repository to mount  (default: git toplevel)
+#   CLEA_IMAGE       base image           (default: ubuntu:24.04)
+#   CLEA_ROOT        repository to mount  (default: git toplevel)
+#   CLEA_CA_BUNDLE   PEM to trust inside the container. Needed wherever TLS is
+#                    intercepted — a corporate proxy, or the sandbox this was
+#                    first run in, where every download failed with
+#                    "self-signed certificate in certificate chain" and the
+#                    probe reported red for a reason that was not the bump.
 set -uo pipefail
 
 DEP="${1:?dep}"; VERSION="${2:?version}"; INSTALLER="${3:?installer}"
@@ -23,6 +28,12 @@ IMAGE="${CLEA_IMAGE:-ubuntu:24.04}"
 ROOT="${CLEA_ROOT:-$(git rev-parse --show-toplevel)}"
 CLEA="$ROOT/scripts/clea/clea.py"
 NAME="clea-probe-$(printf '%s' "$DEP" | tr -c 'a-zA-Z0-9' '-')-$$"
+CA="${CLEA_CA_BUNDLE:-}"
+if [ -n "$CA" ] && [ ! -r "$CA" ]; then
+  echo "✗ CLEA_CA_BUNDLE=${CA} is not readable — refusing to run a probe whose "\
+       "downloads would fail for a reason that is not the bump" >&2
+  exit 1
+fi
 
 # This script bumps a pin and restores the tree with `git checkout -- .`, which
 # would take uncommitted work with it. Refuse rather than find out.
@@ -45,20 +56,32 @@ trap cleanup EXIT
 # match 1.13.90. The leading v is optional because half the tools print it.
 version_re() { printf '(^|[^0-9.])v?%s([^0-9.]|$)' "$(printf '%s' "${1#v}" | sed 's/\./\\./g')"; }
 
+# Trust is passed by environment rather than by update-ca-certificates: that
+# tool indexes one certificate per file and quietly mishandles a bundle, which
+# would leave the same TLS failure with nothing on screen to explain it.
+CA_ENV=""
+[ -n "$CA" ] && CA_ENV="export CURL_CA_BUNDLE=/etc/clea-ca.crt SSL_CERT_FILE=/etc/clea-ca.crt REQUESTS_CA_BUNDLE=/etc/clea-ca.crt; "
+
 in_box() {
   if [ -n "$STDIN" ]; then
-    printf '%b' "$STDIN" | docker exec -i -w /repo "$NAME" bash -lc "$1"
+    printf '%b' "$STDIN" | docker exec -i -w /repo "$NAME" bash -lc "${CA_ENV}$1"
   else
-    docker exec -w /repo "$NAME" bash -lc "$1"
+    docker exec -w /repo "$NAME" bash -lc "${CA_ENV}$1"
   fi
+}
+
+start_box() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  # shellcheck disable=SC2086 # the mount must stay unquoted: empty means none
+  docker run -d --name "$NAME" -v "$ROOT:/repo" \
+    ${CA:+-v "$CA:/etc/clea-ca.crt:ro"} -w /repo "$IMAGE" sleep 3600 >/dev/null \
+    || { echo "✗ could not start ${IMAGE}" >&2; return 1; }
+  in_box 'apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null'
 }
 
 echo "=== ${DEP} -> ${VERSION} ==="
 
-docker run -d --name "$NAME" -v "$ROOT:/repo" -w /repo "$IMAGE" sleep 3600 >/dev/null || {
-  echo "✗ could not start ${IMAGE}" >&2; exit 1; }
-in_box 'apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null' \
-  || { echo "✗ could not add curl to the container" >&2; exit 1; }
+start_box || exit 1
 
 # --- 1. upgrade: the OLD pin first, so there is something to upgrade over -----
 OLD_OUT="$(in_box "$INSTALLER >/dev/null 2>&1; $VERSION_CMD" 2>&1)"
@@ -86,9 +109,7 @@ else
 fi
 
 # --- 4. install from cold, in a container that never had it ------------------
-docker rm -f "$NAME" >/dev/null 2>&1
-docker run -d --name "$NAME" -v "$ROOT:/repo" -w /repo "$IMAGE" sleep 3600 >/dev/null
-in_box 'apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null'
+start_box || exit 1
 COLD_OUT="$(in_box "$INSTALLER 2>&1; echo ---; $VERSION_CMD" 2>&1)"
 if printf '%s' "$COLD_OUT" | grep -qE "$(version_re "$VERSION")"; then
   ok "cold install on a machine that never had it reached ${VERSION}"

--- a/scripts/dev/check-version-drift.sh
+++ b/scripts/dev/check-version-drift.sh
@@ -39,11 +39,13 @@ HELM_MAJOR="$(pin "$RENDER" HELM_MAJOR_EXPECTED)"
 FEINT="$(pin scripts/dev/feint.sh FEINT_VERSION)"
 HELM_SETUP="$(pin scripts/setup.sh HELM_VERSION)"
 HELM_CI="$(sed -nE 's/^[[:space:]]*HELM_VERSION:[[:space:]]*"([^"]+)".*/\1/p' .github/workflows/ci.yml | head -1)"
+TOFU_SETUP="$(pin scripts/setup.sh TOFU_VERSION)"
+TOFU_CI="$(sed -nE 's/^[[:space:]]*tofu_version:[[:space:]]*"([^"]+)".*/\1/p' .github/workflows/ci.yml | head -1)"
 
 # ZERO FLOOR. If the extractors return nothing the comparisons below all pass
 # vacuously, and this file becomes a green line that proves nothing — the exact
 # shape it is written against.
-for v in CILIUM HELM_MAJOR FEINT HELM_SETUP HELM_CI; do
+for v in CILIUM HELM_MAJOR FEINT HELM_SETUP HELM_CI TOFU_SETUP TOFU_CI; do
   [ -n "${!v}" ] || { echo "✗ could not extract ${v} — the extractor is broken, not the repository" >&2; exit 1; }
 done
 
@@ -59,6 +61,15 @@ if [ "${HELM_SETUP%%.*}" = "$HELM_MAJOR" ]; then
   ok "helm major ${HELM_MAJOR}: what setup.sh installs is what the renderer accepts"
 else
   bad "helm: setup.sh installs major ${HELM_SETUP%%.*}, ${RENDER} refuses anything but ${HELM_MAJOR} — a fresh clone cannot render"
+fi
+
+# OpenTofu: unpinned in setup.sh until 2026-08-23, where the official installer
+# asked the GitHub API for the newest version and a 403 took the whole bootstrap
+# down before anything was installed.
+if [ "$TOFU_SETUP" = "$TOFU_CI" ]; then
+  ok "OpenTofu ${TOFU_SETUP}: setup.sh and ci.yml agree"
+else
+  bad "OpenTofu: setup.sh installs ${TOFU_SETUP}, ci.yml pins ${TOFU_CI} — a contributor and CI would not run the same binary"
 fi
 
 # Cilium: the pin versus the artifact actually committed from it.

--- a/scripts/dev/infra-verify.sh
+++ b/scripts/dev/infra-verify.sh
@@ -121,10 +121,26 @@ fi
 
 # CoreDNS proves the CNI actually carries traffic, which "the pod is Running"
 # does not: a broken datapath leaves DNS pods up and every lookup dead.
-if K -n kube-system get deploy coredns -o jsonpath='{.status.readyReplicas}' 2>/dev/null | grep -qE '^[1-9]'; then
-  ok "CoreDNS has a ready replica — the datapath carries traffic"
+#
+# Bounded wait, like the nodes above and for the same reason. This was an
+# INSTANT read, and every node being Ready does not mean CoreDNS has finished
+# rolling out: measured 2026-08-24 on the Docker lane, `local-verify` run right
+# after `local-up` reported "no ready replica" against a cluster that was 2/2
+# forty seconds later. A gate that fails on a healthy cluster is worse than no
+# gate — it is the one people learn to re-run until it passes.
+DNS_TIMEOUT="${DNS_TIMEOUT:-180}"
+deadline=$((SECONDS + DNS_TIMEOUT))
+dns_ready=""
+while :; do
+  dns_ready="$(K -n kube-system get deploy coredns -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  [[ "$dns_ready" =~ ^[1-9] ]] && break
+  [ "$SECONDS" -lt "$deadline" ] || break
+  sleep 5
+done
+if [[ "$dns_ready" =~ ^[1-9] ]]; then
+  ok "CoreDNS has ${dns_ready} ready replica(s) — the datapath carries traffic"
 else
-  bad "CoreDNS has no ready replica — the CNI is up but the network is not"
+  bad "after ${DNS_TIMEOUT}s CoreDNS has no ready replica — the CNI is up but the network is not"
 fi
 
 info "The floor is the floor — what 1.0.0 says is NOT there"

--- a/scripts/dev/test-clea.sh
+++ b/scripts/dev/test-clea.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# Cléa's own assertions, offline, on synthetic fixtures.
+#
+# Every check below has a twin that must FAIL — a reader that matches nothing, a
+# writer that writes nothing, a datasource that answers 403. A check only ever
+# seen to pass is a check nobody has tested; it is the shape behind more than
+# twenty defects here, and Cléa exists to catch that shape in other files, so it
+# does not get to ship with it.
+#
+# Fixtures are built here rather than committed: this repository is public, and
+# a version fixture is one more file that can grow a real value.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLEA="$ROOT/scripts/clea/clea.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+# expect <rc> <label> -- <command...>   : the command must exit with exactly rc
+expect() {
+  local want="$1" label="$2"; shift 3
+  local out rc
+  out="$("$@" 2>&1)"; rc=$?
+  if [ "$rc" -eq "$want" ]; then ok "$label"; else
+    bad "$label (exit $rc, wanted $want)"
+    printf '%s\n' "$out" | sed 's/^/      /' | tail -8
+  fi
+}
+
+# says <label> <needle> -- <command...>  : the output must contain needle
+says() {
+  local label="$1" needle="$2"; shift 3
+  local out
+  out="$("$@" 2>&1)"
+  if printf '%s' "$out" | grep -qF -- "$needle"; then ok "$label"; else
+    bad "$label — no '$needle' in the output"
+    printf '%s\n' "$out" | sed 's/^/      /' | tail -8
+  fi
+}
+
+# --- a fixture repository, one anchor per supported value form ---------------
+mkfixture() { # <dir>
+  local d="$1"
+  mkdir -p "$d/scripts" "$d/.github/workflows" "$d/infra"
+  cat > "$d/scripts/install.sh" <<'EOF'
+#!/usr/bin/env bash
+# clea-test: datasource=github-releases depName=acme/one extractVersion=^v(?<version>.*)$
+ONE_VERSION="1.2.3"
+# clea-test: datasource=github-releases depName=acme/two
+TWO_VERSION="${TWO_VERSION:-v0.9.0}"
+# clea-test: datasource=github-releases depName=acme/three
+local THREE_VERSION="4.5.6"
+EOF
+  cat > "$d/.github/workflows/ci.yml" <<'EOF'
+jobs:
+  a:
+    steps:
+      - name: pip
+        # clea-test: datasource=pypi depName=acme-four
+        run: pip install acme-four==7.8.9
+      - name: env
+        env:
+          # clea-test: datasource=github-releases depName=acme/five
+          FIVE_VERSION: "10.11.12"
+EOF
+  cat > "$d/infra/variables.tf" <<'EOF'
+variable "six" {
+  # clea-test: datasource=github-releases depName=acme/six
+  default = "v13.14.15"
+}
+EOF
+  cat > "$d/Taskfile.yml" <<'EOF'
+tasks:
+  t:
+    vars:
+      # clea-test: datasource=github-releases depName=acme/seven
+      SEVEN: '{{.SEVEN | default "16.17.18"}}'
+EOF
+  cat > "$d/clea.toml" <<'EOF'
+[scan]
+marker = "# clea-test:"
+[report]
+title = "t"
+EOF
+}
+
+echo "=== the reader reads every form this repository actually uses ==="
+mkfixture "$TMP/basic"
+expect 0 "seven anchors in seven forms, all readable" \
+  -- python3 "$CLEA" --root "$TMP/basic" coverage
+says "the bash default form is read" "7 anchors, every one watched" \
+  -- python3 "$CLEA" --root "$TMP/basic" coverage
+
+echo
+echo "=== an anchor inside a Markdown fence is an example, not a pin ==="
+# Cléa's own README documents the anchor convention by showing one. Reading it
+# reported go-task/task as an unwatched dependency of this repository — a
+# detector matching its own documentation, which is the shape it hunts.
+cp -r "$TMP/basic" "$TMP/md"
+printf 'Docs.\n\n```bash\n# clea-test: datasource=github-releases depName=acme/documented\nDOC_VERSION="1.0.0"\n```\n' > "$TMP/md/README.md"
+says "the fenced example is not counted" "7 anchors read" \
+  -- python3 "$CLEA" --root "$TMP/md" coverage
+expect 0 "and the tree is still clean" \
+  -- python3 "$CLEA" --root "$TMP/md" coverage
+
+echo
+echo "=== an anchor that marks no version is a failure, with the reason ==="
+mkdir -p "$TMP/tmpl"; cp "$TMP/basic/clea.toml" "$TMP/tmpl/"
+cat > "$TMP/tmpl/Taskfile.yml" <<'EOF'
+tasks:
+  t:
+    vars:
+      # clea-test: datasource=github-releases depName=acme/computed
+      PINNED:
+        sh: ./compute-it.sh
+      IMAGE: '{{.V | default .PINNED}}'
+EOF
+expect 1 "a template read as a version is refused" \
+  -- python3 "$CLEA" --root "$TMP/tmpl" coverage
+says "and it names what it read instead" "which is not a version" \
+  -- python3 "$CLEA" --root "$TMP/tmpl" coverage
+
+echo
+echo "=== zero floor: nothing to check is not the same as nothing wrong ==="
+mkdir -p "$TMP/empty"; cp "$TMP/basic/clea.toml" "$TMP/empty/"
+echo "nothing here" > "$TMP/empty/README.md"
+expect 1 "a tree with no anchor at all fails rather than reporting green" \
+  -- python3 "$CLEA" --root "$TMP/empty" coverage
+
+echo
+echo "=== coverage against a Renovate config ==="
+cp -r "$TMP/basic" "$TMP/cov"
+cat > "$TMP/cov/renovate.json5" <<'EOF'
+// A config that declares ONE manager, so six of the seven anchors are unwatched.
+{
+  customManagers: [
+    {
+      customType: "regex",
+      fileMatch: ["^infra/variables\\.tf$"],
+      matchStrings: [
+        "# clea-test: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*default\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+    },
+  ],
+}
+EOF
+cat >> "$TMP/cov/clea.toml" <<'EOF'
+[[inventory]]
+kind = "renovate"
+config = "renovate.json5"
+exclude = ["renovate.json5"]
+EOF
+expect 1 "an inventory that sees one anchor of seven fails" \
+  -- python3 "$CLEA" --root "$TMP/cov" coverage
+says "and names the six it cannot see" "renovate cannot see 6 of 7" \
+  -- python3 "$CLEA" --root "$TMP/cov" coverage
+says "the config's own matchStrings are not counted as anchors" "7 anchors read" \
+  -- python3 "$CLEA" --root "$TMP/cov" coverage
+
+# The other direction, which must go green: a manager wide enough to see them all.
+cat > "$TMP/cov/renovate.json5" <<'EOF'
+{
+  customManagers: [
+    { customType: "regex", fileMatch: [".*"],
+      matchStrings: ["# clea-test: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)"] },
+  ],
+}
+EOF
+expect 0 "widening the manager to every anchor turns it green" \
+  -- python3 "$CLEA" --root "$TMP/cov" coverage
+
+echo
+echo "=== managerFilePatterns: /…/ is a regex, anything else a glob ==="
+# Renovate renamed fileMatch and changed how it is read at the same time. A glob
+# read as a regex matches almost nothing, so every anchor would be reported
+# unwatched — and a checker that cries wolf gets muted, which is the failure
+# this whole file is written against. No backslash in the patterns below: they
+# would be eaten by the heredoc, and the assertion would test the escaping.
+cp -r "$TMP/basic" "$TMP/mfp"
+cat >> "$TMP/mfp/clea.toml" <<'EOF'
+[[inventory]]
+kind = "renovate"
+config = "renovate.json5"
+exclude = ["renovate.json5"]
+EOF
+mfp() { # <pattern>
+  cat > "$TMP/mfp/renovate.json5" <<EOF
+{
+  customManagers: [
+    { customType: "regex", managerFilePatterns: ["$1"],
+      matchStrings: ["# clea-test: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[a-z0-9/-]+)"] },
+  ],
+}
+EOF
+}
+mfp 'scripts/*.sh'
+says "a bare pattern is a glob, and it reaches the shell script" \
+  "renovate cannot see 4 of 7" -- python3 "$CLEA" --root "$TMP/mfp" coverage
+mfp '/^scripts/.+[.]sh$/'
+says "slash-delimited is a regex, and reaches the same three" \
+  "renovate cannot see 4 of 7" -- python3 "$CLEA" --root "$TMP/mfp" coverage
+mfp '^scripts/.+[.]sh$'
+says "a regex written without its slashes reaches nothing, and says so" \
+  "renovate cannot see 7 of 7" -- python3 "$CLEA" --root "$TMP/mfp" coverage
+
+echo
+echo "=== a JSON5 config that does not parse stops the run ==="
+cp -r "$TMP/cov" "$TMP/bad5"
+printf '{ customManagers: [ { fileMatch: [".*"\n' > "$TMP/bad5/renovate.json5"
+expect 1 "an unreadable inventory is an error, not an empty one" \
+  -- python3 "$CLEA" --root "$TMP/bad5" coverage
+says "and says which file" "renovate.json5" \
+  -- python3 "$CLEA" --root "$TMP/bad5" coverage
+
+echo
+echo "=== bump: the inverse of the reader, and it refuses to write nothing ==="
+cp -r "$TMP/basic" "$TMP/bump"
+expect 0 "bump rewrites the pin" \
+  -- python3 "$CLEA" --root "$TMP/bump" bump acme/two v0.10.0
+if grep -q 'TWO_VERSION:-v0.10.0' "$TMP/bump/scripts/install.sh"; then
+  ok "the bash default form was rewritten in place"
+else
+  bad "the bash default form was not rewritten"
+fi
+expect 1 "bumping to the version already there is refused" \
+  -- python3 "$CLEA" --root "$TMP/bump" bump acme/two v0.10.0
+expect 1 "bumping an unknown dependency is refused" \
+  -- python3 "$CLEA" --root "$TMP/bump" bump acme/nothing 1.0.0
+expect 1 "bumping across a v prefix is refused" \
+  -- python3 "$CLEA" --root "$TMP/bump" bump acme/three v9.9.9
+expect 0 "extractVersion is applied on the way in" \
+  -- python3 "$CLEA" --root "$TMP/bump" bump acme/one v1.3.0
+if grep -q 'ONE_VERSION="1.3.0"' "$TMP/bump/scripts/install.sh"; then
+  ok "the stripped form was written, not the tag"
+else
+  bad "extractVersion was not applied: $(grep ONE_VERSION "$TMP/bump/scripts/install.sh" | head -1)"
+fi
+
+echo
+echo "=== every site of one dependency, not the first ==="
+cp -r "$TMP/basic" "$TMP/multi"
+cat > "$TMP/multi/scripts/other.sh" <<'EOF'
+# clea-test: datasource=github-releases depName=acme/three
+OTHER_THREE="4.5.6"
+EOF
+python3 "$CLEA" --root "$TMP/multi" bump acme/three 4.6.0 >/dev/null 2>&1
+if grep -q '4.6.0' "$TMP/multi/scripts/other.sh" && \
+   grep -q '4.6.0' "$TMP/multi/scripts/install.sh"; then
+  ok "both sites moved — one tool, one version, everywhere it is claimed"
+else
+  bad "only one of the two sites moved"
+fi
+
+echo
+echo "=== version comparison, and the pair every hand-rolled comparator gets wrong ==="
+python3 - "$CLEA" <<'PY'
+import importlib.util, sys, pathlib
+spec = importlib.util.spec_from_file_location("clea", sys.argv[1])
+clea = importlib.util.module_from_spec(spec); spec.loader.exec_module(clea)
+checks = [
+    ("1.13.10 > 1.13.9", clea.is_newer("1.13.9", "1.13.10")),
+    ("v1.13.10 > v1.13.9", clea.is_newer("v1.13.9", "v1.13.10")),
+    ("1.2.3 is not newer than itself", not clea.is_newer("1.2.3", "1.2.3")),
+    ("a release beats its own rc", clea.is_newer("1.2.3-rc1", "1.2.3")),
+    ("an rc does not beat the release", not clea.is_newer("1.2.3", "1.2.3-rc1")),
+    ("shapes must agree", not clea.same_shape("1.2.3", "v1.2.3")),
+    ("extractVersion strips the v", clea.apply_extract("v1.2.3", r"^v(?<version>.*)$") == "1.2.3"),
+    ("no extractVersion keeps the tag", clea.apply_extract("v1.2.3", None) == "v1.2.3"),
+]
+bad = [name for name, got in checks if not got]
+for name, got in checks:
+    print(("  \033[32m✓\033[0m " if got else "  \033[31m✗\033[0m ") + name)
+sys.exit(1 if bad else 0)
+PY
+if [ $? -eq 0 ]; then PASS=$((PASS + 8)); else FAIL=$((FAIL + 1)); fi
+
+echo
+echo "=== a rate-limited datasource is an error, never 'up to date' ==="
+python3 - "$CLEA" <<'PY'
+import http.server, importlib.util, socket, sys, threading
+
+spec = importlib.util.spec_from_file_location("clea", sys.argv[1])
+clea = importlib.util.module_from_spec(spec); spec.loader.exec_module(clea)
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        code = 403 if "limited" in self.path else 200
+        body = b'{"message":"API rate limit exceeded"}' if code == 403 else b'v9.9.9\n'
+        self.send_response(code); self.send_header("Content-Length", str(len(body)))
+        self.end_headers(); self.wfile.write(body)
+    def log_message(self, *a): pass
+
+sock = socket.socket(); sock.bind(("127.0.0.1", 0)); port = sock.getsockname()[1]; sock.close()
+server = http.server.HTTPServer(("127.0.0.1", port), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+base = f"http://127.0.0.1:{port}"
+
+failures = []
+try:
+    clea.http_get(f"{base}/limited")
+    failures.append("a 403 did not raise")
+except clea.CleaError as exc:
+    if "GITHUB_TOKEN" not in str(exc):
+        failures.append(f"the 403 message does not name the fix: {exc}")
+
+got = clea.latest_url_text("k8s", None, url=f"{base}/ok",
+                           extract=r"^(?P<v>v[0-9][0-9A-Za-z.-]*)$")
+if got["tag"] != "v9.9.9":
+    failures.append(f"url-text read {got['tag']!r}")
+try:
+    clea.latest_url_text("k8s", None, url=f"{base}/ok", extract=r"^(?P<v>NOPE)$")
+    failures.append("an extract that matches nothing did not raise")
+except clea.CleaError:
+    pass
+server.shutdown()
+for f in failures:
+    print("  \033[31m✗\033[0m " + f)
+if not failures:
+    print("  \033[32m✓\033[0m a 403 raises and names GITHUB_TOKEN")
+    print("  \033[32m✓\033[0m url-text extracts, and refuses to invent a version")
+sys.exit(1 if failures else 0)
+PY
+if [ $? -eq 0 ]; then PASS=$((PASS + 2)); else FAIL=$((FAIL + 1)); fi
+
+echo
+echo "=== the helm index reader picks the newest, not the first ==="
+python3 - "$CLEA" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("clea", sys.argv[1])
+clea = importlib.util.module_from_spec(spec); spec.loader.exec_module(clea)
+INDEX = b"""apiVersion: v1
+entries:
+  cilium:
+    - version: 1.20.0
+    - version: 1.19.2
+    - version: 1.21.0-rc.1
+    - version: 1.20.10
+  other:
+    - version: 99.0.0
+"""
+clea.http_get = lambda url, *a, **k: INDEX
+got = clea.latest_helm("cilium", None, registry_url="https://example.invalid")
+ok = got["tag"] == "1.20.10"
+print(("  \033[32m✓\033[0m " if ok else "  \033[31m✗\033[0m ")
+      + f"1.20.10 beats 1.20.0 and the rc, and the next entry is not read (got {got['tag']})")
+sys.exit(0 if ok else 1)
+PY
+if [ $? -eq 0 ]; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); fi
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/dev/test-clea.sh
+++ b/scripts/dev/test-clea.sh
@@ -281,6 +281,32 @@ expect 1 "a probe that cannot start a container exits non-zero" \
        acme/two v0.10.0 /bin/true "echo 0.10.0"
 
 echo
+echo "=== one dependency, two shapes, one bump ==="
+# This repository pins fluxcd/flux2 as `v2.9.3` where the value builds a release
+# URL and as `2.9.3` where it builds a filename. Both are correct, and only the
+# upstream TAG can become both — `bump` re-applies extractVersion per site. The
+# matrix used to carry one anchor's extracted form, chosen by whichever file
+# sorted first: right by luck, wrong the moment a path changed.
+cp -r "$TMP/basic" "$TMP/shapes"
+cat > "$TMP/shapes/scripts/two-shapes.sh" <<'EOF'
+#!/usr/bin/env bash
+# clea-test: datasource=github-releases depName=acme/twoshape
+URL_VERSION="${URL_VERSION:-v3.0.0}"
+# clea-test: datasource=github-releases depName=acme/twoshape extractVersion=^v(?<version>.*)$
+FILE_VERSION="3.0.0"
+EOF
+expect 0 "the tag moves both shapes at once" \
+  -- python3 "$CLEA" --root "$TMP/shapes" bump acme/twoshape v3.1.0
+if grep -q 'URL_VERSION:-v3.1.0' "$TMP/shapes/scripts/two-shapes.sh" &&
+   grep -q 'FILE_VERSION="3.1.0"' "$TMP/shapes/scripts/two-shapes.sh"; then
+  ok "each site got its own form — v3.1.0 and 3.1.0"
+else
+  bad "one of the two shapes was not written: $(grep VERSION "$TMP/shapes/scripts/two-shapes.sh" | tr '\n' ' ')"
+fi
+expect 1 "an extracted form cannot move the site that keeps the v" \
+  -- python3 "$CLEA" --root "$TMP/shapes" bump acme/twoshape 3.2.0
+
+echo
 echo "=== version comparison, and the pair every hand-rolled comparator gets wrong ==="
 python3 - "$CLEA" <<'PY'
 import importlib.util, sys, pathlib

--- a/scripts/dev/test-clea.sh
+++ b/scripts/dev/test-clea.sh
@@ -257,6 +257,30 @@ else
 fi
 
 echo
+echo "=== the probe refuses rather than destroy or pretend ==="
+# It bumps a pin and restores the tree with `git checkout -- .`. Run on a dirty
+# tree that discards somebody's work, and a probe that cannot start a container
+# must not exit 0 — a lane that reports success having run nothing is the whole
+# failure this file is written against.
+PROBE="$ROOT/scripts/clea/probe.sh"
+git -C "$TMP/basic" init -q 2>/dev/null
+git -C "$TMP/basic" add -A 2>/dev/null
+git -C "$TMP/basic" -c user.email=t@t -c user.name=t commit -qm fixture 2>/dev/null
+echo "dirty" >> "$TMP/basic/scripts/install.sh"
+expect 1 "a dirty tree is refused before anything is touched" \
+  -- env CLEA_ROOT="$TMP/basic" "$PROBE" acme/two v0.10.0 /bin/true "echo 0.10.0"
+git -C "$TMP/basic" checkout -q -- .
+if [ -n "$(git -C "$TMP/basic" status --porcelain --untracked-files=no)" ]; then
+  bad "the refusal happened after the tree was already restored"
+else
+  ok "and the refusal came before the trap that would have discarded it"
+fi
+# PATH without docker: the container lanes cannot start, and that is a failure.
+expect 1 "a probe that cannot start a container exits non-zero" \
+  -- env CLEA_ROOT="$TMP/basic" PATH=/usr/bin:/bin "$PROBE" \
+       acme/two v0.10.0 /bin/true "echo 0.10.0"
+
+echo
 echo "=== version comparison, and the pair every hand-rolled comparator gets wrong ==="
 python3 - "$CLEA" <<'PY'
 import importlib.util, sys, pathlib
@@ -328,29 +352,61 @@ PY
 if [ $? -eq 0 ]; then PASS=$((PASS + 2)); else FAIL=$((FAIL + 1)); fi
 
 echo
-echo "=== the helm index reader picks the newest, not the first ==="
+echo "=== the helm index: indent is the only structure a line scanner has ==="
 python3 - "$CLEA" <<'PY'
 import importlib.util, sys
 spec = importlib.util.spec_from_file_location("clea", sys.argv[1])
 clea = importlib.util.module_from_spec(spec); spec.loader.exec_module(clea)
-INDEX = b"""apiVersion: v1
+# Built from the real shape of https://helm.cilium.io/index.yaml, which is
+# 1.7 MB and embeds Kubernetes CRD listings inside an annotation. Reading every
+# `version:` line collected `v2` from depth 10, and (2,) outranks (1,20,1), so
+# the newest chart of a repository serving 1.20 came back as v2. Following the
+# annotation's own list items then re-based the scan and it came back 1.8.13.
+# Both were seen against the live index before this fixture existed.
+INDEX = b'''apiVersion: v1
 entries:
   cilium:
-    - version: 1.20.0
-    - version: 1.19.2
-    - version: 1.21.0-rc.1
-    - version: 1.20.10
-  other:
-    - version: 99.0.0
-"""
+  - annotations:
+      artifacthub.io/crds: "- kind: CiliumNetworkPolicy\\n  version: v2\\n  name: x\\n"
+      artifacthub.io/links: |
+        - name: a
+          version: v2
+        - name: b
+          version: v2
+      artifacthub.io/prerelease: |
+          version: 99.9.9
+    apiVersion: v2
+    appVersion: 1.20.1
+    name: cilium
+    version: 1.20.1
+  - annotations:
+      deep:
+          version: v2
+    apiVersion: v2
+    version: 1.19.2
+  - apiVersion: v2
+    version: 1.21.0-rc.1
+  - apiVersion: v2
+    version: 1.8.13
+  zzz-other-chart:
+  - version: 99.0.0
+'''
 clea.http_get = lambda url, *a, **k: INDEX
-got = clea.latest_helm("cilium", None, registry_url="https://example.invalid")
-ok = got["tag"] == "1.20.10"
-print(("  \033[32m✓\033[0m " if ok else "  \033[31m✗\033[0m ")
-      + f"1.20.10 beats 1.20.0 and the rc, and the next entry is not read (got {got['tag']})")
-sys.exit(0 if ok else 1)
+got = clea.latest_helm("cilium", None, registry_url="https://example.invalid")["tag"]
+checks = [
+    ("v2 at depth 10 is not a chart version", got != "v2"),
+    ("the annotation's own list items do not re-base the scan", got != "1.8.13"),
+    ("1.20.1 beats 1.19.2, 1.8.13 and the rc", got == "1.20.1"),
+    ("the next entry is not read", got != "99.0.0"),
+    # Load-bearing on its own: 99.9.9 IS semver, so only the indent says no.
+    ("a semver-shaped value at the wrong depth is not a chart version",
+     got != "99.9.9"),
+]
+for name, ok in checks:
+    print(("  \033[32m\u2713\033[0m " if ok else "  \033[31m\u2717\033[0m ") + f"{name} (got {got})")
+sys.exit(1 if [c for c in checks if not c[1]] else 0)
 PY
-if [ $? -eq 0 ]; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); fi
+if [ $? -eq 0 ]; then PASS=$((PASS + 5)); else FAIL=$((FAIL + 1)); fi
 
 echo
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"

--- a/scripts/dev/test-clea.sh
+++ b/scripts/dev/test-clea.sh
@@ -304,6 +304,54 @@ PY
 if [ $? -eq 0 ]; then PASS=$((PASS + 8)); else FAIL=$((FAIL + 1)); fi
 
 echo
+echo "=== the bot heartbeat: silence only means something when crossed ==="
+python3 - "$CLEA" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("clea", sys.argv[1])
+clea = importlib.util.module_from_spec(spec); spec.loader.exec_module(clea)
+
+def state(days, behind=True, watched=True):
+    return {"generated_at": "now", "deps": [{
+        "dep": "helm/helm", "file": "scripts/setup.sh", "line": 225,
+        "current": "4.2.3", "latest": "4.2.4", "pinned": True,
+        "behind": behind, "watched": watched, "shape_ok": True}],
+        "bot": {"bot": "renovate[bot]", "number": 11, "at": "2026-07-30",
+                "days": days, "scanned": 100, "silent_after_days": 8}}
+
+warn = "and it has proposed nothing"
+checks = [
+    ("behind, watched, 24 days silent -> the report says so",
+     warn in clea.render_report(state(24))),
+    ("behind but within the window -> nothing concluded",
+     warn not in clea.render_report(state(3))),
+    ("silent but nothing behind -> silence proves nothing",
+     "proves\nnothing either way" in clea.render_report(state(24, behind=False))
+     or "proves nothing either way" in clea.render_report(state(24, behind=False))),
+    ("behind but the bot cannot see it -> not the bot's fault",
+     warn not in clea.render_report(state(24, watched=False))),
+]
+
+# The query itself: a bot with no pull request at all, and one that answers.
+PRS = [{"number": 40, "user": {"login": "a-human"}, "created_at": "2026-08-20T00:00:00Z"},
+       {"number": 11, "user": {"login": "renovate[bot]"}, "created_at": "2026-07-30T05:50:28Z"}]
+clea._gh_json = lambda path, token: PRS
+got = clea.bot_activity("o/r", "renovate[bot]", None)
+checks.append(("the newest pull request by the bot is found, not the newest overall",
+               got["number"] == 11 and got["days"] is not None and got["days"] > 20))
+clea._gh_json = lambda path, token: [PRS[0]]
+none = clea.bot_activity("o/r", "renovate[bot]", None)
+checks.append(("a bot with no pull request at all is reported, not assumed fine",
+               none["number"] is None and none["scanned"] == 1))
+checks.append(("and the report says which", "No pull request from" in
+               clea.render_report({"deps": [], "bot": dict(none, silent_after_days=8)})))
+
+for name, ok in checks:
+    print(("  \033[32m\u2713\033[0m " if ok else "  \033[31m\u2717\033[0m ") + name)
+sys.exit(1 if [c for c in checks if not c[1]] else 0)
+PY
+if [ $? -eq 0 ]; then PASS=$((PASS + 7)); else FAIL=$((FAIL + 1)); fi
+
+echo
 echo "=== a rate-limited datasource is an error, never 'up to date' ==="
 python3 - "$CLEA" <<'PY'
 import http.server, importlib.util, socket, sys, threading

--- a/scripts/dev/test-setup-checks.sh
+++ b/scripts/dev/test-setup-checks.sh
@@ -123,13 +123,25 @@ sudostub() { # <rc of `sudo -n true`>
 }
 lib() { PATH="$TMP/bin:$PATH" bash -c '. "$1"; shift; "$@"' _ "$LIB" "$@"; }
 
+# Only the stub directory on PATH. Removing the sudo stub is NOT enough: a
+# GitHub runner has a real, PASSWORDLESS sudo, so the "absent" case fell through
+# to it and judged absent sudo usable — green on a workstation, red in CI. The
+# same mistake as the missing-tool cases above, made two sections after the
+# comment warning about it.
+#
+# /bin/bash by absolute path, because with PATH reduced to the stub directory
+# `bash` itself stops being findable: the call dies 127 and the `&&` chain reads
+# that as the answer, so the assertion passes having run nothing. oa_sudo_usable
+# calls no external command, so the bare PATH costs it nothing.
+lib_bare() { env PATH="$TMP/bin" /bin/bash -c '. "$1"; shift; "$@"' _ "$LIB" "$@"; }
+
 sudostub 0
 lib oa_sudo_usable && ok "passwordless sudo is usable" || bad "passwordless sudo judged unusable"
 sudostub 1
 lib oa_sudo_usable && bad "sudo that would prompt was judged usable with no terminal" \
                    || ok "sudo that would prompt, with no terminal, is not usable"
 rm -f "$TMP/bin/sudo"
-lib oa_sudo_usable && bad "absent sudo judged usable" || ok "absent sudo is not usable"
+lib_bare oa_sudo_usable && bad "absent sudo judged usable" || ok "absent sudo is not usable"
 
 echo
 echo "=== and where a binary should go ==="

--- a/scripts/dev/test-setup-checks.sh
+++ b/scripts/dev/test-setup-checks.sh
@@ -111,5 +111,53 @@ run 1 "absent with a pin" clea-absent-by-construction 4.2.3
 run 1 "absent without one" clea-absent-by-construction
 
 echo
+echo "=== sudo that exists is not sudo that can be used ==="
+# Eight places asked `command -v sudo`. On a workstation where /usr/local/bin is
+# not writable and sudo wants a password, that answers yes and the installer
+# then dies on a prompt nobody can answer — under `set -e`, taking the whole
+# bootstrap with it. Measured 2026-08-24 on exactly such a machine.
+LIB="$ROOT/scripts/lib/common.sh"
+sudostub() { # <rc of `sudo -n true`>
+  printf '#!/bin/sh\n[ "$1" = -n ] && exit %s\nexec "$@"\n' "$1" > "$TMP/bin/sudo"
+  chmod +x "$TMP/bin/sudo"
+}
+lib() { PATH="$TMP/bin:$PATH" bash -c '. "$1"; shift; "$@"' _ "$LIB" "$@"; }
+
+sudostub 0
+lib oa_sudo_usable && ok "passwordless sudo is usable" || bad "passwordless sudo judged unusable"
+sudostub 1
+lib oa_sudo_usable && bad "sudo that would prompt was judged usable with no terminal" \
+                   || ok "sudo that would prompt, with no terminal, is not usable"
+rm -f "$TMP/bin/sudo"
+lib oa_sudo_usable && bad "absent sudo judged usable" || ok "absent sudo is not usable"
+
+echo
+echo "=== and where a binary should go ==="
+sudostub 0
+[ "$(lib oa_bin_dir)" = /usr/local/bin ] \
+  && ok "with a usable sudo, the system directory" \
+  || bad "with a usable sudo, got $(lib oa_bin_dir)"
+sudostub 1
+if [ -w /usr/local/bin ]; then
+  echo "  ~ /usr/local/bin is writable here (root?), so the fallback case is NOT exercised"
+elif [ "$(lib oa_bin_dir)" = "$HOME/.local/bin" ]; then
+  ok "with no usable sudo, the per-user directory"
+else
+  bad "with no usable sudo, got $(lib oa_bin_dir)"
+fi
+
+mkdir -p "$TMP/writable"
+[ -z "$(lib oa_sudo_for "$TMP/writable")" ] \
+  && ok "a writable directory needs no sudo" || bad "a writable directory asked for sudo"
+[ -z "$(lib oa_sudo_for "$TMP/writable/not-created-yet")" ] \
+  && ok "a directory yet to be created is judged by its parent" \
+  || bad "creating a subdirectory of a writable one asked for sudo"
+sudostub 0
+[ "$(lib oa_sudo_for /usr/local/bin)" = "sudo" ] || [ -w /usr/local/bin ] \
+  && ok "a directory needing privilege gets the prefix" \
+  || bad "a directory needing privilege got no prefix"
+rm -f "$TMP/bin/sudo"
+
+echo
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/dev/test-setup-checks.sh
+++ b/scripts/dev/test-setup-checks.sh
@@ -29,8 +29,18 @@ grep -q 'command -v' "$TMP/fn.sh" || {
   exit 1
 }
 
-stub() { # <name> <what `version` prints>
-  printf '#!/bin/sh\nprintf "%%s\\n" "%s"\n' "$2" > "$TMP/bin/$1"
+stub() { # <name> <what both probes print>
+  stub2 "$1" "$2" "$2"
+}
+
+stub2() { # <name> <what --version prints> <what version prints> [rc-of--version]
+  cat > "$TMP/bin/$1" <<EOF
+#!/bin/sh
+case "\$1" in
+  --version) [ -n "$2" ] && printf '%s\n' "$2"; exit ${4:-0} ;;
+  version)   [ -n "$3" ] && printf '%s\n' "$3"; exit 0 ;;
+esac
+EOF
   chmod +x "$TMP/bin/$1"
 }
 mkdir -p "$TMP/bin"
@@ -56,6 +66,27 @@ run 0 "the pinned version installed" helm 4.2.3
 run 1 "a different version is refused, not accepted as present" helm 4.2.4
 grep -q '↻' "$TMP/last" && ok "and it says the version is not the pinned one" \
   || bad "the refusal does not name what it found"
+
+echo
+echo "=== which probe answers differs per tool, and emptiness is the signal ==="
+# Measured on this repository's own seven: helm, kubectl and talosctl answer
+# only `version`; flux, tflint and task answer only `--version`, and
+# `task version` prints the task LIST. Exit codes do not discriminate — several
+# return 0 with nothing at all.
+stub2 onlyversion "" "v1.2.3"
+run 0 "a tool that answers only on version" onlyversion 1.2.3
+stub2 onlydash "v1.2.3" ""
+run 0 "a tool that answers only on --version" onlydash 1.2.3
+stub2 mute "" ""
+run 1 "a tool that answers neither cannot satisfy a pin" mute 1.2.3
+run 0 "and with no pin it is still just present" mute
+
+# The one that matters: `$(a || b)` concatenated both answers when the first
+# printed and then failed, so a version string was assembled out of two
+# commands and TWO different pins would both match it.
+stub2 noisy "9.9.9" "1.2.3" 1
+run 0 "the first non-empty answer is the answer" noisy 9.9.9
+run 1 "and the second is not appended to it" noisy 1.2.3
 
 echo
 echo "=== the comparison is bounded on both sides ==="

--- a/scripts/dev/test-setup-checks.sh
+++ b/scripts/dev/test-setup-checks.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# setup.sh asks whether a tool is CURRENT, not merely present.
+#
+# The bare presence check installed the pin on a fresh machine and refused every
+# upgrade afterwards, in silence, on every machine that had run the script once.
+# Measured 2026-08-23 by the Cléa probe: a cold install reached helm 4.2.4 while
+# upgrading over 4.2.3 left 4.2.3. The same shape had been found and fixed for
+# feint two days earlier (scripts/dev/feint.sh:310), which is why it gets a
+# harness rather than a comment.
+#
+# The function is extracted and driven against stub binaries: setup.sh runs its
+# whole bootstrap when sourced, so there is nothing to import.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+sed -n '/^check_cmd() {/,/^}/p' "$ROOT/scripts/setup.sh" > "$TMP/fn.sh"
+# ZERO FLOOR: an extractor that returns nothing makes every assertion below pass
+# vacuously, which is the exact shape this file exists against.
+grep -q 'command -v' "$TMP/fn.sh" || {
+  echo "✗ could not extract check_cmd from setup.sh — the extractor is broken, not the script" >&2
+  exit 1
+}
+
+stub() { # <name> <what `version` prints>
+  printf '#!/bin/sh\nprintf "%%s\\n" "%s"\n' "$2" > "$TMP/bin/$1"
+  chmod +x "$TMP/bin/$1"
+}
+mkdir -p "$TMP/bin"
+
+run() { # <expected-rc> <label> <tool> [pin]
+  local want="$1" label="$2"; shift 2
+  local out rc
+  out="$(PATH="$TMP/bin:$PATH" bash -c '
+    RED=""; GREEN=""; NC=""
+    . "$1"
+    check_cmd "${2}" "${3:-}"' _ "$TMP/fn.sh" "$@" 2>&1)"
+  rc=$?
+  if [ "$rc" -eq "$want" ]; then ok "$label"; else
+    bad "$label (exit $rc, wanted $want) — $out"
+  fi
+  printf '%s' "$out" > "$TMP/last"
+}
+
+echo "=== present is not current ==="
+stub helm "v4.2.3"
+run 0 "no pin given: presence is still the only question" helm
+run 0 "the pinned version installed" helm 4.2.3
+run 1 "a different version is refused, not accepted as present" helm 4.2.4
+grep -q '↻' "$TMP/last" && ok "and it says the version is not the pinned one" \
+  || bad "the refusal does not name what it found"
+
+echo
+echo "=== the comparison is bounded on both sides ==="
+stub helm "v4.2.30"
+run 1 "4.2.30 does not satisfy a 4.2.3 pin" helm 4.2.3
+stub helm "v14.2.3"
+run 1 "14.2.3 does not satisfy a 4.2.3 pin" helm 4.2.3
+
+echo
+echo "=== the leading v is optional on either side ==="
+stub tofu "OpenTofu v1.12.5"
+run 0 "a tool that prints v against a pin that does not" tofu 1.12.5
+stub flux "flux version 2.9.3"
+run 0 "a tool that prints neither" flux 2.9.3
+
+echo
+echo "=== a missing tool is missing, whatever the pin says ==="
+# A name nothing on this machine provides, rather than deleting the stub: the
+# host has a real helm, so removing the stub falls through to it and the
+# assertion passes for the wrong reason. A machine that works hides the defect.
+run 1 "absent with a pin" clea-absent-by-construction 4.2.3
+run 1 "absent without one" clea-absent-by-construction
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/internal/install-actionlint.sh
+++ b/scripts/internal/install-actionlint.sh
@@ -17,16 +17,11 @@ set -euo pipefail
 # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v(?<version>.*)$
 ACTIONLINT_VERSION="1.7.12"
 
-BIN_DIR="${1:-}"
-if [ -z "$BIN_DIR" ]; then
-  if [ -w /usr/local/bin ] || command -v sudo >/dev/null 2>&1; then
-    BIN_DIR=/usr/local/bin
-  else
-    BIN_DIR="$HOME/.local/bin"
-  fi
-fi
-SUDO=""
-[ -w "$BIN_DIR" ] || [ ! -d "$BIN_DIR" ] || SUDO="sudo"
+# shellcheck source=scripts/lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
+
+BIN_DIR="${1:-$(oa_bin_dir)}"
+SUDO="$(oa_sudo_for "$BIN_DIR")"
 
 # Bounded, so 1.7.7 does not match 1.7.70.
 if command -v actionlint >/dev/null 2>&1 &&

--- a/scripts/internal/install-actionlint.sh
+++ b/scripts/internal/install-actionlint.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v(?<version>.*)$
-ACTIONLINT_VERSION="1.7.7"
+ACTIONLINT_VERSION="1.7.12"
 
 BIN_DIR="${1:-}"
 if [ -z "$BIN_DIR" ]; then

--- a/scripts/internal/install-actionlint.sh
+++ b/scripts/internal/install-actionlint.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Install actionlint, pinned and checksum-verified.
+#
+# yamllint says a workflow file is well-formed YAML. It cannot say that
+# `needs.scan.outputs.matrix` names an output that exists, that a `${{ }}` is
+# valid where it sits, or that a `run:` block's shell is sound. Nothing here
+# could, and a scheduled workflow cannot be dry-run: its first execution is
+# production. actionlint answers all three statically, and runs shellcheck over
+# every `run:` block on the way.
+#
+# Same shape as the other installers here: a pinned version, the project's own
+# checksums file, and no third party in the path.
+#
+# Usage: install-actionlint.sh [bin-dir]   (default: /usr/local/bin, else ~/.local/bin)
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v(?<version>.*)$
+ACTIONLINT_VERSION="1.7.7"
+
+BIN_DIR="${1:-}"
+if [ -z "$BIN_DIR" ]; then
+  if [ -w /usr/local/bin ] || command -v sudo >/dev/null 2>&1; then
+    BIN_DIR=/usr/local/bin
+  else
+    BIN_DIR="$HOME/.local/bin"
+  fi
+fi
+SUDO=""
+[ -w "$BIN_DIR" ] || [ ! -d "$BIN_DIR" ] || SUDO="sudo"
+
+# Bounded, so 1.7.7 does not match 1.7.70.
+if command -v actionlint >/dev/null 2>&1 &&
+  actionlint --version 2>/dev/null |
+    grep -qE "(^|[^0-9.])${ACTIONLINT_VERSION//./\\.}([^0-9.]|\$)"; then
+  echo "actionlint ${ACTIONLINT_VERSION} already installed"
+  exit 0
+fi
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) asset="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" ;;
+  Linux-aarch64) asset="actionlint_${ACTIONLINT_VERSION}_linux_arm64.tar.gz" ;;
+  Darwin-x86_64) asset="actionlint_${ACTIONLINT_VERSION}_darwin_amd64.tar.gz" ;;
+  Darwin-arm64) asset="actionlint_${ACTIONLINT_VERSION}_darwin_arm64.tar.gz" ;;
+  *) echo "✗ no published actionlint binary for $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+base="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL -o "$tmp/$asset" "${base}/${asset}"
+curl -fsSL -o "$tmp/checksums.txt" "${base}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+# --ignore-missing: the file lists every platform, and without it the check
+# fails on the ones we did not download — which reads like a bad binary.
+(cd "$tmp" && sha256sum -c checksums.txt --ignore-missing)
+tar -xzf "$tmp/$asset" -C "$tmp" actionlint
+mkdir -p "$BIN_DIR"
+$SUDO install -m 0755 "$tmp/actionlint" "$BIN_DIR/actionlint"
+echo "actionlint ${ACTIONLINT_VERSION} installed to ${BIN_DIR}"

--- a/scripts/internal/install-kubectl-cnpg.sh
+++ b/scripts/internal/install-kubectl-cnpg.sh
@@ -19,16 +19,11 @@ set -euo pipefail
 # renovate: datasource=github-releases depName=cloudnative-pg/cloudnative-pg extractVersion=^v(?<version>.*)$
 CNPG_VERSION="1.23.6"
 
-BIN_DIR="${1:-}"
-if [ -z "$BIN_DIR" ]; then
-  if [ -w /usr/local/bin ] || command -v sudo >/dev/null 2>&1; then
-    BIN_DIR=/usr/local/bin
-  else
-    BIN_DIR="$HOME/.local/bin"
-  fi
-fi
-SUDO=""
-[ -w "$BIN_DIR" ] || [ ! -d "$BIN_DIR" ] || SUDO="sudo"
+# shellcheck source=scripts/lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
+
+BIN_DIR="${1:-$(oa_bin_dir)}"
+SUDO="$(oa_sudo_for "$BIN_DIR")"
 
 if command -v kubectl-cnpg >/dev/null 2>&1 &&
   kubectl-cnpg version 2>/dev/null | grep -qF "${CNPG_VERSION}"; then

--- a/scripts/internal/install-task.sh
+++ b/scripts/internal/install-task.sh
@@ -17,15 +17,11 @@ set -euo pipefail
 # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.*)$
 TASK_VERSION="3.52.0"
 
-BIN_DIR="${1:-}"
-if [ -z "$BIN_DIR" ]; then
-  if [ -w /usr/local/bin ]; then BIN_DIR=/usr/local/bin
-  elif command -v sudo >/dev/null 2>&1; then BIN_DIR=/usr/local/bin
-  else BIN_DIR="$HOME/.local/bin"
-  fi
-fi
-SUDO=""
-[ -w "$BIN_DIR" ] || [ ! -d "$BIN_DIR" ] || SUDO="sudo"
+# shellcheck source=scripts/lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
+
+BIN_DIR="${1:-$(oa_bin_dir)}"
+SUDO="$(oa_sudo_for "$BIN_DIR")"
 
 # `task --version` prints a bare "3.52.0" today and "Task version: v3.x.y" on
 # older releases, so match either, and bound it so 3.52.0 does not match 3.52.01.

--- a/scripts/internal/install-tflint.sh
+++ b/scripts/internal/install-tflint.sh
@@ -14,16 +14,11 @@ set -euo pipefail
 # renovate: datasource=github-releases depName=terraform-linters/tflint
 TFLINT_VERSION="v0.64.0"
 
-BIN_DIR="${1:-}"
-if [ -z "$BIN_DIR" ]; then
-  if [ -w /usr/local/bin ] || command -v sudo >/dev/null 2>&1; then
-    BIN_DIR=/usr/local/bin
-  else
-    BIN_DIR="$HOME/.local/bin"
-  fi
-fi
-SUDO=""
-[ -w "$BIN_DIR" ] || [ ! -d "$BIN_DIR" ] || SUDO="sudo"
+# shellcheck source=scripts/lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
+
+BIN_DIR="${1:-$(oa_bin_dir)}"
+SUDO="$(oa_sudo_for "$BIN_DIR")"
 
 if command -v tflint >/dev/null 2>&1 && tflint --version 2>/dev/null | grep -qF "${TFLINT_VERSION#v}"; then
   echo "tflint ${TFLINT_VERSION} already installed"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -10,6 +10,39 @@
 # and consistent — change a rule here, not in five places.
 # ==============================================================================
 
+# --- Can sudo actually be USED here, or does it merely exist? -----------------
+# `command -v sudo` answers the wrong question, and eight places asked it. On a
+# workstation where /usr/local/bin is not writable and sudo wants a password,
+# every installer chose the sudo branch and then died on a prompt nobody could
+# answer — under `set -e` that ends the whole bootstrap. Measured 2026-08-24.
+# Same shape as asking whether a binary exists rather than which version it is.
+oa_sudo_usable() {
+  command -v sudo >/dev/null 2>&1 || return 1
+  sudo -n true 2>/dev/null && return 0
+  [ -t 0 ]   # a human is here and can be asked
+}
+
+# --- Where to install a binary. Echoes the directory. -------------------------
+# /usr/local/bin when it is writable or reachable with a usable sudo; otherwise
+# ~/.local/bin, which needs no privilege at all.
+oa_bin_dir() {
+  if [ -w /usr/local/bin ] || oa_sudo_usable; then
+    printf '/usr/local/bin'
+  else
+    printf '%s/.local/bin' "${HOME}"
+  fi
+}
+
+# --- The sudo prefix needed to write into <dir>. Echoes "sudo" or nothing. ----
+# A directory that does not exist yet is judged by its parent, so creating
+# ~/.local/bin does not ask for a password.
+oa_sudo_for() {
+  local d="${1:?usage: oa_sudo_for <dir>}"
+  [ -d "$d" ] || d="$(dirname "$d")"
+  [ -w "$d" ] && return 0
+  oa_sudo_usable && printf 'sudo'
+}
+
 # --- AWS CLI quirk: S3-compatible stores (OOS, OVH, Scaleway) reject the AWS
 # CLI v2.23+ default trailing checksum. Call once before any `aws` command.
 oa_aws_compat() {

--- a/scripts/ops/verify-provider-clean.py
+++ b/scripts/ops/verify-provider-clean.py
@@ -153,6 +153,19 @@ def outscale_leftovers(cluster: str) -> list[str]:
 
 CHECKS = {"openstack": openstack_leftovers, "outscale": outscale_leftovers}
 
+# What each check actually enumerates, and what it does not. Printed on success
+# because a teardown proof that says NOTHING when the account is clean looks
+# exactly like one that did not run — `docs/backlog.md` lists that shape twice,
+# once for a purge script and once for "an empty server list is not an empty
+# account", where seven block volumes billed for three days behind a clean
+# instance list.
+SCOPE = {
+    "openstack": "servers, load balancers",
+    "outscale": "VMs, unassociated public IPs",
+}
+UNCHECKED = ("volumes, snapshots, images and buckets are NOT enumerated here — "
+             "see scripts/ops/purge-orphans/")
+
 
 def main() -> int:
     if len(sys.argv) != 3:
@@ -175,6 +188,8 @@ def main() -> int:
         return 2
 
     if not leftovers:
+        print(f"✓ {provider}/{cluster}: nothing left (checked: {SCOPE[provider]})")
+        print(f"  {UNCHECKED}")
         return 0
     for item in leftovers:
         print(item)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -37,7 +37,7 @@ TOFU_VERSION="1.12.5"
 # renovate: datasource=github-releases depName=fluxcd/flux2 extractVersion=^v(?<version>.*)$
 FLUX_VERSION="2.9.3"
 # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
-HELM_VERSION="4.2.3"
+HELM_VERSION="4.2.4"
 
 # check_cmd <tool> [pinned-version]
 #

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -359,6 +359,12 @@ if ! check_cmd kubectl-cnpg; then
     "$(dirname "${BASH_SOURCE[0]}")/internal/install-kubectl-cnpg.sh"
 fi
 
+# 5b-ter. actionlint — `task lint` calls it. A workflow file is the one thing in
+# this repository that cannot be run before it is merged.
+if ! check_cmd actionlint; then
+    "$(dirname "${BASH_SOURCE[0]}")/internal/install-actionlint.sh"
+fi
+
 # 5c. Check checkov (`task security` runs it directly; only CI ever had it)
 if ! check_cmd checkov; then
     install_checkov

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,20 +20,63 @@ else
     echo -e "${RED}⚠ Neither root nor sudo: system-wide installs will fail.${NC}"
 fi
 
-# Helper to check command existence
+# The versions this repository pins, at the top so the checks below can compare
+# against them. They used to live inside their install functions, where nothing
+# could read them — see check_cmd.
+#
+# TOFU_VERSION MUST stay equal to tofu_version in .github/workflows/ci.yml, and
+# HELM_VERSION to HELM_VERSION there and to HELM_MAJOR_EXPECTED in
+# scripts/bootstrap/render-bootstrap-manifests.sh, which refuses to render on any
+# other major. check-version-drift.sh compares all of them.
+#
+# renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
+TOFU_VERSION="1.12.5"
+# renovate: datasource=github-releases depName=fluxcd/flux2 extractVersion=^v(?<version>.*)$
+FLUX_VERSION="2.9.3"
+# renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
+HELM_VERSION="4.2.3"
+
+# check_cmd <tool> [pinned-version]
+#
+# PRESENT IS NOT CURRENT. With no second argument this only asks whether the
+# binary exists, and that was the only question it ever asked: setup.sh
+# installed the pin on a fresh machine and refused every upgrade afterwards, in
+# silence, on every machine that had run it once. Measured 2026-08-23 by the
+# Cléa probe — cold install reached helm 4.2.4, upgrading over 4.2.3 left 4.2.3.
+# The same shape was found and fixed for feint on 2026-08-21
+# (scripts/dev/feint.sh:310).
+#
+# Only the tools this file PINS get the second argument. For the others there is
+# no version to compare against, and inventing one would be a check that cannot
+# fail; pinning them is a separate decision, in docs/backlog.md.
 check_cmd() {
-    if ! command -v "$1" &> /dev/null; then
-        echo -e "${RED}✖ $1 is missing${NC}"
+    local tool="$1" want="${2:-}" version
+    if ! command -v "$tool" &> /dev/null; then
+        echo -e "${RED}✖ $tool is missing${NC}"
         return 1
-    else
-        VERSION=$("$1" version 2>/dev/null || "$1" --version 2>/dev/null || echo "detected")
-        echo -e "${GREEN}✔ $1 is installed${NC} ($VERSION)"
-        return 0
     fi
+    version=$("$tool" version 2>/dev/null || "$tool" --version 2>/dev/null || echo "detected")
+    # Bounded on both sides: 4.2.3 must not match 4.2.30, and the leading v is
+    # optional because half of these print it and half do not.
+    if [ -n "$want" ] && ! grep -qE "(^|[^0-9.])v?${want//./\\.}([^0-9.]|$)" <<< "$version"; then
+        echo -e "${RED}↻ $tool is not the pinned ${want}${NC} (found: $(head -1 <<< "$version"))"
+        return 1
+    fi
+    echo -e "${GREEN}✔ $tool is installed${NC} ($version)"
+    return 0
 }
 
 install_tofu() {
-    echo "Installing OpenTofu..."
+    # Pinned, and passed to the installer explicitly. Without it the official
+    # script asks the GitHub API which version is newest — UNAUTHENTICATED, 60
+    # requests an hour from an IP shared with every other customer of the
+    # platform. That is what took `main` red on 2026-08-13 through a different
+    # tool, and here it is worse: this is the FIRST step, so `set -e` takes the
+    # whole bootstrap with it and nothing at all gets installed. Measured
+    # 2026-08-23 in a bare ubuntu:24.04, exit 2, by the Cléa probe.
+    # MUST stay equal to tofu_version in .github/workflows/ci.yml —
+    # check-version-drift.sh compares them.
+    echo "Installing OpenTofu v${TOFU_VERSION}..."
     if command -v snap &> /dev/null; then
         $SUDO snap install --classic opentofu
     elif command -v brew &> /dev/null; then
@@ -66,7 +109,7 @@ install_tofu() {
         tmp="$(mktemp)"
         trap 'rm -f "$tmp"' RETURN
         curl -fsSL https://get.opentofu.org/install-opentofu.sh -o "$tmp"
-        sh "$tmp" --install-method standalone
+        sh "$tmp" --install-method standalone --opentofu-version "${TOFU_VERSION}"
     fi
 }
 
@@ -214,8 +257,6 @@ install_image_tools() {
 }
 
 install_flux() {
-    # renovate: datasource=github-releases depName=fluxcd/flux2 extractVersion=^v(?<version>.*)$
-    local FLUX_VERSION="2.9.3"
     local ARCH="linux_amd64"
     echo "Installing Flux CLI v${FLUX_VERSION}..."
     local tmp
@@ -241,8 +282,6 @@ install_helm() {
     # those required 4, so a fresh clone got a toolchain that could not run
     # `task local-up` — the credential-free rung the README calls the best first
     # step. The mismatch was invisible to anyone who already had helm 4.
-    # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
-    local HELM_VERSION="4.2.3"
     local ARCH="linux-amd64"
     echo "Installing Helm v${HELM_VERSION}..."
     local tmp
@@ -277,7 +316,7 @@ install_precommit() {
 }
 
 # 1. Check OpenTofu
-if ! check_cmd tofu; then
+if ! check_cmd tofu "$TOFU_VERSION"; then
     install_tofu
 fi
 
@@ -335,13 +374,13 @@ if [ "$MISSING_IMG_TOOLS" -eq 1 ]; then
 fi
 
 # 7. Check Flux CLI
-if ! check_cmd flux; then
+if ! check_cmd flux "$FLUX_VERSION"; then
     install_flux
 fi
 
 # 8. Check Helm — render-bootstrap-manifests.sh runs `helm template`, so every
 # path that renders Cilium or Flux needs it, including `task local-up`.
-if ! check_cmd helm; then
+if ! check_cmd helm "$HELM_VERSION"; then
     install_helm
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,13 +11,16 @@ echo -e "${GREEN}🌐 Checking OpenAether Development Environment...${NC}"
 # Root in a container has no sudo and needs none. Bare `sudo` calls exited 127
 # there, and set -e took the whole bootstrap with them: on a clean machine this
 # died at yamllint and never reached task, flux or helm.
+# shellcheck source=scripts/lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
 if [ "$(id -u)" -eq 0 ]; then
     SUDO=""
-elif command -v sudo &> /dev/null; then
+elif oa_sudo_usable; then
     SUDO="sudo"
 else
     SUDO=""
-    echo -e "${RED}⚠ Neither root nor sudo: system-wide installs will fail.${NC}"
+    echo -e "${RED}⚠ Neither root nor a usable sudo: system-wide installs will fail.${NC}"
 fi
 
 # The versions this repository pins, at the top so the checks below can compare
@@ -88,41 +91,58 @@ install_tofu() {
     # 2026-08-23 in a bare ubuntu:24.04, exit 2, by the Cléa probe.
     # MUST stay equal to tofu_version in .github/workflows/ci.yml —
     # check-version-drift.sh compares them.
+    #
+    # snap and brew used to come first here, and both had to go. Neither can
+    # install a NAMED version — `snap install --classic opentofu` serves
+    # whatever the channel holds — so on any machine with snap the pin above
+    # was decorative. That is how this repository's own workstation ended up on
+    # 1.12.6 against a pinned 1.12.5 (measured 2026-08-24). A pin an installer
+    # cannot honour is a pin that guarantees drift, and check-version-drift.sh
+    # now compares this one. The standalone installer honours it, and installs
+    # without root when asked to.
     echo "Installing OpenTofu v${TOFU_VERSION}..."
-    if command -v snap &> /dev/null; then
-        $SUDO snap install --classic opentofu
-    elif command -v brew &> /dev/null; then
-        brew install opentofu
-    else
-        # The official installer unzips its download and verifies the signature,
-        # refusing to run without unzip, and without either cosign or gpg. A
-        # minimal image has none of them: it aborted here, and set -e meant
-        # nothing at all got installed — not even the tools further down.
-        local need=()
-        # curl belongs here too: it is used ten lines down, and a bare ubuntu:24.04
-        # has none of these. Listing only two of the three left the same abort this
-        # comment describes — exit 127, nothing installed.
-        command -v curl &> /dev/null || need+=(curl ca-certificates)
-        command -v unzip &> /dev/null || need+=(unzip)
-        { command -v gpg &> /dev/null || command -v cosign &> /dev/null; } || need+=(gnupg)
-        if [ ${#need[@]} -gt 0 ]; then
-            if command -v apt-get &> /dev/null; then
-                $SUDO apt-get update && $SUDO apt-get install -y "${need[@]}"
-            else
-                echo "⚠️  OpenTofu's installer needs: ${need[*]}"
-                echo "    Install them, then re-run ./scripts/setup.sh"
-                return 1
-            fi
+    # The official installer unzips its download and verifies the signature,
+    # refusing to run without unzip, and without either cosign or gpg. A
+    # minimal image has none of them: it aborted here, and set -e meant
+    # nothing at all got installed — not even the tools further down.
+    local need=()
+    # curl belongs here too: it is used ten lines down, and a bare ubuntu:24.04
+    # has none of these. Listing only two of the three left the same abort this
+    # comment describes — exit 127, nothing installed.
+    command -v curl &> /dev/null || need+=(curl ca-certificates)
+    command -v unzip &> /dev/null || need+=(unzip)
+    { command -v gpg &> /dev/null || command -v cosign &> /dev/null; } || need+=(gnupg)
+    if [ ${#need[@]} -gt 0 ]; then
+        if command -v apt-get &> /dev/null; then
+            $SUDO apt-get update && $SUDO apt-get install -y "${need[@]}"
+        else
+            echo "⚠️  OpenTofu's installer needs: ${need[*]}"
+            echo "    Install them, then re-run ./scripts/setup.sh"
+            return 1
         fi
-        # Downloads to $TMPDIR, not to the CWD: the `rm` this replaced sat
-        # AFTER the installer, so under `set -e` a failed install left a 50 KB
-        # third-party script in the root of a public repository.
-        local tmp
-        tmp="$(mktemp)"
-        trap 'rm -f "$tmp"' RETURN
-        curl -fsSL https://get.opentofu.org/install-opentofu.sh -o "$tmp"
-        sh "$tmp" --install-method standalone --opentofu-version "${TOFU_VERSION}"
     fi
+    # Downloads to $TMPDIR, not to the CWD: the `rm` this replaced sat
+    # AFTER the installer, so under `set -e` a failed install left a 50 KB
+    # third-party script in the root of a public repository.
+    local tmp
+    tmp="$(mktemp)"
+    trap 'rm -f "$tmp"' RETURN
+    curl -fsSL https://get.opentofu.org/install-opentofu.sh -o "$tmp"
+    # Where the binary goes follows the same rule as every other tool here:
+    # the system path when it is reachable, the per-user one otherwise. The
+    # default (/opt/opentofu + /usr/local/bin) needs root, and asking for it
+    # on a machine that cannot give it is what aborted this step.
+    local bin data
+    bin="$(oa_bin_dir)"
+    if [ "$bin" = /usr/local/bin ]; then
+        data=/opt/opentofu
+    else
+        data="${HOME}/.local/share/openaether/opentofu"
+    fi
+    $(oa_sudo_for "$bin") sh "$tmp" --install-method standalone \
+        --opentofu-version "${TOFU_VERSION}" \
+        --install-path "$data" --symlink-path "$bin"
+    [ "$bin" = /usr/local/bin ] || echo "NOTE: tofu installed to $bin. Ensure it's in your PATH."
 }
 
 install_talosctl() {
@@ -140,15 +160,11 @@ install_kubectl() {
     echo "Installing kubectl..."
     curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
     chmod +x kubectl
-    if [ -w /usr/local/bin ]; then
-        mv kubectl /usr/local/bin/
-    elif command -v sudo &> /dev/null; then
-        $SUDO mv kubectl /usr/local/bin/
-    else
-        mkdir -p ~/.local/bin
-        mv kubectl ~/.local/bin/
-        echo "NOTE: kubectl installed to ~/.local/bin. Ensure it's in your PATH."
-    fi
+    local dir sudo_cmd
+    dir="$(oa_bin_dir)"; sudo_cmd="$(oa_sudo_for "$dir")"
+    mkdir -p "$dir"
+    $sudo_cmd mv kubectl "$dir/kubectl"
+    [ "$dir" = /usr/local/bin ] || echo "NOTE: kubectl installed to $dir. Ensure it's in your PATH."
 }
 
 install_shellcheck() {
@@ -275,15 +291,11 @@ install_flux() {
     tmp="$(mktemp -d)"
     curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_${ARCH}.tar.gz" -o "$tmp/flux.tar.gz"
     tar -xzf "$tmp/flux.tar.gz" -C "$tmp"
-    if [ -w /usr/local/bin ]; then
-        install -m 755 "$tmp/flux" /usr/local/bin/flux
-    elif command -v sudo &> /dev/null; then
-        $SUDO install -m 755 "$tmp/flux" /usr/local/bin/flux
-    else
-        mkdir -p ~/.local/bin
-        install -m 755 "$tmp/flux" ~/.local/bin/flux
-        echo "NOTE: flux installed to ~/.local/bin. Ensure it's in your PATH."
-    fi
+    local dir sudo_cmd
+    dir="$(oa_bin_dir)"; sudo_cmd="$(oa_sudo_for "$dir")"
+    mkdir -p "$dir"
+    $sudo_cmd install -m 755 "$tmp/flux" "$dir/flux"
+    [ "$dir" = /usr/local/bin ] || echo "NOTE: flux installed to $dir. Ensure it's in your PATH."
     rm -rf "$tmp"
 }
 
@@ -300,15 +312,11 @@ install_helm() {
     tmp="$(mktemp -d)"
     curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-${ARCH}.tar.gz" -o "$tmp/helm.tar.gz"
     tar -xzf "$tmp/helm.tar.gz" -C "$tmp"
-    if [ -w /usr/local/bin ]; then
-        install -m 755 "$tmp/${ARCH}/helm" /usr/local/bin/helm
-    elif command -v sudo &> /dev/null; then
-        $SUDO install -m 755 "$tmp/${ARCH}/helm" /usr/local/bin/helm
-    else
-        mkdir -p ~/.local/bin
-        install -m 755 "$tmp/${ARCH}/helm" ~/.local/bin/helm
-        echo "NOTE: helm installed to ~/.local/bin. Ensure it's in your PATH."
-    fi
+    local dir sudo_cmd
+    dir="$(oa_bin_dir)"; sudo_cmd="$(oa_sudo_for "$dir")"
+    mkdir -p "$dir"
+    $sudo_cmd install -m 755 "$tmp/${ARCH}/helm" "$dir/helm"
+    [ "$dir" = /usr/local/bin ] || echo "NOTE: helm installed to $dir. Ensure it's in your PATH."
     rm -rf "$tmp"
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -55,7 +55,19 @@ check_cmd() {
         echo -e "${RED}✖ $tool is missing${NC}"
         return 1
     fi
-    version=$("$tool" version 2>/dev/null || "$tool" --version 2>/dev/null || echo "detected")
+    # First NON-EMPTY answer, and `--version` asked first. Measured on this
+    # repository's seven tools: helm, kubectl and talosctl answer only `version`;
+    # flux, tflint and task answer only `--version`, and `task version` prints
+    # the task LIST. Exit codes do not discriminate — several return 0 with no
+    # output — and the previous `$(a || b)` form concatenated both answers when
+    # the first failed after printing, which is a version string assembled from
+    # two commands.
+    version=""
+    for flag in --version version; do
+        version="$("$tool" "$flag" 2>/dev/null || true)"
+        if [ -n "$version" ]; then break; fi
+    done
+    [ -n "$version" ] || version="detected"
     # Bounded on both sides: 4.2.3 must not match 4.2.30, and the leading v is
     # optional because half of these print it and half do not.
     if [ -n "$want" ] && ! grep -qE "(^|[^0-9.])v?${want//./\\.}([^0-9.]|$)" <<< "$version"; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -37,7 +37,7 @@ TOFU_VERSION="1.12.5"
 # renovate: datasource=github-releases depName=fluxcd/flux2 extractVersion=^v(?<version>.*)$
 FLUX_VERSION="2.9.3"
 # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
-HELM_VERSION="4.2.4"
+HELM_VERSION="4.2.3"
 
 # check_cmd <tool> [pinned-version]
 #


### PR DESCRIPTION
## What this adds

**Cléa** — `scripts/clea/` — answers three questions about this repository every
day, and holds no knowledge of it: everything specific is in `clea.toml`.

1. **What has moved upstream** since the pins in this tree were written.
2. **Is anything pinned that nothing watches.** An anchor a bot cannot read is a
   pin nobody will ever bump, and it looks exactly like a healthy one.
3. **Does the bump survive being installed** — from cold, and *over the version
   that was already there*.

It does **not** open bump pull requests. Renovate keeps that job;
`.github/dependabot.yml` records what happened the last time two bots proposed
the same dependency. `.github/workflows/clea.yml` runs it: daily for tools,
weekly for the local Talos cluster, never for a cloud.

Python, standard library only. `task lint` gains `clea coverage` (offline,
milliseconds) and `actionlint`; `task test-scripts` gains two harnesses.

## Why

Renovate cannot say what it is **not** watching, and it installs nothing. Both
gaps were load-bearing here:

- **Nine of twenty-one version anchors were inert.** The `# renovate:` comment
  was there; no `fileMatch` reached the file or the key; Renovate ignores such
  an anchor in silence. `commitizen` had been pinned at a version released
  **2025-09-10** — eleven months — behind one of them. The six custom managers
  are now three, matched on the *shape* of a value rather than the names of the
  keys holding it, in the current `managerFilePatterns` spelling.
- **Renovate has proposed nothing since its config landed.** Its nine pull
  requests were created three hours *before* `renovate.json5` existed, and
  nothing since. Two independent misses settle it: `helm` 4.2.4 published
  2026-08-13 and `flux` 2.9.4 published 2026-08-07, both on anchors it could
  always see, with the scheduled windows of 2026-08-10 and 2026-08-17 passing.
  The window goes from six hours weekly to six hours daily and
  `dependencyDashboard` becomes explicit — issues were disabled on this
  repository until 2026-08-21, so it had nowhere to report a problem or its own
  state. Cléa now crosses "the bot is silent" with "something it watches is
  behind", which is the only form of that observation that means anything.

## What it found by running

Six defects, none visible from a green pipeline. Each was measured, and each
fix was watched to fail before it was kept.

| | found by | measured |
|---|---|---|
| `command -v sudo` asks whether sudo **exists**, not whether it can be **used** — 8 sites | `task setup` on a workstation | `/usr/local/bin` unwritable + password-prompting sudo → the sudo branch → dead on a prompt → `set -e` ends the bootstrap at step one |
| `install_tofu` preferred snap, which **cannot install a named version** | the same run | that is exactly how this workstation ran OpenTofu 1.12.6 against a pinned 1.12.5 |
| `check_cmd` asked whether a tool was **present**, never which version | the probe, on a real bump | cold install reached helm 4.2.4; upgrading over 4.2.3 left 4.2.3 |
| a version string assembled from **two** commands | seven real tools | helm/kubectl/talosctl answer only `version`; flux/tflint/task only `--version`; `task version` prints the task list |
| the CoreDNS gate **failed on a healthy cluster** | the local cluster lane | instant read where the nodes wait 300s; red at T+15s, 2/2 at T+55s |
| `verify-provider-clean.py` printed **nothing** on a clean account | read-only calls to two providers | indistinguishable from a query that never ran — and it is the teardown proof |

Cléa also found two things in itself: its Helm index reader answered `v2` for a
repository serving 1.20 (1.7 MB of index with CRD listings at depth 10), and its
probe matrix carried one anchor's extracted form rather than the upstream tag —
`fluxcd/flux2` is pinned as `v2.9.3` where the value builds a URL and `2.9.3`
where it builds a filename, and only the tag can become both.

## Rungs

**Reached — mocked:** `task lint`, `task validate` on both roots, `task test`
(52), `task test-scripts` (**406 assertions across 13 harnesses**), `task
render-check`, gitleaks, `renovate-config-validator`, `actionlint`.

**Reached — real, on a workstation:**

- `task setup` → exit 0 for the first time on this machine; two real drifts
  caught and closed (`tofu` 1.12.6→1.12.5, `flux` **2.4.0**→2.9.3).
- **Local cluster lane, first execution ever**: `task local-up` on Talos v1.13.9
  / Kubernetes v1.36.4 at 1 CP + 1 worker → both nodes Ready, Cilium 2/2,
  CoreDNS serving, `local-verify` **6/6**, `local-down` leaving no container,
  volume, network or credential.
- **Four container probes**, bare `ubuntu:24.04`, three lanes each:
  `go-task/task` 3.53.1, `cloudnative-pg` **1.30.0** (seven minors),
  `helm` 4.2.4, `fluxcd/flux2` v2.9.4 — 3/3 each.
- **Read-only cloud**: Outscale and OVH quotas at 0 instances / 0 vCPU / 0 RAM,
  `verify-provider-clean` clean on both. Nothing created, modified or deleted.

**Skipped:**

- **Real cloud deployment.** No lane here carries a provider credential and each
  must fail rather than acquire one.
- **The workflow itself has never run.** A scheduled workflow cannot be
  triggered until it is on the default branch, so its first execution will be
  the first one. `actionlint` is in `task lint` precisely because of that.

## Not claimed

- Talos v1.13.9 / Kubernetes v1.36.4 **boots** on Docker. That is not proof that
  a running cloud cluster survives being moved to it. The bumps that lane
  applied are deliberately not kept; `docs/backlog.md` names the two rungs
  apart.
- A green probe means a tool installs, upgrades, and leaves this repository's
  own checks passing. It says nothing about behaviour on a live cluster.
- `verify-provider-clean` enumerates servers and load balancers (OpenStack) or
  VMs and unassociated public IPs (Outscale). Not volumes, snapshots, images or
  buckets — it now says so itself.

## Reading order

`docs/clea.md` for what runs and what a green report may claim;
`scripts/clea/README.md` for the tool, written so it can be lifted into another
repository unchanged.
