### PR TITLE
chore(deps): apply Cléa's #91 bumps, and fix the gate that missed one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install commitizen
         # renovate: datasource=pypi depName=commitizen
-        run: pip install commitizen==4.9.1
+        run: pip install commitizen==4.18.0
 
       - name: Conventional Commits
         run: cz check --rev-range origin/${{ github.base_ref }}..HEAD
@@ -101,7 +101,7 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
         with:
           # renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
-          tofu_version: "1.12.5"
+          tofu_version: "1.12.6"
 
       # Same installer as setup.sh and the session-start hook, for the same reason
       # as Task below: one pinned version, verified against the project's own
@@ -194,7 +194,7 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
         with:
           # renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
-          tofu_version: "1.12.5"
+          tofu_version: "1.12.6"
 
       - name: Setup Task
         run: ./scripts/internal/install-task.sh
@@ -219,7 +219,7 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
         with:
           # renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
-          tofu_version: "1.12.5"
+          tofu_version: "1.12.6"
 
       - name: Setup Task
         run: ./scripts/internal/install-task.sh
@@ -257,7 +257,7 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
         with:
           # renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
-          tofu_version: "1.12.5"
+          tofu_version: "1.12.6"
 
       - name: Setup Task
         run: ./scripts/internal/install-task.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,22 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Changed
 
+- **Six dependencies Cléa's first report ([#91](https://github.com/dis-bzh/OpenAether-infra/issues/91)) found behind upstream and probed green, bumped for real**:
+  `go-task/task` 3.52.0 → 3.53.1, `cloudnative-pg/cloudnative-pg` 1.23.6 →
+  1.30.0, `opentofu/opentofu` 1.12.5 → 1.12.6 (four anchors in `ci.yml` plus
+  `setup.sh`), `cilium` 1.20.0 → 1.20.1 (chart re-rendered,
+  `task render-check` green against the new manifest) and `commitizen` 4.9.1 →
+  4.18.0. `helm/helm` and `fluxcd/flux2` stay put: the report's own verdict for
+  both is "not probed" (they ride the weekly lane, `daily = false`), so there is
+  nothing yet to act on. `stephrobert/feint` stays at 0.10.0: its probe failed
+  outright — the installer at the current pin reported no version, so the
+  upgrade lane had nothing to upgrade over — a defect in the installer, not
+  something this bump could paper over.
+  `task lint`, `task render-check`, `task test-scripts`, `task validate`
+  (`cluster` and `talos-image`), `task test` and `task security` (checkov and
+  gitleaks; `trivy` was not reachable from this sandbox) all green on the
+  bumped tree.
+
 - **`talosctl` is pinned and checksum-verified** by
   `scripts/internal/install-talosctl.sh`, instead of piping `talos.dev/install`
   into a shell — the last tool in `setup.sh` that was neither, in a repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,17 @@ in git. 0.1.0 is the first entry describing something proven.
   (`cluster` and `talos-image`), `task test` and `task security` (checkov and
   gitleaks; `trivy` was not reachable from this sandbox) all green on the
   bumped tree.
+  - **`kubernetes/kubernetes` v1.36.3 → v1.37.0, also reported probed green,
+    is deliberately left out.** `task test` — not part of Cléa's own gate list
+    — fails immediately on the bumped tree:
+    `cluster/versions-guard.tf`'s Talos↔Kubernetes support matrix caps Talos
+    1.13 at Kubernetes 1.36, and none of the three checks Cléa's daily lane
+    does run (`task lint`, `task render-check`, `task test-scripts`) exercise
+    that guard. The pairing is unproven, not confirmed broken — Cléa's weekly
+    local-cluster lane is what would actually boot it, and the report says
+    that lane "has not reported yet". `clea.toml`'s `[lane].repo` now also runs
+    `task test`, so a probe branch hitting this guard is reported for what it
+    is instead of green.
 
 - **`talosctl` is pinned and checksum-verified** by
   `scripts/internal/install-talosctl.sh`, instead of piping `talos.dev/install`

--- a/README.fr.md
+++ b/README.fr.md
@@ -85,7 +85,7 @@ version qui le fera : **[docs/capi-bootstrap.fr.md](docs/capi-bootstrap.fr.md)**
 |--------|-------------|--------|
 | **IaC** | OpenTofu 1.12.x | ✅ |
 | **OS** | Talos Linux v1.13.x (immuable) | ✅ |
