### PR TITLE
fix(clea): use --force, not --force-with-lease, on bot-owned probe branches

### DIFF
--- a/.github/workflows/clea.yml
+++ b/.github/workflows/clea.yml
@@ -229,10 +229,21 @@ jobs:
           git commit -q -m "chore(clea): probe ${DEP} ${VERSION}"
           # Pushed green or red on purpose: a red branch is the reproduction, and
           # deleting it leaves a report describing something nobody can re-run.
+          #
+          # --force, not --force-with-lease: this checkout never fetched the
+          # branch it is about to overwrite (only the default branch is
+          # fetched), so the lease has nothing to compare against and refuses
+          # every push once the branch already exists from a prior run — "!
+          # [rejected] ... (stale info)", on EVERY dependency, seen on this
+          # workflow's second-ever run (2026-08-24). The lease exists to stop
+          # clobbering someone else's concurrent work; nobody but this
+          # workflow ever writes to clea/probe/*, so there is nothing to
+          # protect against, and the branch is meant to always reflect only
+          # the latest probe.
           remote=origin
           [ -n "${CLEA_WORKFLOW_TOKEN}" ] &&
             remote="https://x-access-token:${CLEA_WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git"
-          git push --force-with-lease "$remote" "HEAD:clea/probe/${SLUG}"
+          git push --force "$remote" "HEAD:clea/probe/${SLUG}"
 
   cluster:
     name: Local Talos cluster
@@ -331,10 +342,12 @@ jobs:
           git add -u
           git add clea-probe.json
           git commit -q -m "chore(clea): local cluster lane"
+          # --force: see the probe job's push for why --force-with-lease
+          # cannot work here — this checkout never fetched the branch either.
           remote=origin
           [ -n "${CLEA_WORKFLOW_TOKEN}" ] &&
             remote="https://x-access-token:${CLEA_WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git"
-          git push --force-with-lease "$remote" HEAD:clea/probe/local-cluster
+          git push --force "$remote" HEAD:clea/probe/local-cluster
 
   report:
     name: Report


### PR DESCRIPTION
## What broke

Re-triggering the daily lane to confirm PR #92's `CLEA_WORKFLOW_TOKEN` fix made
things worse instead: all seven probes failed, including the four that were
green on the first run.

```
! [rejected]        HEAD -> clea/probe/cilium (stale info)
```

## Why

`--force-with-lease` compares the push against the local tracking ref for the
branch it's about to overwrite. This checkout only fetches the default branch
— `clea/probe/*` is never fetched — so on the first-ever run every probe branch
was new (nothing to compare, lease trivially satisfied) and on every run since,
for every dependency probed before, the lease has no basis to trust and refuses
on principle. Unfixable by fetching more either: the whole point is these
branches get overwritten every run, and a lease is for protecting concurrent
work nobody else does here.

## Fix

`--force`, not `--force-with-lease`, at both push sites (the probe job, and the
cluster job's local-cluster verdict). `clea/probe/*` is bot-owned, single
writer, always-overwrite by design — there is nothing for a lease to protect.

## Proof

The failure: https://github.com/dis-bzh/OpenAether-infra/actions/runs/32738233559
— all 7 probe jobs failed with the rejection above.

Not yet proven: this fix's own run. Triggering `daily` again after merge, same
as the previous fix.

## Rungs

Mocked: `task lint`, gitleaks — green.
Real: the failure was found on a live second run of the workflow.
