### PR TITLE
fix(setup): pin talosctl, and let the local teardown run without OpenAether-apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,14 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`task local-down` refused to run on a clone that had only this repository.**
+  `test-talos-local.sh` resolves `APPS_DIR` and exits 1 when it cannot find
+  `OpenAether-apps/apps/flux/local` — before it reads `--destroy`, which never
+  uses that directory. So the one command that cleans up after a failed deploy
+  needed a second repository cloned, and refused exactly when containers,
+  volumes and state were already on disk. Measured 2026-08-26 on the Docker
+  lane; `--destroy` is now exempt from the check.
+
 - **`task security` could not be completed on a machine set up by
   `scripts/setup.sh`.** `install_checkov` tried pipx, then `python3 -m pip`,
   then apt — and Ubuntu 24.04 ships python3 with neither pip nor pipx, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,19 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Changed
 
+- **`talosctl` is pinned and checksum-verified** by
+  `scripts/internal/install-talosctl.sh`, instead of piping `talos.dev/install`
+  into a shell — the last tool in `setup.sh` that was neither, in a repository
+  that checksums helm, task, tflint and feint. The version is not a new anchor:
+  it is the cluster's own `talos_version` via `talos-version.sh`, so a
+  workstation cannot end up with a CLI two patches from the fleet it talks to,
+  and `siderolabs/talos` leaves `clea.toml`'s `[[unpinned]]` for a weekly probe
+  row. It runs unconditionally rather than behind `check_cmd`, which probes with
+  `talosctl version` — that prints the SERVER's tag too, so a stale client
+  against a current cluster would satisfy the pin. Surfaced on a machine whose
+  egress policy refuses `www.talos.dev`, where the old installer took the whole
+  bootstrap down with it at step 2 under `set -e`.
+
 - **Renovate moves from a six-hour weekly window to a daily one**, and
   `dependencyDashboard` becomes explicit. It has proposed nothing since its
   config landed on 2026-07-30 — its nine pull requests were created three hours

--- a/clea.toml
+++ b/clea.toml
@@ -74,6 +74,16 @@ installer_stdin = "y\n"
 version_cmd = "flux --version"
 daily = false
 
+# talosctl carries no pin of its own: install-talosctl.sh reads the cluster's
+# `talos_version`, so the probe answers a sharper question than "does it
+# install" — whether a Talos bump also hands you a CLI that matches the fleet.
+# Weekly, like the other heavy rows: the release asset is ~100 MB.
+[[tool]]
+name = "siderolabs/talos"
+installer = "scripts/internal/install-talosctl.sh"
+version_cmd = "talosctl version --client"
+daily = false
+
 # --- What the repository consumes without pinning it -------------------------
 # No version is written down anywhere, so no two machines are guaranteed the
 # same tool. Cléa cannot bump these — it can only make the movement visible,
@@ -85,11 +95,6 @@ datasource = "url-text"
 url = "https://dl.k8s.io/release/stable.txt"
 extract = "^(?P<v>v[0-9][0-9A-Za-z.-]*)$"
 consumed_by = "scripts/setup.sh (install_kubectl)"
-
-[[unpinned]]
-name = "siderolabs/talos"
-datasource = "github-releases"
-consumed_by = "scripts/setup.sh (install_talosctl, via talos.dev/install)"
 
 [[unpinned]]
 # github-TAGS, not releases: aws/aws-cli tags every version and publishes no

--- a/scripts/dev/test-talos-local.sh
+++ b/scripts/dev/test-talos-local.sh
@@ -31,11 +31,14 @@ if [[ ! -d "${APPS_DIR}/apps/flux/local" ]]; then
   # Fallback: apps/ still lives in this repo (pre-split or monorepo layout)
   if [[ -d "${ROOT_DIR}/apps/flux/local" ]]; then
     APPS_DIR="${ROOT_DIR}"
-  else
+  elif [[ "${1:-}" != "--destroy" ]]; then
     echo "ERROR: Cannot find apps/flux/local in APPS_DIR=${APPS_DIR}" >&2
     echo "       Clone dis-bzh/OpenAether-apps next to this repo, or set APPS_DIR." >&2
     exit 1
   fi
+  # --destroy is deliberately exempt: it never reads APPS_DIR, and a teardown
+  # that demands a SECOND repository is one that refuses exactly when a failed
+  # deploy has left containers, volumes and state behind.
 fi
 
 CLUSTER_NAME="openaether-local-dev"

