### PR TITLE
fix(clea): unset the persisted Authorization header before replacing it

### DIFF
--- a/.github/workflows/clea.yml
+++ b/.github/workflows/clea.yml
@@ -243,15 +243,21 @@ jobs:
           # A URL-embedded credential does NOT override actions/checkout's own
           # token: it persists GITHUB_TOKEN as an `http.…/.extraheader` git
           # config entry, and that header wins over Basic-Auth in the push URL
-          # — confirmed against actions/checkout#162. The push still failed
-          # with CLEA_WORKFLOW_TOKEN embedded in the remote URL, identically to
-          # having no token at all, because it was never actually used. The
-          # documented override is `-c http…extraheader=…`, a ONE-SHOT config
-          # value for this single command only, never persisted.
+          # — confirmed against actions/checkout#162. Adding a SECOND
+          # extraheader with `-c` did not replace it either: the key is
+          # multi-valued in git on purpose (so several headers can combine),
+          # so `-c` on top of the persisted one sent TWO Authorization headers
+          # and GitHub's server refused the request outright — "remote:
+          # Duplicate header: \"Authorization\"", HTTP 400. The persisted one
+          # has to go before a replacement means anything; `--local` matches
+          # exactly what actions/checkout set (confirmed in its own cleanup
+          # log), and `|| true` covers CLEA_WORKFLOW_TOKEN being unset, where
+          # there is nothing to remove.
           if [ -n "${CLEA_WORKFLOW_TOKEN}" ]; then
-            basic="$(printf 'x-access-token:%s' "${CLEA_WORKFLOW_TOKEN}" | base64 -w0)"
-            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${basic}" \
-              push --force origin "HEAD:clea/probe/${SLUG}"
+            git config --local --unset-all http.https://github.com/.extraheader || true
+            git push --force \
+              "https://x-access-token:${CLEA_WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git" \
+              "HEAD:clea/probe/${SLUG}"
           else
             git push --force origin "HEAD:clea/probe/${SLUG}"
           fi
@@ -355,12 +361,13 @@ jobs:
           git commit -q -m "chore(clea): local cluster lane"
           # --force: see the probe job's push for why --force-with-lease
           # cannot work here — this checkout never fetched the branch either.
-          # See the probe job's push for why the URL-embedded token never
-          # worked, and why this form does.
+          # See the probe job's push for the extraheader precedence AND the
+          # duplicate-header failure this form avoids.
           if [ -n "${CLEA_WORKFLOW_TOKEN}" ]; then
-            basic="$(printf 'x-access-token:%s' "${CLEA_WORKFLOW_TOKEN}" | base64 -w0)"
-            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${basic}" \
-              push --force origin HEAD:clea/probe/local-cluster
+            git config --local --unset-all http.https://github.com/.extraheader || true
+            git push --force \
+              "https://x-access-token:${CLEA_WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git" \
+              HEAD:clea/probe/local-cluster
           else
             git push --force origin HEAD:clea/probe/local-cluster
           fi


### PR DESCRIPTION
## What broke, this time

`#95`'s `-c` extraheader override still failed, with a different error:

```
remote: Duplicate header: "Authorization"
fatal: unable to access '...': The requested URL returned error: 400
```

## Why

`http.extraheader` is multi-valued in git by design (so several headers can
combine). `git -c "http.…extraheader=…" push` **adds** a value on top of
whatever's already configured — it does not replace the one
`actions/checkout` already persisted. Two `Authorization` headers reached
GitHub's server in one request; it refused the whole thing.

## Fix

Remove the persisted entry first — `git config --local --unset-all
http.https://github.com/.extraheader`, the same key and scope
`actions/checkout`'s own cleanup step unsets at the end of every job — then
the URL-embedded credential from #92 (correct on its own the whole time, just
always overridden) is what actually reaches GitHub.

## The chain, for the record

1. `permissions: { workflows: write }` — not a real scope.
2. URL-embedded token alone — silently overridden by the persisted header.
3. `-c` header override — added a second header, GitHub refused the request.
4. `--unset-all` first, then #2's credential — this PR.

## Rungs

Mocked: `task lint`, gitleaks — green.
Real: not yet — needs its own trigger after merge, same as every attempt
before it.
