### PR TITLE
fix(ci): validate Talos configs with the talosctl the clusters run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,18 +285,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
+      # The repository's own installer, so this job cannot validate configs with
+      # a talosctl the clusters do not run. It reads talos-version.sh, the one
+      # place that decides `talos_version`. This step used to carry a second pin
+      # of its own and it had drifted two patches behind — v1.13.7 against the
+      # v1.13.9 both roots pin — with nothing comparing the pair.
       - name: Install talosctl (pinned + checksum-verified)
-        env:
-          # renovate: datasource=github-releases depName=siderolabs/talos
-          TALOS_VERSION: "v1.13.7"
         run: |
-          set -euo pipefail
-          base="https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}"
-          curl -fsSL -o talosctl-linux-amd64 "${base}/talosctl-linux-amd64"
-          curl -fsSL "${base}/sha256sum.txt" | grep ' talosctl-linux-amd64$' > sha256sum.txt
-          sha256sum -c sha256sum.txt
-          chmod +x talosctl-linux-amd64
-          sudo install -m 0755 talosctl-linux-amd64 /usr/local/bin/talosctl
+          ./scripts/internal/install-talosctl.sh
           talosctl version --client
 
       - name: Generate Talos secrets

--- a/scripts/dev/check-version-drift.sh
+++ b/scripts/dev/check-version-drift.sh
@@ -41,11 +41,17 @@ HELM_SETUP="$(pin scripts/setup.sh HELM_VERSION)"
 HELM_CI="$(sed -nE 's/^[[:space:]]*HELM_VERSION:[[:space:]]*"([^"]+)".*/\1/p' .github/workflows/ci.yml | head -1)"
 TOFU_SETUP="$(pin scripts/setup.sh TOFU_VERSION)"
 TOFU_CI="$(sed -nE 's/^[[:space:]]*tofu_version:[[:space:]]*"([^"]+)".*/\1/p' .github/workflows/ci.yml | head -1)"
+# Talos has no second pin to compare: ci.yml installs it through
+# scripts/internal/install-talosctl.sh, which reads the cluster's own. So the
+# question is whether that is still true — TALOS_CI is EXPECTED to be empty, and
+# is not part of the zero floor below for that reason.
+TALOS_CLUSTER="$(scripts/internal/talos-version.sh 2>/dev/null || true)"
+TALOS_CI="$(sed -nE 's/^[[:space:]]*TALOS_VERSION:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/p' .github/workflows/ci.yml | head -1)"
 
 # ZERO FLOOR. If the extractors return nothing the comparisons below all pass
 # vacuously, and this file becomes a green line that proves nothing — the exact
 # shape it is written against.
-for v in CILIUM HELM_MAJOR FEINT HELM_SETUP HELM_CI TOFU_SETUP TOFU_CI; do
+for v in CILIUM HELM_MAJOR FEINT HELM_SETUP HELM_CI TOFU_SETUP TOFU_CI TALOS_CLUSTER; do
   [ -n "${!v}" ] || { echo "✗ could not extract ${v} — the extractor is broken, not the repository" >&2; exit 1; }
 done
 
@@ -70,6 +76,22 @@ if [ "$TOFU_SETUP" = "$TOFU_CI" ]; then
   ok "OpenTofu ${TOFU_SETUP}: setup.sh and ci.yml agree"
 else
   bad "OpenTofu: setup.sh installs ${TOFU_SETUP}, ci.yml pins ${TOFU_CI} — a contributor and CI would not run the same binary"
+fi
+
+# Talos: the drift here was invisible for a different reason than the others —
+# there was no rule comparing the pair at all, so ci.yml validated configs with
+# v1.13.7 while both roots pinned v1.13.9. The fix is structural rather than a
+# comparison: ci.yml installs through install-talosctl.sh, which reads the
+# cluster's pin, so the two cannot disagree. What is checked is that the
+# structure holds — a hardcoded version coming back is the regression.
+if ! grep -q 'install-talosctl\.sh' .github/workflows/ci.yml; then
+  bad "ci.yml no longer installs talosctl through scripts/internal/install-talosctl.sh — it can pin a version of its own again"
+elif [ -z "$TALOS_CI" ]; then
+  ok "Talos ${TALOS_CLUSTER}: ci.yml declares no version of its own, it installs the cluster's"
+elif [ "${TALOS_CI#v}" = "${TALOS_CLUSTER#v}" ]; then
+  ok "Talos ${TALOS_CLUSTER}: ci.yml names the same version the cluster pins"
+else
+  bad "Talos: ci.yml pins ${TALOS_CI}, the cluster pins ${TALOS_CLUSTER} — CI would validate configs against another release"
 fi
 
 # Cilium: the pin versus the artifact actually committed from it.


### PR DESCRIPTION
Flagged in #99's description as "worth an issue"; this is the change instead of the constat.

## The drift

`ci.yml`'s talos job carried a second pin of its own, and it had drifted: `TALOS_VERSION: "v1.13.7"` against the `v1.13.9` both roots pin — and nothing compared the pair. `check-version-drift.sh` compares helm and tofu between `setup.sh` and `ci.yml`, never talos. So "Talos Config Validation" was green while validating configs with a client two patches behind the fleet.

## The fix is structural, not a third copy

The job now installs through `scripts/internal/install-talosctl.sh` (landed in #99), which reads `talos-version.sh` — the one place that decides `talos_version` — so the pair *cannot* disagree. Same reasoning as the Taskfile literal that once drifted to v1.13.7 against v1.13.8 and built an image the cluster refused to find: two defaults for one fact is one too many.

`check-version-drift.sh` gains the rule that keeps it true:

- red if `ci.yml` stops calling the installer (it can pin a version of its own again);
- red if a `TALOS_VERSION` of its own comes back stale, naming both versions;
- green — and still checked — if one comes back matching.

`TALOS_CI` is *expected* empty and deliberately outside the extractor zero floor.

## Rung

Mocked, plus the installer run exactly as CI will run it — a bare PATH with no talosctl, installing into an empty dir: checksum `OK`, v1.13.9 in 2.2 s. The drift rule mutation-tested three ways, each caught by its own message: a stale `TALOS_VERSION` re-added, a matching one re-added, the installer call removed. `task lint` green (the check itself now answers 8 passed), `task test-scripts` 468, actionlint clean.

The real proof is this PR's own CI: the "Talos Config Validation" job on this head runs the new path on a bare runner.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiC6JGaTecmJVqE9GfDgjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiC6JGaTecmJVqE9GfDgjA)_