### PR TITLE
fix(clea): GITHUB_TOKEN cannot push a workflow-file change, in any repository

### DIFF
--- a/.github/workflows/clea.yml
+++ b/.github/workflows/clea.yml
@@ -194,6 +194,13 @@ jobs:
       - name: Verdict, and the branch that carries it
         env:
           GREEN: ${{ steps.probe.outcome != 'failure' && steps.gates.outcome != 'failure' }}
+          # Optional. GITHUB_TOKEN cannot push a change to a file under
+          # .github/workflows/ — three anchors live there (commitizen,
+          # opentofu/opentofu, siderolabs/talos, all in ci.yml) — and no
+          # `permissions:` grant exists for it; only a classic PAT with the
+          # `workflow` scope can. Falls back to the default token when unset,
+          # which still pushes every OTHER probe branch fine.
+          CLEA_WORKFLOW_TOKEN: ${{ secrets.CLEA_WORKFLOW_TOKEN }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -222,7 +229,10 @@ jobs:
           git commit -q -m "chore(clea): probe ${DEP} ${VERSION}"
           # Pushed green or red on purpose: a red branch is the reproduction, and
           # deleting it leaves a report describing something nobody can re-run.
-          git push --force-with-lease origin "HEAD:clea/probe/${SLUG}"
+          remote=origin
+          [ -n "${CLEA_WORKFLOW_TOKEN}" ] &&
+            remote="https://x-access-token:${CLEA_WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git"
+          git push --force-with-lease "$remote" "HEAD:clea/probe/${SLUG}"
 
   cluster:
     name: Local Talos cluster
@@ -285,6 +295,10 @@ jobs:
         env:
           UP: ${{ steps.up.outcome }}
           VERIFY: ${{ steps.verify.outcome }}
+          # See the probe job's Verdict step: `talos_version` is one of the
+          # bumps above, and it is also anchored inside ci.yml — the same
+          # GITHUB_TOKEN restriction applies here.
+          CLEA_WORKFLOW_TOKEN: ${{ secrets.CLEA_WORKFLOW_TOKEN }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -317,7 +331,10 @@ jobs:
           git add -u
           git add clea-probe.json
           git commit -q -m "chore(clea): local cluster lane"
-          git push --force-with-lease origin HEAD:clea/probe/local-cluster
+          remote=origin
+          [ -n "${CLEA_WORKFLOW_TOKEN}" ] &&
+            remote="https://x-access-token:${CLEA_WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git"
+          git push --force-with-lease "$remote" HEAD:clea/probe/local-cluster
 
   report:
     name: Report
@@ -333,12 +350,13 @@ jobs:
       - name: Collect the probe verdicts from their own branches
         env:
           STATE: ${{ needs.scan.outputs.state }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           printf '%s' "$STATE" > clea-state.json
           git fetch -q origin "+refs/heads/clea/probe/*:refs/remotes/origin/clea/probe/*" || true
           python3 - <<'PY'
-          import json, subprocess
+          import json, os, subprocess, urllib.request
           state = json.load(open("clea-state.json"))
           refs = subprocess.run(["git", "for-each-ref", "--format=%(refname:short)",
                                  "refs/remotes/origin/clea/probe/*"],
@@ -360,8 +378,34 @@ jobs:
           state["probes"] = probes
           if cluster:
               state["cluster_lane"] = cluster
+
+          # A probe job can fail before it ever reaches its own verdict-push
+          # step — most durably, GITHUB_TOKEN cannot push a change to a file
+          # under .github/workflows/, and no `permissions:` grant can fix
+          # that (there is no such scope; only a PAT with the classic
+          # `workflow` scope can, and that is a credential decision, not a
+          # workflow-file one). Cross-referenced against the run's own job
+          # list — data the platform already has, not a second push path —
+          # so a dependency that failed to record a verdict is at least named
+          # rather than silently missing from the report.
+          got = {p["dep"] for p in probes}
+          req = urllib.request.Request(
+              f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}"
+              f"/actions/runs/{os.environ['GITHUB_RUN_ID']}/jobs?per_page=100",
+              headers={"Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                       "Accept": "application/vnd.github+json"})
+          jobs = json.load(urllib.request.urlopen(req, timeout=30))["jobs"]
+          stalled = [
+              {"dep": j["name"].removeprefix("Probe "),
+               "job": j["name"], "url": j["html_url"]}
+              for j in jobs
+              if j["name"].startswith("Probe ") and j["conclusion"] == "failure"
+              and j["name"].removeprefix("Probe ") not in got]
+          state["stalled_probes"] = stalled
+
           json.dump(state, open("clea-state.json", "w"), indent=2)
-          print(f"{len(probes)} probe verdict(s), cluster lane: {bool(cluster)}")
+          print(f"{len(probes)} probe verdict(s), {len(stalled)} stalled, "
+                f"cluster lane: {bool(cluster)}")
           PY
 
       - name: Rewrite the report issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ in git. 0.1.0 is the first entry describing something proven.
     both go green. The GitHub datasources answered 403 in that session and were
     reported as failures, which is the behaviour that matters most: a
     datasource that did not answer is not a dependency that is up to date.
+  - **The workflow's own first real run found what a bare-container probe
+    could not.** Triggered by hand 2026-08-24 (`daily` lane): three probes —
+    `commitizen`, `opentofu/opentofu`, `siderolabs/talos` — failed with
+    "refusing to allow a GitHub App to create or update workflow… without
+    `workflows` permission". All three are anchored (also) inside
+    `.github/workflows/ci.yml`, and `GITHUB_TOKEN` cannot push a change to a
+    workflow file in any repository — there is no `permissions:` grant for it.
+    Two fixes: the Report job now cross-references the run's own job list, so
+    a probe that fails before it can push is *named*, not silently absent from
+    the report; and an optional `CLEA_WORKFLOW_TOKEN` secret (classic PAT,
+    scope `workflow`), wired into both push sites with a clean fallback to the
+    default token when unset, closes the gap for real where it is set.
 
 ### Changed
 

--- a/docs/clea.fr.md
+++ b/docs/clea.fr.md
@@ -82,6 +82,15 @@ supprime une branche dès que sa montée de version a atterri sur `main`.
   `talosctl`, `kubectl`, l'AWS CLI, shellcheck, yamllint, checkov et pre-commit
   sont dans cet état, et les épingler est une décision à part — ouvrir une issue
   pour qui la prend.
+- **`commitizen`, `opentofu/opentofu` et `siderolabs/talos`** — ancrés (aussi)
+  dans `.github/workflows/ci.yml` — font échouer leur sonde avec « refusing to
+  allow a GitHub App to create or update workflow… without `workflows`
+  permission ». Mesuré au premier vrai passage de ce workflow, le 2026-08-24.
+  `GITHUB_TOKEN` ne peut pousser ce changement dans aucun dépôt, et aucune
+  permission `permissions:` ne le corrige. Un secret `CLEA_WORKFLOW_TOKEN` (PAT
+  classique, scope `workflow`) referme le trou une fois posé ; sans lui, le
+  rapport nomme quand même les trois plutôt que de les faire disparaître — voir
+  « Probes that could not record a verdict » dans sa propre section.
 
 ## Le lancer à la main
 

--- a/docs/clea.md
+++ b/docs/clea.md
@@ -77,6 +77,14 @@ landed on `main`.
   its upgrade lane can only report what it found. `talosctl`, `kubectl`, the AWS
   CLI, shellcheck, yamllint, checkov and pre-commit are all in that state, and
   pinning them is a separate decision — open one if you take it.
+- **`commitizen`, `opentofu/opentofu` and `siderolabs/talos`** — anchored (also)
+  inside `.github/workflows/ci.yml` — fail their probe with "refusing to allow
+  a GitHub App to create or update workflow… without `workflows` permission".
+  Measured on this workflow's first real run, 2026-08-24. `GITHUB_TOKEN` cannot
+  push that change in any repository, and no `permissions:` grant fixes it.
+  A `CLEA_WORKFLOW_TOKEN` secret (classic PAT, scope `workflow`) closes it when
+  set; without one, the report still names the three rather than dropping them
+  silently — see "Probes that could not record a verdict" in its own section.
 
 ## Running it by hand
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -52,7 +52,7 @@ every apply plans to a file and applies THAT file, and a saved plan never prompt
 Destroy always takes two commands and no flag collapses them. S3 credentials are
 namespaced by the cloud that HOLDS the bucket, and a cross-provider backup is
 proven — an encrypted tfstate at Outscale while the cluster runs on Scaleway.
-406 offline assertions across 13 harnesses, every one mutation-tested — 330 of
+413 offline assertions across 13 harnesses, every one mutation-tested — 330 of
 them from the eleven harnesses that existed before Cléa, three fewer than the
 333 this page claimed and nothing had re-counted since; the emulated lane runs
 feint 0.10.0 against Scaleway provider 2.81.0, the version the clusters run.

--- a/scripts/clea/README.md
+++ b/scripts/clea/README.md
@@ -112,6 +112,14 @@ or a sandbox. Without it every download inside the container fails with
 reason that is not the bump. A bundle that cannot be read is refused rather than
 ignored, for the same reason.
 
+**A dependency anchored only inside `.github/workflows/*.yml` cannot be probed
+by CI's own `GITHUB_TOKEN`.** GitHub refuses that push outright, in any
+repository, and no `permissions:` grant changes it — there is no such scope.
+The workaround is a classic Personal Access Token with the `workflow` scope,
+stored as a repository secret and named `CLEA_WORKFLOW_TOKEN`; a workflow that
+wires it in falls back to the default token cleanly when the secret is absent,
+so this is opt-in, not a requirement to get everything else running.
+
 ## Configuration
 
 ```toml

--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -1050,6 +1050,20 @@ def render_report(state: dict) -> str:
             lines += [f"### `{probe['dep']}` → `{probe['version']}`", "",
                       "```", probe.get("log", "(no log captured)").strip(), "```", ""]
 
+    # A probe job can fail before it ever reaches the step that pushes its
+    # verdict — GITHUB_TOKEN cannot push a change to a file under
+    # .github/workflows/, with no `permissions:` grant able to fix that; a
+    # transient runner failure would land here too. Either way, "no branch" and
+    # "nothing to report" must not read the same: the dependency was tried and
+    # the run knows it failed, even with no verdict to show.
+    stalled = state.get("stalled_probes", [])
+    if stalled:
+        lines += ["## Probes that could not record a verdict", "",
+                  "The job ran and failed before it could push its branch — a "
+                  "gap in the reporting path, not necessarily in the bump "
+                  "itself. See the run for why.", ""]
+        lines += [f"- `{s['dep']}` — [{s['job']}]({s['url']})" for s in stalled] + [""]
+
     if state.get("errors"):
         # Grouped on the message with its URL removed: one rate limit produces
         # one failure per dependency, and twenty copies of the same sentence is
@@ -1075,7 +1089,12 @@ def render_report(state: dict) -> str:
               "run by hand, by someone watching — see `CONTRIBUTING.md`.",
               "- A green probe means the tool installs from cold, upgrades over its "
               "previous version, and the repository's own checks still pass. It does not "
-              "mean the new version behaves the same on a running cluster."]
+              "mean the new version behaves the same on a running cluster.",
+              "- **A dependency pinned only inside `.github/workflows/` cannot be "
+              "probed** unless a `CLEA_WORKFLOW_TOKEN` secret is set (a classic PAT, "
+              "scope `workflow`) — GITHUB_TOKEN cannot push such a change in any "
+              "repository, and no `permissions:` grant can fix that. See "
+              "\"Probes that could not record a verdict\" below if this run hit one."]
     cluster = state.get("cluster_lane")
     if cluster:
         lines += [f"- Weekly local cluster lane: **{cluster.get('verdict', '?')}**, "

--- a/scripts/dev/test-clea.sh
+++ b/scripts/dev/test-clea.sh
@@ -483,5 +483,36 @@ PY
 if [ $? -eq 0 ]; then PASS=$((PASS + 5)); else FAIL=$((FAIL + 1)); fi
 
 echo
+echo "=== a probe that failed before it could push is named, not silent ==="
+# GITHUB_TOKEN cannot push a change to a workflow file, in any repository —
+# measured 2026-08-24 on this workflow's first real run, three probes
+# (commitizen, opentofu/opentofu, siderolabs/talos, all anchored inside
+# .github/workflows/ci.yml) failed at exactly that step. Without this section
+# they would just be ABSENT from the report — indistinguishable from a
+# dependency that was never behind at all.
+python3 - "$CLEA" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("clea", sys.argv[1])
+clea = importlib.util.module_from_spec(spec); spec.loader.exec_module(clea)
+state = {"generated_at": "now", "deps": [], "probes": [],
+         "stalled_probes": [{"dep": "commitizen", "job": "Probe commitizen",
+                             "url": "https://example.invalid/run/1"}]}
+report = clea.render_report(state)
+checks = [
+    ("the section header appears", "could not record a verdict" in report),
+    ("the dependency is named", "commitizen" in report),
+    ("the job's own URL is linked, not just asserted", "example.invalid/run/1" in report),
+    ("an empty list produces no section at all — not just the standing "
+     "disclaimer bullet, which names the same section on purpose",
+     "## Probes that could not record a verdict"
+     not in clea.render_report({**state, "stalled_probes": []})),
+]
+for name, ok in checks:
+    print(("  \033[32m\u2713\033[0m " if ok else "  \033[31m\u2717\033[0m ") + name)
+sys.exit(1 if [c for c in checks if not c[1]] else 0)
+PY
+if [ $? -eq 0 ]; then PASS=$((PASS + 4)); else FAIL=$((FAIL + 1)); fi
+
+echo
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

The daily lane's first real run (triggered by hand) found that `GITHUB_TOKEN`
cannot push a change to a file under `.github/workflows/` — a hard, undocumented-
in-`permissions:` GitHub restriction, not something a `permissions:` grant can
fix (verified: `workflows` is not a real scope, actionlint rejects it, and
GitHub's own community discussions confirm the only path is a classic PAT with
the `workflow` scope).

Three probes hit it: `commitizen`, `opentofu/opentofu`, `siderolabs/talos` — all
anchored (also) inside `.github/workflows/ci.yml`.

## Fix

Two parts, independent of each other:

1. **The report names a probe that failed to record a verdict**, instead of it
   silently vanishing. The Report job now cross-references the run's own job
   list — data already available, no new push path — for any `Probe *` job that
   failed with no matching branch. This is a general fix: a transient runner
   failure would have hit the same silent gap.
2. **`CLEA_WORKFLOW_TOKEN`** (optional, classic PAT, scope `workflow`), wired
   into both push sites — the probe job and the cluster job's own verdict push
   (`siderolabs/talos` is also anchored in ci.yml, so the weekly lane would hit
   this identically the first time Talos is behind). Falls back to the default
   token cleanly when unset.

The secret already exists on this repository (`CLEA_WORKFLOW_TOKEN`), so once
this merges the three previously-stalled probes should close for real, not
just report themselves cleanly.

## Proof

The failure: https://github.com/dis-bzh/OpenAether-infra/actions/runs/32735564782
— `Probe commitizen`, `Probe opentofu/opentofu`, `Probe siderolabs/talos` all
failed with the exact rejection message; the other four (cilium, cloudnative-pg,
go-task/task, kubernetes/kubernetes — none anchored in a workflow file) all
succeeded, 3/3 lanes each.

Not yet proven: this fix's own first real run. Triggering `Clea` (`daily`) again
after merge is the next step.

## Rungs

Mocked: `task lint`, `task test` (52), `task test-scripts` (413 across 13
harnesses, 4 new) — green. Real: the failure this fixes was found on a live
workflow run, not simulated.
