### PR TITLE
fix(ci): run on stacked pull requests, and on a retarget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches` filter and `edited` added, both measured on PR #100: a PR
+  # based on another PR's branch got NO run at all (not a red one — none), and
+  # retargeting it to main fired only `edited`, which the default types skip.
+  # An unvalidated stacked PR looks exactly like a green one in the list.
   pull_request:
-    branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 # All jobs here are read-only validation — always safe to cancel a superseded run.
 concurrency:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,12 @@ name: Security
 on:
   push:
     branches: [main]
+  # No `branches` filter and `edited` added, both measured on PR #100: a PR
+  # based on another PR's branch got NO run at all (not a red one — none), and
+  # retargeting it to main fired only `edited`, which the default types skip.
+  # An unvalidated stacked PR looks exactly like a green one in the list.
   pull_request:
-    branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The trap #100 measured, closed.

## What happened

A PR based on another PR's branch got **no CI at all** — not a red run, none — because `ci.yml` and `security.yml` filter `pull_request` to `branches: [main]`. Retargeting it to `main` did not help either: that fires `edited`, which the default activity types (`opened`, `synchronize`, `reopened`) skip. So an unvalidated stacked PR sat in the list looking exactly like a green one, and only a later push — the post-merge rebase — ever gave it checks. Full sequence recorded in [#100's comment](https://github.com/dis-bzh/OpenAether-infra/pull/100#issuecomment-5443236975).

## The change

Both workflows:

- the `branches: [main]` filter on `pull_request` goes — a PR against any base gets validated;
- `edited` joins the activity types — a retarget re-runs.

**Accepted cost:** `edited` also fires on title and body edits. Both workflows already cancel superseded runs per ref (`concurrency` + `cancel-in-progress`), and a wasted two-minute run is cheap against a PR that can be merged with no validation at all.

`push` stays `branches: [main]` — feature-branch pushes without a PR still run nothing.

## Rung

actionlint clean on both workflows, `task lint` green. The failure this fixes is measured, not hypothesized: #100 showed 0 check runs through an open + retarget cycle, then 14/14 within seconds of its first real push. The counterpart proof — this PR's own CI running — is visible on this page.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiC6JGaTecmJVqE9GfDgjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiC6JGaTecmJVqE9GfDgjA)_