### PR TITLE
fix(local): the roots agree now — both pin Talos v1.13.9 / Kubernetes v1.36.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,19 @@ in git. 0.1.0 is the first entry describing something proven.
   remains: it takes `--opentofu-version`, and `--install-path` /
   `--symlink-path` let it install without root.
 
+- **`infrastructure/opentofu-local/variables.tf` pinned a different Talos and
+  Kubernetes than the cloud root** — `v1.13.3` / `v1.35.3` against `v1.13.9` /
+  `v1.36.3`, drifted before either was anchored. The credential-free lane the
+  README calls the best first step was exercising a pair that is not the one
+  that ships. Now pinned equal. Measured on the shipped default topology
+  (3 control planes + 3 workers, Docker): all six nodes Ready, Cilium on 6/6,
+  `task local-verify` 6/6 — versions read from the cluster itself, not the tool
+  that deployed it (`kubectl get nodes` → `v1.36.3` on all six; `talosctl
+  version` against the control plane's own API → server tag `v1.13.9`).
+  Closes [#87](https://github.com/dis-bzh/OpenAether-infra/issues/87). The
+  cloud root's own pin — `v1.13.9`, one patch past what this repository's
+  real-cloud evidence table covers — is untouched and unrelated.
+
 - **`scripts/setup.sh` asked whether a tool was present, never which version it
   was** — so it installed the pin on a fresh machine and refused every upgrade
   afterwards, in silence, on every machine that had run it once. Found by the

--- a/docs/status.md
+++ b/docs/status.md
@@ -96,12 +96,24 @@ assembled from two commands; the CoreDNS readiness gate failing on a cluster it
 had just watched come up; and the teardown proof printing nothing on a clean
 account, indistinguishable from a check that never ran. All five are fixed.
 
-**The local lane's pin mismatch is measured, not yet closed.** Talos `v1.13.9` /
-Kubernetes `v1.36.4` — upstream's current pair — boots on the Docker lane:
-`task local-verify` 6/6. The two roots still pin different versions, and no
-real cloud has run the newer pair — [#87](https://github.com/dis-bzh/OpenAether-infra/issues/87).
+**The local and cloud roots now pin the same Talos and Kubernetes.** They had
+drifted to `v1.13.3` / `v1.35.3` against `v1.13.9` / `v1.36.3` before either
+was anchored; `infrastructure/opentofu-local/variables.tf` now carries the
+cloud root's exact pin. Measured 2026-08-24 on the Docker lane at the shipped
+default topology (3 control planes + 3 workers, not a smaller probe): all six
+nodes Ready, Cilium on 6/6, `task local-verify` 6/6, versions read from the
+cluster itself rather than the tool that deployed it — `kubectl get nodes`
+reports `v1.36.3` on all six, and `talosctl version` against the control
+plane's own API reports server tag `v1.13.9`. `task local-down` afterward left
+no container, volume, network or credential.
+[#87](https://github.com/dis-bzh/OpenAether-infra/issues/87) is closed on that
+basis; what it does not answer is below.
 
-**Not proven**: no lane has ever run unattended to completion; nobody has
+**Not proven**: whether `v1.13.9` — the cloud root's own pin, unrelated to the
+change above — has been through the same real-cloud upgrade evidence this page
+records for `v1.13.7`→`v1.13.8`; the table stops one patch short of what is
+currently pinned, and nothing here re-ran it. No lane has ever run unattended
+to completion; nobody has
 deployed under a non-empty `bucket_suffix`; and the failover — provider A treated
 as gone, the cluster rebuilt on B from B's replica alone — has never been
 attempted.

--- a/infrastructure/opentofu-local/variables.tf
+++ b/infrastructure/opentofu-local/variables.tf
@@ -8,21 +8,23 @@ variable "environment" {
   default = "dev"
 }
 
-# ⚠️ These two are BEHIND the cloud root (infrastructure/opentofu/cluster/
-# variables.tf), and nothing compared them until they were anchored: the
-# credential-free lane the README calls the best first step was exercising a
-# different Talos/Kubernetes pair than the one that ships. Anchored here so a
-# bot proposes the move and the weekly local lane is what proves it boots.
+# Kept EQUAL to the cloud root's pin (infrastructure/opentofu/cluster/
+# variables.tf) — they drifted six patches and a whole Kubernetes minor apart
+# before either was anchored (see docs/status.md, "Dependency watch"), and
+# nothing compared them until they were. The two are bumped together by hand:
+# Renovate proposes each independently, and a PR that moves one without the
+# other is a regression, not a bump — check-version-drift.sh does not (yet)
+# compare them to each other, only to their own anchors.
 variable "talos_version" {
   type = string
   # renovate: datasource=github-releases depName=siderolabs/talos
-  default = "v1.13.3"
+  default = "v1.13.9"
 }
 
 variable "kubernetes_version" {
   type = string
   # renovate: datasource=github-releases depName=kubernetes/kubernetes
-  default = "v1.35.3"
+  default = "v1.36.3"
 }
 
 variable "talos_bootstrap" {


### PR DESCRIPTION
## What

`infrastructure/opentofu-local/variables.tf` pinned Talos `v1.13.3` /
Kubernetes `v1.35.3`; the cloud root pins `v1.13.9` / `v1.36.3`. Both are now
`v1.13.9` / `v1.36.3`.

## Why

The two drifted before either pin was anchored, and the credential-free lane
the README calls the best first step was exercising a pair that is not the
one that ships. Closes #87.

## Proof

Measured on the shipped default topology, not a smaller probe — `task local-up`
at 3 control planes + 3 workers, Docker:

```
$ kubectl get nodes
NAME                            STATUS   VERSION
openaether-local-dev-cp-0       Ready    v1.36.3
openaether-local-dev-cp-1       Ready    v1.36.3
openaether-local-dev-cp-2       Ready    v1.36.3
openaether-local-dev-worker-0   Ready    v1.36.3
openaether-local-dev-worker-1   Ready    v1.36.3
openaether-local-dev-worker-2   Ready    v1.36.3

$ talosctl --nodes 10.5.0.10 version --short
Server: Tag: v1.13.9
```

Both read from the cluster itself — kubectl's own report, and Talos's own API
— never from the tool that deployed it. `task local-verify` 6/6.
`task local-down` afterward left no container, volume, network or credential.

## Not closed by this

The cloud root's own pin, `v1.13.9`, sits one patch past what
`docs/status.md`'s real-cloud evidence table covers (`v1.13.7`→`v1.13.8`).
Pre-existing, unrelated to this change, surfaced in `docs/status.md`'s
"Not proven" line rather than left for someone to notice later.

## Rungs

Mocked: `task lint`, `task test` (52), `task test-scripts` (409 across 13
harnesses), `task render-check`, gitleaks — all green.
Real, local: the cluster lane above, end to end.
Skipped: real cloud — this change touches only the Docker lane's root.
