### PR TITLE
fix(clea): match a probe to its anchor by the same tag the matrix used to bump it

### DIFF
--- a/.github/workflows/clea.yml
+++ b/.github/workflows/clea.yml
@@ -221,12 +221,21 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY'
-          import json, os, pathlib
+          import json, os, pathlib, re
+          # ANSI stripped before this goes anywhere near JSON. This blob is
+          # embedded in a GitHub issue body (as an HTML-comment-wrapped JSON
+          # state, for the next scan's --previous diff) and round-tripped back
+          # out of it — and GitHub's own issue-body storage does not return raw
+          # terminal escape sequences unchanged: `\u001b[32m` came back on this
+          # workflow's sixth real run as the literal three characters `\^[`,
+          # which is not valid JSON and broke the embedded state entirely.
+          # Terminal color has no reason to survive into stored data anyway.
+          ansi = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
           log = ""
           for name in ("probe.log", "gates.log"):
               path = pathlib.Path(name)
               if path.is_file():
-                  log += path.read_text(errors="replace")[-2000:]
+                  log += ansi.sub("", path.read_text(errors="replace"))[-2000:]
           json.dump({
               "dep": os.environ["DEP"],
               "version": os.environ["VERSION"],

--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -971,8 +971,23 @@ def render_report(state: dict) -> str:
     if behind:
         rows = []
         for d in behind:
+            # Matched on the TAG, not on `latest`. `cmd_matrix` hands the probe
+            # `dep.get("tag") or dep["latest"]` — the raw upstream tag, unstripped
+            # — because a dependency can be pinned in two shapes across its
+            # anchors (see fluxcd/flux2) and only the tag becomes both. `latest`
+            # is THIS anchor's own extracted form, and for anything with an
+            # extractVersion clause that actually strips something (opentofu,
+            # go-task, cloudnative-pg — anything using `^v(?<version>.*)$`),
+            # tag and latest are DIFFERENT STRINGS for the same real version:
+            # "v1.12.6" vs "1.12.6". Comparing against `latest` here meant three
+            # of seven real probes never matched their own anchors and were
+            # reported "not probed" despite running and pushing green — found
+            # 2026-08-24 on this workflow's sixth real run, where exactly the
+            # three dependencies with a stripping extractVersion were affected
+            # and the four without one were not.
+            expect = d.get("tag") or d["latest"]
             probe = next((p for p in state.get("probes", [])
-                          if p["dep"] == d["dep"] and p["version"] == d["latest"]), None)
+                          if p["dep"] == d["dep"] and p["version"] == expect), None)
             verdict = "not probed"
             if probe:
                 verdict = ("✅ probed green — `%s`" % probe["branch"]) if probe["green"] \

--- a/scripts/dev/test-clea.sh
+++ b/scripts/dev/test-clea.sh
@@ -514,5 +514,69 @@ PY
 if [ $? -eq 0 ]; then PASS=$((PASS + 4)); else FAIL=$((FAIL + 1)); fi
 
 echo