-| **CNI** | Cilium 1.20.0 (WireGuard) | ✅ livré, manifeste inline — toute la plateforme de la 0.1.0 |
+| **CNI** | Cilium 1.20.1 (WireGuard) | ✅ livré, manifeste inline — toute la plateforme de la 0.1.0 |
 | **GitOps** | Flux v2.9.3 | ⬜ code présent, `deploy_flux = false` — redeviendra un choix dans une version ultérieure |
 
 Tout le reste — secrets, PKI, mesh, base de données, stockage, identité,

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ resources of which only 3 are compute instances. It is an optional overlay and
 |-------|------------|--------|
 | **IaC** | OpenTofu 1.12.x | ✅ |
 | **OS** | Talos Linux v1.13.x (immutable) | ✅ |
-| **CNI** | Cilium 1.20.0 (WireGuard) | ✅ shipped, inline manifest — the whole of 0.1.0's platform |
+| **CNI** | Cilium 1.20.1 (WireGuard) | ✅ shipped, inline manifest — the whole of 0.1.0's platform |
 | **GitOps** | Flux v2.9.3 | ⬜ code present, `deploy_flux = false` — returns as a choice in a later release |
 
 Everything else — secrets, PKI, mesh, database, storage, identity, observability,

--- a/clea.toml
+++ b/clea.toml
@@ -136,9 +136,14 @@ regen = ["./scripts/bootstrap/render-bootstrap-manifests.sh"]
 
 # The gates, on the bumped tree. `task lint` is the one that earns its place:
 # it runs check-version-drift.sh, which is exactly the "did the bump leave a
-# second copy behind" question.
+# second copy behind" question. `task test` earns its place the same way:
+# without it, bumping kubernetes/kubernetes to v1.37.0 probed green on
+# 2026-08-27 while cluster/versions-guard.tf's Talos-1.13 support window still
+# capped Kubernetes at 1.36 — a real incompatibility none of the other three
+# gates exercise.
 repo = [
   "task lint",
   "task render-check",
   "task test-scripts",
+  "task test",
 ]

--- a/infrastructure/opentofu/cluster/bootstrap-manifests/cilium.yaml
+++ b/infrastructure/opentofu/cluster/bootstrap-manifests/cilium.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "cilium-secrets"
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
   annotations:
 ---
 # Source: cilium/templates/cilium-agent/serviceaccount.yaml
@@ -346,7 +346,7 @@ metadata:
   name: cilium
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 rules:
 - apiGroups:
   - networking.k8s.io
@@ -459,7 +459,7 @@ metadata:
   name: cilium-operator
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 rules:
 - apiGroups:
   - ""
@@ -722,7 +722,7 @@ metadata:
   name: cilium
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -740,7 +740,7 @@ metadata:
   name: cilium-operator
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -759,7 +759,7 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 rules:
 - apiGroups:
   - ""
@@ -778,7 +778,7 @@ metadata:
   namespace: "cilium-secrets"
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 rules:
 - apiGroups:
   - ""
@@ -798,7 +798,7 @@ metadata:
   namespace: "cilium-secrets"
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 rules:
 - apiGroups:
   - ""
@@ -818,7 +818,7 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 rules:
 # ZTunnel DaemonSet management permissions
 # Note: These permissions must always be granted (not conditional on encryption.type)
@@ -851,7 +851,7 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -869,7 +869,7 @@ metadata:
   namespace: "cilium-secrets"
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -888,7 +888,7 @@ metadata:
   namespace: "cilium-secrets"
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -906,7 +906,7 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -930,7 +930,7 @@ metadata:
     k8s-app: cilium-envoy
     app.kubernetes.io/name: cilium-envoy
     app.kubernetes.io/part-of: cilium
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
     io.cilium/app: proxy
 spec:
   clusterIP: None
@@ -954,7 +954,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-agent
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 spec:
   selector:
     matchLabels:
@@ -973,7 +973,7 @@ spec:
         k8s-app: cilium
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium
-        helm.sh/chart: cilium-1.20.0
+        helm.sh/chart: cilium-1.20.1
     spec:
       securityContext:
         appArmorProfile:
@@ -982,7 +982,7 @@ spec:
           type: Unconfined
       containers:
       - name: cilium-agent
-        image: "quay.io/cilium/cilium:v1.20.0@sha256:383968cd5e8873f7976fa76aa6196045643558f4cc9518a207b9335cb24a0e93"
+        image: "quay.io/cilium/cilium:v1.20.1@sha256:ae9ea21f7427fe24bc6ea7247eb552157a1b0a431744045d3f641545ca71d11b"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -1158,7 +1158,7 @@ spec:
 
       initContainers:
       - name: config
