### PR TITLE
feat(session): start Docker in the SessionStart hook, and say what the local lane needs of its host

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -4,8 +4,11 @@
 # Claude Code on the web sessions.
 #
 # Requires the environment's network policy to allow outbound access to the
-# tool download domains (get.opentofu.org, talos.dev, dl.k8s.io, github.com,
-# pypi.org, ...). If egress is blocked, the installs below fail.
+# tool download domains (get.opentofu.org, dl.k8s.io, github.com, pypi.org, ...).
+# If egress is blocked, the installs below fail. The Docker lanes need one host
+# beyond those: pkg-containers.githubusercontent.com, which serves ghcr.io's
+# blobs — without it the daemon starts but `task local-up` cannot pull the Talos
+# image.
 set -euo pipefail
 
 # root in the remote environment, sudo elsewhere.
@@ -28,3 +31,31 @@ printf 'y\n' | ./scripts/setup.sh
 # uses. This copy was the third place the same download was written out by hand.
 
 echo "✅ Toolchain ready (tofu, talosctl, kubectl, yamllint, tflint, task, flux)."
+
+# 3. Docker daemon. The remote image ships dockerd STOPPED — /var/run/docker.sock
+# does not exist until something starts it — and every container lane here needs
+# it: `task local-up`/`local-down`, test-talos-local.sh, test-gates-local.sh.
+# Never fatal, and last on purpose: a session that cannot have Docker must still
+# come out of this hook with the toolchain above.
+start_dockerd() {
+  if ! command -v dockerd > /dev/null 2>&1; then
+    echo "⚠ dockerd is not installed — the Docker lanes (task local-*) are unavailable."
+    return 0
+  fi
+  if docker info > /dev/null 2>&1; then
+    echo "✅ Docker daemon already running."
+    return 0
+  fi
+  $SUDO_CMD mkdir -p /var/log || true
+  $SUDO_CMD sh -c 'dockerd >> /var/log/dockerd.log 2>&1 &' || true
+  # It answers in about a second; 20 is headroom, not an expectation.
+  for _ in $(seq 1 20); do
+    if docker info > /dev/null 2>&1; then
+      echo "✅ Docker daemon started."
+      return 0
+    fi
+    sleep 1
+  done
+  echo "⚠ Docker daemon did not come up in 20s — see /var/log/dockerd.log."
+}
+start_dockerd

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -38,6 +38,9 @@ echo "✅ Toolchain ready (tofu, talosctl, kubectl, yamllint, tflint, task, flux
 # Never fatal, and last on purpose: a session that cannot have Docker must still
 # come out of this hook with the toolchain above.
 start_dockerd() {
+  # Overridable so scripts/dev/test-session-start.sh can drive this against
+  # stubs without appending to a real /var/log on the machine running it.
+  local log="${DOCKERD_LOG:-/var/log/dockerd.log}"
   if ! command -v dockerd > /dev/null 2>&1; then
     echo "⚠ dockerd is not installed — the Docker lanes (task local-*) are unavailable."
     return 0
@@ -46,8 +49,8 @@ start_dockerd() {
     echo "✅ Docker daemon already running."
     return 0
   fi
-  $SUDO_CMD mkdir -p /var/log || true
-  $SUDO_CMD sh -c 'dockerd >> /var/log/dockerd.log 2>&1 &' || true
+  $SUDO_CMD mkdir -p "$(dirname "$log")" || true
+  $SUDO_CMD sh -c "dockerd >> '$log' 2>&1 &" || true
   # It answers in about a second; 20 is headroom, not an expectation.
   for _ in $(seq 1 20); do
     if docker info > /dev/null 2>&1; then
@@ -56,6 +59,6 @@ start_dockerd() {
     fi
     sleep 1
   done
-  echo "⚠ Docker daemon did not come up in 20s — see /var/log/dockerd.log."
+  echo "⚠ Docker daemon did not come up in 20s — see $log."
 }
 start_dockerd

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -41,6 +41,7 @@ start_dockerd() {
   # Overridable so scripts/dev/test-session-start.sh can drive this against
   # stubs without appending to a real /var/log on the machine running it.
   local log="${DOCKERD_LOG:-/var/log/dockerd.log}"
+  local containerd_pid="${CONTAINERD_PIDFILE:-/run/docker/containerd/containerd.pid}"
   if ! command -v dockerd > /dev/null 2>&1; then
     echo "⚠ dockerd is not installed — the Docker lanes (task local-*) are unavailable."
     return 0
@@ -50,15 +51,30 @@ start_dockerd() {
     return 0
   fi
   $SUDO_CMD mkdir -p "$(dirname "$log")" || true
-  $SUDO_CMD sh -c "dockerd >> '$log' 2>&1 &" || true
-  # It answers in about a second; 20 is headroom, not an expectation.
-  for _ in $(seq 1 20); do
-    if docker info > /dev/null 2>&1; then
-      echo "✅ Docker daemon started."
-      return 0
+  # TWO attempts, because one is not enough on a RESUMED container: it keeps a
+  # containerd pid from before the snapshot, dockerd sees that pid, refuses to
+  # start a managed containerd and gives up after 15 s — "failed to start
+  # containerd: timeout waiting for containerd to start". The pid is gone
+  # moments later and the retry comes up. Measured 2026-08-27 on a resume: first
+  # attempt timed out, second was serving in 2 s. Worst case 40 s, only ever on
+  # a session that was not going to have Docker at all.
+  local attempt
+  for attempt in 1 2; do
+    $SUDO_CMD sh -c "dockerd >> '$log' 2>&1 &" || true
+    # It answers in about a second; 20 is headroom, not an expectation.
+    for _ in $(seq 1 20); do
+      if docker info > /dev/null 2>&1; then
+        echo "✅ Docker daemon started."
+        return 0
+      fi
+      sleep 1
+    done
+    # Only a pidfile whose process is GONE. Killing a live containerd would take
+    # a working daemon down to fix one that is not running.
+    if [ -f "$containerd_pid" ] && ! kill -0 "$(cat "$containerd_pid" 2>/dev/null)" 2>/dev/null; then
+      $SUDO_CMD rm -f "$containerd_pid" || true
     fi
-    sleep 1
   done
-  echo "⚠ Docker daemon did not come up in 20s — see $log."
+  echo "⚠ Docker daemon did not come up after two tries — see $log."
 }
 start_dockerd

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -323,6 +323,11 @@ tasks:
       # so it installed the pin once and refused every upgrade after that. Found
       # by the Cléa probe, guarded here so it does not need Docker to stay fixed.
       - ./scripts/dev/test-setup-checks.sh
+      # The SessionStart hook runs under `set -e` and is the only thing that
+      # installs the toolchain in a web session. Its Docker block fails in ways
+      # the ENVIRONMENT chooses, and any of them returning non-zero leaves the
+      # session with no tools at all — a failure nothing would connect to Docker.
+      - ./scripts/dev/test-session-start.sh
 
   test:
     desc: Run OpenTofu tests (cluster root)

--- a/docs/status.md
+++ b/docs/status.md
@@ -52,10 +52,12 @@ every apply plans to a file and applies THAT file, and a saved plan never prompt
 Destroy always takes two commands and no flag collapses them. S3 credentials are
 namespaced by the cloud that HOLDS the bucket, and a cross-provider backup is
 proven — an encrypted tfstate at Outscale while the cluster runs on Scaleway.
-413 offline assertions across 13 harnesses, every one mutation-tested — 330 of
-them from the eleven harnesses that existed before Cléa, three fewer than the
-333 this page claimed and nothing had re-counted since; the emulated lane runs
-feint 0.10.0 against Scaleway provider 2.81.0, the version the clusters run.
+464 offline assertions across 14 harnesses, every one mutation-tested. Counted
+2026-08-27 from `task test-scripts` itself, and it had drifted again: 452 across
+13 before the SessionStart-hook harness was added, against the 413 this page
+claimed — the same defect the 333 above records, which is what a number nothing
+re-counts does. The emulated lane runs feint 0.10.0 against Scaleway provider
+2.81.0, the version the clusters run.
 
 **The root cause behind a week of upgrade failures is fixed**, and it was ours:
 the shared schematic shipped `siderolabs/qemu-guest-agent`, which never starts on

--- a/docs/status.md
+++ b/docs/status.md
@@ -52,7 +52,7 @@ every apply plans to a file and applies THAT file, and a saved plan never prompt
 Destroy always takes two commands and no flag collapses them. S3 credentials are
 namespaced by the cloud that HOLDS the bucket, and a cross-provider backup is
 proven — an encrypted tfstate at Outscale while the cluster runs on Scaleway.
-464 offline assertions across 14 harnesses, every one mutation-tested. Counted
+468 offline assertions across 14 harnesses, every one mutation-tested. Counted
 2026-08-27 from `task test-scripts` itself, and it had drifted again: 452 across
 13 before the SessionStart-hook harness was added, against the 413 this page
 claimed — the same defect the 333 above records, which is what a number nothing

--- a/infrastructure/opentofu-local/README.md
+++ b/infrastructure/opentofu-local/README.md
@@ -26,6 +26,30 @@ before spending money in the cloud.
 Plus, on top of the cluster: Cilium CNI on all 5 nodes, Flux, and the
 `ApplicationSet → Application` hub mechanism.
 
+## Host requirement: `CAP_SYS_RESOURCE`
+
+Talos's in-node containerd sets its own OOM score to `-999`, which needs
+`CAP_SYS_RESOURCE`. Sandboxes and some CI runners drop that capability from the
+BOUNDING set, and `--privileged` cannot get it back: Docker grants capabilities
+from its parent's bounding set, so a privileged container inherits the same hole.
+Check before spending fifteen minutes on it:
+
+```bash
+# The BOUNDING line, and only it: capsh names the capability twice more as a
+# NEGATION ("cap_sys_resource-ep", "!cap_sys_resource"), so a bare grep over the
+# whole output reports a missing capability as present.
+capsh --print | grep '^Bounding set' | grep -q cap_sys_resource ||
+  echo "MISSING — this lane cannot run here"
+```
+
+Without it the containers come up and look healthy while
+`talos_machine_bootstrap` retries to its timeout, and the reason is only in
+`docker logs openaether-local-dev-cp-0`: containerd `going to restart forever:
+failed to change OOMScoreAdj [...] to -999: permission denied`. No containerd
+means no `apid`, so the Talos API port never listens. There is no workaround —
+the qemu provisioner wants `/dev/kvm`, which such hosts do not expose either.
+Measured 2026-08-27 on a host where bit 24 was the only one of 41 missing.
+
 ## Quick start
 
 ```bash

--- a/scripts/dev/test-session-start.sh
+++ b/scripts/dev/test-session-start.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# The SessionStart hook must never cost a session its toolchain.
+#
+# `.claude/hooks/session-start.sh` runs under `set -euo pipefail` and is the only
+# thing that installs tofu, talosctl, kubectl, task and the rest into a Claude
+# Code on the web session. The Docker block appended to it can fail in three ways
+# the ENVIRONMENT chooses and the repository cannot: no dockerd in the image, a
+# daemon that never answers, a /var/log it may not write. Any of them returning
+# non-zero aborts the hook, and the session comes out with no toolchain at all —
+# a failure that looks nothing like its cause.
+#
+# So the assertions here are mostly about an exit code being zero. That reads
+# thin and is not: `return 0` on every path is the whole guarantee.
+#
+# The function is extracted and driven against stubs — the hook runs its whole
+# bootstrap when sourced, so there is nothing to import. Same shape as
+# test-setup-checks.sh.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$ROOT/.claude/hooks/session-start.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+sed -n '/^start_dockerd() {/,/^}/p' "$HOOK" > "$TMP/fn.sh"
+# ZERO FLOOR: an extractor that returns nothing makes every assertion below pass
+# vacuously, which is the exact shape this file exists against.
+grep -q 'command -v dockerd' "$TMP/fn.sh" || {
+  echo "✗ could not extract start_dockerd from the hook — the extractor is broken, not the hook" >&2
+  exit 1
+}
+
+mkdir -p "$TMP/bin"
+LOG="$TMP/dockerd.log"
+
+# `docker info` answers 0 once $TMP/ready exists, and every probe is counted:
+# a loop that forgot its ceiling shows up as a number instead of as a hang.
+cat > "$TMP/bin/docker" <<EOF
+#!/bin/sh
+echo p >> "$TMP/probes"
+[ -f "$TMP/ready" ] && exit 0
+exit 1
+EOF
+
+# The daemon comes up on a SLEEP, not on a wall clock: the stub below is
+# instant, so anything timing-based here would be a race, and a racing test is
+# worse than no test.
+cat > "$TMP/bin/sleep" <<EOF
+#!/bin/sh
+n=\$(cat "$TMP/sleeps" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" > "$TMP/sleeps"
+if [ -f "$TMP/comes-up-after" ] && [ "\$n" -ge "\$(cat "$TMP/comes-up-after")" ]; then
+  : > "$TMP/ready"
+fi
+exit 0
+EOF
+
+cat > "$TMP/bin/dockerd" <<EOF
+#!/bin/sh
+echo d >> "$TMP/launched"
+exit 0
+EOF
+
+chmod +x "$TMP/bin/docker" "$TMP/bin/sleep" "$TMP/bin/dockerd"
+
+reset() { rm -f "$TMP/ready" "$TMP/probes" "$TMP/sleeps" "$TMP/launched" \
+                "$TMP/comes-up-after" "$TMP/bin/mkdir" "$LOG"; }
+
+OUT=""
+RC=0
+drive() { # [extra PATH entries in front]
+  OUT="$(PATH="$TMP/bin:${1:-/bin:/usr/bin}" DOCKERD_LOG="$LOG" \
+    /bin/bash -c 'set -euo pipefail; SUDO_CMD=""; . "$1"; start_dockerd' _ "$TMP/fn.sh" 2>&1)"
+  RC=$?
+}
+
+rc0() { # <label>
+  if [ "$RC" -eq 0 ]; then ok "$1"; else bad "$1 (exit $RC) — $OUT"; fi
+}
+says() { # <needle> <label>
+  if grep -qF -- "$1" <<< "$OUT"; then ok "$2"; else bad "$2 — got: $OUT"; fi
+}
+
+# The launch is backgrounded, so the marker lands after the function returns.
+# Bounded, and generous: a ceiling this far above the real cost fails only when
+# nothing was launched at all.
+launched() {
+  local i
+  for i in $(seq 1 100); do
+    [ -f "$TMP/launched" ] && return 0
+    sleep 0.02
+  done
+  return 1
+}
+
+echo "=== the daemon comes up ==="
+reset
+echo 2 > "$TMP/comes-up-after"
+drive
+rc0 "a stopped daemon is started"
+says "Docker daemon started" "and it says so"
+if launched; then ok "and dockerd was actually launched"; else bad "nothing was launched"; fi
+
+echo
+echo "=== an already-running daemon is left alone ==="
+reset
+: > "$TMP/ready"
+drive
+rc0 "a running daemon needs nothing"
+says "already running" "and it says so"
+# Not cosmetic: a second dockerd over a live socket is how you get two daemons
+# fighting over /var/lib/docker.
+sleep 0.2
+if [ -f "$TMP/launched" ]; then bad "a second dockerd was launched over it"; else ok "and no second dockerd is launched over it"; fi
+
+echo
+echo "=== and when it cannot, the session still gets its toolchain ==="
+# Only the stub directory on PATH, and bash reached by absolute path: leaving
+# /usr/bin in front would find the REAL dockerd and judge an absent one present
+# — green on this machine, meaningless everywhere.
+reset
+rm -f "$TMP/bin/dockerd"
+drive "$TMP/bin"
+rc0 "dockerd absent is survivable"
+says "task local-*" "and it names the lanes that are unavailable"
+cat > "$TMP/bin/dockerd" <<EOF
+#!/bin/sh
+echo d >> "$TMP/launched"
+exit 0
+EOF
+chmod +x "$TMP/bin/dockerd"
+
+reset
+drive
+rc0 "a daemon that never answers is survivable"
+says "$LOG" "and it names the log to read"
+
+reset
+printf '#!/bin/sh\nexit 1\n' > "$TMP/bin/mkdir"
+chmod +x "$TMP/bin/mkdir"
+drive
+rc0 "a log directory it cannot create is survivable"
+
+echo
+echo "=== the wait is bounded ==="
+# 1 probe before the launch, then the loop's own. A ceiling that drifts silently
+# is a hook that hangs a session for minutes with no output.
+reset
+drive
+probes="$(wc -l < "$TMP/probes")"
+if [ "$probes" -eq 21 ]; then
+  ok "it gives up after 20 tries rather than looping (1 + 20 probes)"
+else
+  bad "expected 1 + 20 probes, counted $probes"
+fi
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/dev/test-session-start.sh
+++ b/scripts/dev/test-session-start.sh
@@ -37,6 +37,7 @@ grep -q 'command -v dockerd' "$TMP/fn.sh" || {
 
 mkdir -p "$TMP/bin"
 LOG="$TMP/dockerd.log"
+PIDFILE="$TMP/containerd.pid"
 
 # `docker info` answers 0 once $TMP/ready exists, and every probe is counted:
 # a loop that forgot its ceiling shows up as a number instead of as a hang.
@@ -70,12 +71,12 @@ EOF
 chmod +x "$TMP/bin/docker" "$TMP/bin/sleep" "$TMP/bin/dockerd"
 
 reset() { rm -f "$TMP/ready" "$TMP/probes" "$TMP/sleeps" "$TMP/launched" \
-                "$TMP/comes-up-after" "$TMP/bin/mkdir" "$LOG"; }
+                "$TMP/comes-up-after" "$TMP/bin/mkdir" "$LOG" "$PIDFILE"; }
 
 OUT=""
 RC=0
 drive() { # [extra PATH entries in front]
-  OUT="$(PATH="$TMP/bin:${1:-/bin:/usr/bin}" DOCKERD_LOG="$LOG" \
+  OUT="$(PATH="$TMP/bin:${1:-/bin:/usr/bin}" DOCKERD_LOG="$LOG" CONTAINERD_PIDFILE="$PIDFILE" \
     /bin/bash -c 'set -euo pipefail; SUDO_CMD=""; . "$1"; start_dockerd' _ "$TMP/fn.sh" 2>&1)"
   RC=$?
 }
@@ -140,7 +141,6 @@ reset
 drive
 rc0 "a daemon that never answers is survivable"
 says "$LOG" "and it names the log to read"
-
 reset
 printf '#!/bin/sh\nexit 1\n' > "$TMP/bin/mkdir"
 chmod +x "$TMP/bin/mkdir"
@@ -148,17 +148,51 @@ drive
 rc0 "a log directory it cannot create is survivable"
 
 echo
+echo "=== a resumed container gets a second attempt ==="
+# A container restored from a snapshot keeps a containerd pid from before it.
+# dockerd sees the pid, refuses to start a managed containerd and gives up after
+# 15 s; the pid is gone moments later. Measured 2026-08-27 — one attempt left
+# the session with the warning and no daemon, a second came up in 2 s.
+reset
+drive
+if [ "$(wc -l < "$TMP/launched")" -eq 2 ]; then
+  ok "a first attempt that times out is followed by a second"
+else
+  bad "expected 2 launches, counted $(wc -l < "$TMP/launched")"
+fi
+
+# Clearing the pidfile is what makes the retry deterministic instead of hopeful.
+reset
+# Reaped HERE on purpose: a background child of a subshell is never reaped, and
+# `kill -0` succeeds on the zombie it leaves — a dead pid that reads as alive.
+sh -c 'exit 0' & dead_pid=$!
+wait "$dead_pid" 2>/dev/null || true
+echo "$dead_pid" > "$PIDFILE"
+drive
+if [ -f "$PIDFILE" ]; then bad "a containerd pidfile whose process is gone was kept"; else ok "a containerd pidfile whose process is gone is cleared"; fi
+
+# The dangerous half, and the reason this is not a pkill: a live containerd
+# belongs to a working daemon somewhere, and taking it down to fix one that is
+# not running trades a real outage for a hypothetical one.
+reset
+echo $$ > "$PIDFILE"
+drive
+if [ -f "$PIDFILE" ]; then ok "a LIVE containerd is left alone"; else bad "a live containerd's pidfile was deleted"; fi
+
+
+echo
 echo "=== the wait is bounded ==="
-# 1 probe before the launch, then the loop's own. A ceiling that drifts silently
-# is a hook that hangs a session for minutes with no output.
+# 1 probe before the first launch, then 20 per attempt, twice. A ceiling that
+# drifts silently is a hook that hangs a session for minutes with no output.
 reset
 drive
 probes="$(wc -l < "$TMP/probes")"
-if [ "$probes" -eq 21 ]; then
-  ok "it gives up after 20 tries rather than looping (1 + 20 probes)"
+if [ "$probes" -eq 41 ]; then
+  ok "it gives up rather than looping (1 + 2 × 20 probes)"
 else
-  bad "expected 1 + 20 probes, counted $probes"
+  bad "expected 1 + 2 × 20 probes, counted $probes"
 fi
+says "after two tries" "and says it tried twice"
 
 echo
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
> ⚠️ **This is a code-execution pull request.** It touches `.claude/hooks/**`, which runs by itself at the start of every session. Read the diff before running an agent on the branch. Checks done on my side: no address anywhere in it, `settings.json` untouched and still without `permissions.allow`, and the hook downloads nothing new.

> *History note, resolved.* This was opened stacked on #99's branch to keep its diff to its own commits, which cost it all CI — `ci.yml` and `security.yml` trigger on `pull_request: branches: [main]` only, and retargeting fires `edited`, not a default activity type, so no run started either way. #99 has since merged and the branch was rebased onto `main`: four commits of its own, and CI is green on `5f5bfc4`. The earlier comment describing the blockage is kept for the record.

## Docker was unavailable in every web session

The remote image ships `dockerd` **stopped** — `/var/run/docker.sock` does not exist until something starts it — so every container lane here was out of reach in a Claude Code on the web session: `task local-up`/`local-down`, `test-talos-local.sh`, `test-gates-local.sh`. A daemon started by hand does not survive the container.

The hook is the only thing that runs at session start, and it runs under `set -euo pipefail`, so the Docker block is placed last and returns 0 on every path. A session that cannot have Docker must still come out of the hook with its toolchain.

**Two attempts, not one.** A container restored from a snapshot keeps a containerd pid from before it; `dockerd` sees that pid, refuses to start a managed containerd and gives up after 15 s — `failed to start containerd: timeout waiting for containerd to start`. The pid is gone moments later. Measured on a resumed session: first attempt timed out, second was serving in 2 s. Between the attempts a containerd pidfile whose process is **gone** is removed — only that one; a live containerd belongs to a working daemon, and a `pkill` would trade a real outage for a hypothetical one.

## A harness, because this is the expensive thing to get wrong

`scripts/dev/test-session-start.sh` extracts `start_dockerd` and drives it against stubs, same shape as `test-setup-checks.sh`: 16 assertions over the paths that work, the three failures the *environment* chooses and the repository cannot prevent (no dockerd, a daemon that never answers, a `/var/log` it may not write), the retry, the pidfile rule in both directions, and the probe count so the ceiling cannot shrink in silence. The daemon comes up on a stubbed `sleep` rather than a wall clock — anything timing-based there would be a race.

Six mutations, each caught by the assertion meant for it and no other:

| mutation | assertion that goes red |
|---|---|
| `\|\| true` dropped from the `mkdir` | *a log directory it cannot create is survivable* |
| absent dockerd returns 1 | *dockerd absent is survivable* |
| early return over a live daemon removed | *a second dockerd was launched over it* |
| inner ceiling shrunk to 5 | *counted 11* |
| the retry dropped | *expected 2 launches, counted 1* + *counted 21* |
| pidfile cleared unconditionally | *a live containerd's pidfile was deleted* |

Hook byte-identical after each. `docs/status.md`'s assertion count is re-measured rather than incremented — 468 across 14 harnesses; it had already drifted to 452 across 13 against the 413 the page claimed.

## And what the local lane needs of its host

`infrastructure/opentofu-local/README.md` now names `CAP_SYS_RESOURCE`. Talos's in-node containerd sets its own OOM score to `-999`, which needs it; sandboxes and some CI runners drop it from the **bounding** set, where `--privileged` cannot get it back — Docker grants capabilities from its parent's bounding set, so a privileged container inherits the same hole.

Undocumented it costs fifteen minutes: the containers come up and look healthy, `talos_machine_bootstrap` retries to its timeout, and the cause is a layer below anything the lane prints. The check had to be written twice — `capsh --print | grep -q cap_sys_resource` reports a **missing** capability as present, because capsh names it twice more as a negation (`cap_sys_resource-ep`, `!cap_sys_resource`). Only the `Bounding set` line answers the question asked.

## Rung

CI green on `5f5bfc4`, 14/14. Locally: `task lint`, `task test-scripts` (468 across 14), `task test` (52/52), `task render-check`, `task feint-test` (both providers, both lanes).

The hook run as the harness runs it: cold with `dockerd` killed — `✅ Docker daemon started`, 4.69 s, `docker run --rm hello-world` answering; again with the daemon up — `already running`, 4.40 s.

Beyond that, the whole reason the capability note exists: the Docker lane was run to its failure on this host. Six Talos containers up, network, node identity and certificates established, dead at the in-node containerd, with `CAP_SYS_RESOURCE` the only one of 41 missing from `CapBnd`. Teardown afterwards left no container, volume, network or credential — which is #99's `--destroy` fix doing its job on exactly the case it was written for.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiC6JGaTecmJVqE9GfDgjA