+echo "=== a probe matches its anchor by the SAME tag the matrix used to bump it ==="
+# cmd_matrix hands the probe dep.get("tag") or dep["latest"] — the raw upstream
+# tag, unstripped, because a dependency can be pinned in two shapes across its
+# anchors and only the tag becomes both (see fluxcd/flux2 above). render_report
+# used to compare a probe's recorded version against `latest` — THIS anchor's
+# own extracted form — which is a DIFFERENT STRING whenever extractVersion
+# actually strips something. opentofu/opentofu, go-task/task and
+# cloudnative-pg/cloudnative-pg all ran green and pushed a verdict on this
+# workflow's sixth real run (2026-08-24) and were reported "not probed" anyway
+# — three of seven, silently wrong in the direction that hides success.
+python3 - "$CLEA" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("clea", sys.argv[1])
+clea = importlib.util.module_from_spec(spec); spec.loader.exec_module(clea)
+
+# acme/stripped: extractVersion strips the v, so tag ("v9.0.0") and latest
+# ("9.0.0") are different strings for the same real version — exactly the
+# opentofu/go-task/cloudnative-pg shape.
+state = {
+    "generated_at": "now",
+    "deps": [{"dep": "acme/stripped", "file": "f", "line": 1, "current": "8.0.0",
+              "latest": "9.0.0", "tag": "v9.0.0", "pinned": True, "behind": True,
+              "shape_ok": True, "notes_url": None}],
+    # The matrix bumped it with the TAG, so that is what the probe recorded —
+    # matching cmd_matrix's own dep.get("tag") or dep["latest"] expression.
+    "probes": [{"dep": "acme/stripped", "version": "v9.0.0", "green": True,
+               "branch": "clea/probe/acme-stripped", "run": "x", "log": ""}],
+}
+report = clea.render_report(state)
+checks = [
+    ("a stripped-tag dependency's real probe is found",
+     "✅ probed green" in report),
+    ("and it is not reported as unprobed",
+     "not probed" not in report),
+]
+for name, ok in checks:
+    print(("  \033[32m\u2713\033[0m " if ok else "  \033[31m\u2717\033[0m ") + name)
+sys.exit(1 if [c for c in checks if not c[1]] else 0)
+PY
+if [ $? -eq 0 ]; then PASS=$((PASS + 2)); else FAIL=$((FAIL + 1)); fi
+
+echo
+echo "=== ANSI color has no reason to survive into stored data ==="
+# GitHub's own issue-body storage does not return raw terminal escape sequences
+# unchanged — \u001b[32m came back as the literal three characters \^[ on a
+# real run, which is not valid JSON and broke the embedded state entirely. The
+# strip has to happen before the log ever reaches json.dump, not after.
+python3 - <<'PY'
+import re, sys
+ansi = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+sample = "\x1b[32m\u2713\x1b[0m the dependency is named\n  \x1b[31m\u2717\x1b[0m one failed"
+stripped = ansi.sub("", sample)
+checks = [
+    ("no ESC byte survives", "\x1b" not in stripped),
+    ("the readable text is untouched", "the dependency is named" in stripped
+     and "one failed" in stripped),
+]
+for name, ok in checks:
+    print(("  \033[32m\u2713\033[0m " if ok else "  \033[31m\u2717\033[0m ") + name)
+sys.exit(1 if [c for c in checks if not c[1]] else 0)
+PY
+if [ $? -eq 0 ]; then PASS=$((PASS + 2)); else FAIL=$((FAIL + 1)); fi
+
+echo
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

The sixth real run of Clea (the one that finally got the credential fix
right, #97) showed all seven daily probes succeeding — and the report still
said "not probed" for three of them: `opentofu/opentofu` (all five of its
anchors), `go-task/task`, `cloudnative-pg/cloudnative-pg`. Verified directly
against the branches: `clea/probe/opentofu-opentofu` exists,
`clea-probe.json` reads `green: true`. The push worked. The report was wrong.

## Why

`cmd_matrix` hands the probe `dep.get("tag") or dep["latest"]` — the raw
upstream tag, unstripped, on purpose (a dependency can be pinned in two
shapes across its anchors, and only the tag becomes both). The report's
lookup compared the probe's recorded version against `latest` instead — the
anchor's own extracted form. For anything with an `extractVersion` that
actually strips a `v`, tag and latest are different strings for the same
version: `v1.12.6` vs `1.12.6`. The three affected dependencies all have that
kind of `extractVersion`; the four that matched correctly by luck
(commitizen, siderolabs/talos, kubernetes/kubernetes, cilium) don't.

## Fix 1

Match on the same expression `cmd_matrix` used to build the probe's version,
not a differently-shaped field.

## Fix 2 (found investigating, unrelated but real)

The state embedded in the report issue (for the next scan's `--previous`
diff) came back from GitHub's own issue-body storage with an ANSI color code
turned into three characters that are not valid JSON, breaking the embedded
blob. Stripped before the log ever reaches `json.dump` — no reason for color
codes to survive into stored data anyway.

## Proof

Two mutations, two caught. Reverting the tag-based match back to `latest`
turns the new assertion red; the ANSI regex is asserted against a realistic
sample.

## Rungs

Mocked: `task lint`, `task test-scripts` (456 assertions across 13 harnesses,
4 new) — green. Real: the defect itself was found on a live run; not yet
re-run to confirm the fix — the next trigger after merge is what settles it.