-        image: "quay.io/cilium/cilium:v1.20.0@sha256:383968cd5e8873f7976fa76aa6196045643558f4cc9518a207b9335cb24a0e93"
+        image: "quay.io/cilium/cilium:v1.20.1@sha256:ae9ea21f7427fe24bc6ea7247eb552157a1b0a431744045d3f641545ca71d11b"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-dbg
@@ -1189,7 +1189,7 @@ spec:
             drop:
               - ALL
       - name: apply-sysctl-overwrites
-        image: "quay.io/cilium/cilium:v1.20.0@sha256:383968cd5e8873f7976fa76aa6196045643558f4cc9518a207b9335cb24a0e93"
+        image: "quay.io/cilium/cilium:v1.20.1@sha256:ae9ea21f7427fe24bc6ea7247eb552157a1b0a431744045d3f641545ca71d11b"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -1227,7 +1227,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "quay.io/cilium/cilium:v1.20.0@sha256:383968cd5e8873f7976fa76aa6196045643558f4cc9518a207b9335cb24a0e93"
+        image: "quay.io/cilium/cilium:v1.20.1@sha256:ae9ea21f7427fe24bc6ea7247eb552157a1b0a431744045d3f641545ca71d11b"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -1243,7 +1243,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "quay.io/cilium/cilium:v1.20.0@sha256:383968cd5e8873f7976fa76aa6196045643558f4cc9518a207b9335cb24a0e93"
+        image: "quay.io/cilium/cilium:v1.20.1@sha256:ae9ea21f7427fe24bc6ea7247eb552157a1b0a431744045d3f641545ca71d11b"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1293,7 +1293,7 @@ spec:
           mountPath: /var/run/cilium # wait-for-kube-proxy
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "quay.io/cilium/cilium:v1.20.0@sha256:383968cd5e8873f7976fa76aa6196045643558f4cc9518a207b9335cb24a0e93"
+        image: "quay.io/cilium/cilium:v1.20.1@sha256:ae9ea21f7427fe24bc6ea7247eb552157a1b0a431744045d3f641545ca71d11b"
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -1447,7 +1447,7 @@ metadata:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-envoy
     name: cilium-envoy
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 spec:
   selector:
     matchLabels:
@@ -1465,14 +1465,14 @@ spec:
         name: cilium-envoy
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium
-        helm.sh/chart: cilium-1.20.0
+        helm.sh/chart: cilium-1.20.1
     spec:
       securityContext:
         appArmorProfile:
           type: Unconfined
       containers:
       - name: cilium-envoy
-        image: "quay.io/cilium/cilium-envoy:v1.37.5-1782911245-7cffc778c923f68a77954a53b1a98d6b5353f004@sha256:583057dd4f7d54cd41efff3c413aa0b148ac201f522e2c3336851fa89c78b039"
+        image: "quay.io/cilium/cilium-envoy:v1.37.5-1786810558-766ccfb37260a43e9d228837aa84ce3faf9f64e7@sha256:75b8094c7127736a2ffd2dce3945e0931cb6df21b0372ff661940eca26730b91"
         imagePullPolicy: IfNotPresent
         command:
         - /usr/bin/cilium-envoy-starter
@@ -1632,7 +1632,7 @@ metadata:
     name: cilium-operator
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
-    helm.sh/chart: cilium-1.20.0
+    helm.sh/chart: cilium-1.20.1
 spec:
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.
@@ -1660,14 +1660,14 @@ spec:
         name: cilium-operator
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: cilium-operator
-        helm.sh/chart: cilium-1.20.0
+        helm.sh/chart: cilium-1.20.1
     spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
       containers:
       - name: cilium-operator
-        image: "quay.io/cilium/operator-generic:v1.20.0@sha256:80744a8cc7c91c2f9e6347629406844eb35d79b30a732c6d41c15b17232a74f3"
+        image: "quay.io/cilium/operator-generic:v1.20.1@sha256:6c3885fc7b629099fdbe2a5c87869c86feb825fa18fae299eac0f61918d16ecf"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/scripts/bootstrap/render-bootstrap-manifests.sh
+++ b/scripts/bootstrap/render-bootstrap-manifests.sh
@@ -37,7 +37,7 @@ fi
 # for it and nothing reporting it. It is also what --check compares the
 # committed flux-install.yaml against, so bump the pin and the artifact together.
 # renovate: datasource=helm depName=cilium registryUrl=https://helm.cilium.io/
