### PR TITLE
fix(clea): a URL-embedded credential never overrides actions/checkout's own

### DIFF
--- a/.github/workflows/clea.yml
+++ b/.github/workflows/clea.yml
@@ -240,10 +240,21 @@ jobs:
           # workflow ever writes to clea/probe/*, so there is nothing to
           # protect against, and the branch is meant to always reflect only
           # the latest probe.
-          remote=origin
-          [ -n "${CLEA_WORKFLOW_TOKEN}" ] &&
-            remote="https://x-access-token:${CLEA_WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git"
-          git push --force "$remote" "HEAD:clea/probe/${SLUG}"
+          # A URL-embedded credential does NOT override actions/checkout's own
+          # token: it persists GITHUB_TOKEN as an `http.…/.extraheader` git
+          # config entry, and that header wins over Basic-Auth in the push URL
+          # — confirmed against actions/checkout#162. The push still failed
+          # with CLEA_WORKFLOW_TOKEN embedded in the remote URL, identically to
+          # having no token at all, because it was never actually used. The
+          # documented override is `-c http…extraheader=…`, a ONE-SHOT config
+          # value for this single command only, never persisted.
+          if [ -n "${CLEA_WORKFLOW_TOKEN}" ]; then
+            basic="$(printf 'x-access-token:%s' "${CLEA_WORKFLOW_TOKEN}" | base64 -w0)"
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${basic}" \
+              push --force origin "HEAD:clea/probe/${SLUG}"
+          else
+            git push --force origin "HEAD:clea/probe/${SLUG}"
+          fi
 
   cluster:
     name: Local Talos cluster
@@ -344,10 +355,15 @@ jobs:
           git commit -q -m "chore(clea): local cluster lane"
           # --force: see the probe job's push for why --force-with-lease
           # cannot work here — this checkout never fetched the branch either.
-          remote=origin
-          [ -n "${CLEA_WORKFLOW_TOKEN}" ] &&
-            remote="https://x-access-token:${CLEA_WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git"
-          git push --force "$remote" HEAD:clea/probe/local-cluster
+          # See the probe job's push for why the URL-embedded token never
+          # worked, and why this form does.
+          if [ -n "${CLEA_WORKFLOW_TOKEN}" ]; then
+            basic="$(printf 'x-access-token:%s' "${CLEA_WORKFLOW_TOKEN}" | base64 -w0)"
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${basic}" \
+              push --force origin HEAD:clea/probe/local-cluster
+          else
+            git push --force origin HEAD:clea/probe/local-cluster
+          fi
 
   report:
     name: Report


### PR DESCRIPTION
## What

`CLEA_WORKFLOW_TOKEN` (#92) still failed identically after the two most likely
causes — the PAT's `workflow` scope, an org-level PAT restriction — were both
directly checked and ruled out.

## Why

The tell was the error's own wording, staying identical between "no token" and
"token embedded in the push URL": GitHub distinguishes "refusing... a Personal
Access Token... without `workflow` scope" from "refusing... a GitHub App...
without `workflows` permission" in these rejections. Both runs said "GitHub
App" — the push was still authenticating as the Actions bot, never the PAT.

Confirmed against
[actions/checkout#162](https://github.com/actions/checkout/issues/162):
`actions/checkout` persists `GITHUB_TOKEN` as an `http.https://github.com/
.extraheader` git config entry, and that header wins over any credential
embedded in a push URL. Building
`https://x-access-token:${TOKEN}@github.com/...` and pushing to it was
silently ignored, by design on GitHub's side, every time.

## Fix

The documented override: a one-shot `-c` config value on the push command
itself (never persisted), setting the Authorization header directly —
`git -c "http.…/.extraheader=AUTHORIZATION: basic <base64(x-access-token:TOKEN)>" push`.
Applied at both push sites (the probe job, the cluster job).

## Proof

Base64/Basic-Auth construction tested locally against a dummy token,
round-tripped correctly. Not yet proven against GitHub itself — a fourth real
run is the next step, same as every fix in this chain.

## Rungs

Mocked: `task lint`, gitleaks — green.
Real: not yet — pending the next `daily` trigger after merge.