--- a/scripts/internal/install-talosctl.sh
+++ b/scripts/internal/install-talosctl.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Install talosctl, pinned and checksum-verified.
+#
+# It was the last tool here installed by piping an unpinned upstream script
+# (`curl talos.dev/install | bash`), in a repository that checksums helm, task,
+# gitleaks, feint and tflint. Same shape as install-task.sh now.
+#
+# The version is NOT a new anchor: it is the cluster's own `talos_version`, read
+# from talos-version.sh, so the CLI cannot drift from the fleet it talks to.
+# talos.dev/install also 301s to www.talos.dev, which a restricted egress policy
+# may refuse; the release asset is the same binary from github.com.
+#
+# Usage: install-talosctl.sh [bin-dir]     (default: /usr/local/bin, else ~/.local/bin)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/common.sh
+. "$HERE/../lib/common.sh"
+
+TALOS_VERSION="$("$HERE/talos-version.sh")"   # e.g. v1.13.9
+
+BIN_DIR="${1:-$(oa_bin_dir)}"
+SUDO="$(oa_sudo_for "$BIN_DIR")"
+
+# `talosctl version --client` is the only form that answers without a cluster:
+# bare `talosctl version` tries to reach a node and fails where none is configured.
+if command -v talosctl >/dev/null 2>&1 &&
+  talosctl version --client 2>/dev/null | grep -qE "(^|[^0-9.])${TALOS_VERSION//./\\.}([^0-9.]|\$)"; then
+  echo "talosctl ${TALOS_VERSION} already installed"
+  exit 0
+fi
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) asset="talosctl-linux-amd64" ;;
+  Linux-aarch64 | Linux-arm64) asset="talosctl-linux-arm64" ;;
+  Darwin-x86_64) asset="talosctl-darwin-amd64" ;;
+  Darwin-arm64) asset="talosctl-darwin-arm64" ;;
+  *) echo "✗ no published talosctl binary for $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+base="https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/sha256sum.txt" "$base/sha256sum.txt"
+# --ignore-missing: the file covers all twelve published platforms, and without
+# it the check fails on the eleven we did not download — which reads like a bad
+# binary rather than a file we never asked for.
+(cd "$tmp" && sha256sum -c sha256sum.txt --ignore-missing)
+
+mkdir -p "$BIN_DIR" 2>/dev/null || $SUDO mkdir -p "$BIN_DIR"
+$SUDO install -m 0755 "$tmp/$asset" "$BIN_DIR/talosctl"
+echo "installed talosctl ${TALOS_VERSION} → $BIN_DIR/talosctl"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -145,17 +145,6 @@ install_tofu() {
     [ "$bin" = /usr/local/bin ] || echo "NOTE: tofu installed to $bin. Ensure it's in your PATH."
 }
 
-install_talosctl() {
-    echo "Installing Talosctl..."
-    # Download first, then execute (avoid piping a partially-fetched script to a
-    # shell — a truncated download could otherwise run incomplete commands).
-    local tmp
-    tmp="$(mktemp)"
-    trap 'rm -f "$tmp"' RETURN
-    curl -fsSL https://talos.dev/install -o "$tmp"
-    bash "$tmp"
-}
-
 install_kubectl() {
     echo "Installing kubectl..."
     curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
@@ -340,10 +329,12 @@ if ! check_cmd tofu "$TOFU_VERSION"; then
     install_tofu
 fi
 
-# 2. Check talosctl
-if ! check_cmd talosctl; then
-    install_talosctl
-fi
+# 2. talosctl — pinned to the version the CLUSTERS run, like every other tool
+# here. Not behind check_cmd: that probes with `talosctl version`, which prints
+# the SERVER's tag too, so a stale client against a current cluster would
+# satisfy the pin. The installer asks with `--client`, and is a no-op when it
+# already holds.
+"$(dirname "${BASH_SOURCE[0]}")/internal/install-talosctl.sh"
 
 # 3. Check kubectl
 if ! check_cmd kubectl; then


### PR DESCRIPTION
Two defects found by running the toolchain from cold on a machine this repository had never been set up on.

## `talosctl` was the last unpinned installer

`setup.sh` installed it by piping `talos.dev/install` into a shell — the only tool here that was neither pinned nor checksum-verified, in a repository that checksums helm, task, tflint and feint, and whose own CI already installs talosctl pinned from the release assets. `scripts/internal/install-talosctl.sh` replaces it, same shape as `install-task.sh`.

Two things beyond "it downloads":

- **The version is not a new anchor.** It is the cluster's own `talos_version`, read from `talos-version.sh`, so a workstation cannot end up with a CLI two patches behind the fleet it talks to. `siderolabs/talos` therefore leaves `clea.toml`'s `[[unpinned]]` for a weekly `[[tool]]` probe row.
- **It runs outside `check_cmd`**, deliberately. `check_cmd` probes with `talosctl version`, which prints the *server's* tag as well — so a stale client against a current cluster would satisfy the pin. The installer asks with `--client` and is a no-op when the answer already holds.

Found because the old installer 301s to `www.talos.dev`; on a host whose egress policy refuses it, `setup.sh` died at step 2 under `set -e` and installed nothing at all.

## `task local-down` refused to run without a second repository

`test-talos-local.sh` resolves `APPS_DIR` and exits 1 when it cannot find `OpenAether-apps/apps/flux/local` — *before* it reads `--destroy`, which never uses that directory. So the one command that cleans up after a failed deploy demanded a second clone, and refused exactly when containers, volumes and state were already on disk. `--destroy` is now exempt.

## Rung

Mocked, and the toolchain itself run from cold:

| | |
|---|---|
| `task test` | 52/52 OpenTofu tests |
| `task test-scripts` | 452 assertions, 13 harnesses |
| `task lint` | green, incl. `check-version-drift` and `clea coverage` (23 anchors) |
| `task render-check` | green |
| `setup.sh` | reaches "Environment ready" twice — 1 min 41 s cold, then 4.9 s idempotent, every tool reported at its pin |
| `task local-down` | refused before the change on a clone holding only this repository; after it, "no container, volume or network in docker, no credential on disk", confirmed against `docker ps -a`, `docker volume ls` and the working tree |

Not reached: the real-cloud rung. The Docker lane could not be reached either on the host this was written on — see the stacked follow-up.

## Also worth an issue, not fixed here

`.github/workflows/ci.yml` pins `TALOS_VERSION: "v1.13.7"` while `cluster/variables.tf` and `opentofu-local/variables.tf` both pin `v1.13.9`. The "Talos Config Validation" job therefore validates configs with a talosctl two patches behind the fleet, and `check-version-drift.sh` does not compare that pair — it compares helm and tofu between `setup.sh` and `ci.yml`, not talos. Deriving it from `talos-version.sh` and adding the drift rule would close it; left out to keep this diff off CI.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiC6JGaTecmJVqE9GfDgjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiC6JGaTecmJVqE9GfDgjA)_