-CILIUM_VERSION="${CILIUM_VERSION:-1.20.0}"
+CILIUM_VERSION="${CILIUM_VERSION:-1.20.1}"
 # renovate: datasource=github-releases depName=fluxcd/flux2
 FLUX_VERSION="${FLUX_VERSION:-v2.9.3}"
 FLUX_URL="https://github.com/fluxcd/flux2/releases/download/${FLUX_VERSION}/install.yaml"

--- a/scripts/internal/install-kubectl-cnpg.sh
+++ b/scripts/internal/install-kubectl-cnpg.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 # renovate: datasource=github-releases depName=cloudnative-pg/cloudnative-pg extractVersion=^v(?<version>.*)$
-CNPG_VERSION="1.23.6"
+CNPG_VERSION="1.30.0"
 
 # shellcheck source=scripts/lib/common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"

--- a/scripts/internal/install-task.sh
+++ b/scripts/internal/install-task.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.*)$
-TASK_VERSION="3.52.0"
+TASK_VERSION="3.53.1"
 
 # shellcheck source=scripts/lib/common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -33,7 +33,7 @@ fi
 # other major. check-version-drift.sh compares all of them.
 #
 # renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
-TOFU_VERSION="1.12.5"
+TOFU_VERSION="1.12.6"
 # renovate: datasource=github-releases depName=fluxcd/flux2 extractVersion=^v(?<version>.*)$
 FLUX_VERSION="2.9.3"
 # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$


### PR DESCRIPTION
## Summary

Applies the bumps Cléa's dependency report ([#91](https://github.com/dis-bzh/OpenAether-infra/issues/91)) found behind upstream and probed green — Cléa itself never opens PRs, it only watches, probes and reports.

- Bumped: `go-task/task` 3.52.0 → 3.53.1, `cloudnative-pg/cloudnative-pg` 1.23.6 → 1.30.0, `opentofu/opentofu` 1.12.5 → 1.12.6 (four `ci.yml` anchors + `setup.sh`), `cilium` 1.20.0 → 1.20.1 (chart re-rendered), `commitizen` 4.9.1 → 4.18.0. Also fixed the one doc line (`README.md`/`README.fr.md`) that stated the old Cilium version outside the `# renovate:` anchors `clea bump` rewrites.
- Left alone: `helm/helm` and `fluxcd/flux2` — the report's own verdict is "not probed" (weekly lane). `stephrobert/feint` — its probe failed outright (installer reports no version at the current pin, so there's nothing to upgrade over).
- **Deliberately not bumped**: `kubernetes/kubernetes` v1.36.3 → v1.37.0, despite also being reported "probed green". Running `task test` locally on the bumped tree fails immediately: `cluster/versions-guard.tf`'s Talos↔Kubernetes support matrix caps Talos 1.13 at Kubernetes 1.36, and Cléa's daily gate (`task lint`, `task render-check`, `task test-scripts`) never runs `task test`, so it can't see this. The pairing isn't confirmed broken, just unproven — Cléa's weekly local-cluster lane is what would actually boot it, and #91 says that lane hasn't reported yet. Follow-up tracked in [#104](https://github.com/dis-bzh/OpenAether-infra/issues/104).
- Fixed the gap that let that happen: `clea.toml`'s `[lane].repo` now also runs `task test` on every probe branch.

## Test plan

- [x] `task lint` — green (`check-version-drift.sh` and `clea coverage` both included)
- [x] `task render-check` — green (Cilium manifest re-rendered and matches)
- [x] `task test-scripts` — green (60 + 23 + 16 passed)
- [x] `task validate ROOT=cluster` — green
- [x] `task validate ROOT=talos-image` — green (pre-existing, unrelated proxmox provider deprecation warning only)
- [x] `task test` — green (52 passed) once `kubernetes/kubernetes` was left at v1.36.3; failed with the version-pair guard error before that revert, which is exactly the finding above
- [x] `task security` — checkov (16 passed) and gitleaks (no leaks, rules self-check 6/6) green; `trivy` could not be installed in this sandbox (network-restricted), so that one scan relies on CI
- [x] `scripts/dev/test-clea.sh` — green (60 passed), confirms the `clea.toml` gate-list change doesn't break Cléa's own fixtures

Mocked rung (`task test`/`task lint`/etc.) reached; emulated (`task feint-*`) and real-cloud rungs skipped — this is a dependency-pin bump, not a provider-module change.

Assisted-by: Claude Code (claude-sonnet-5)