### PR TITLE
fix(scripts): give converge-versions.sh its own downgrade guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,14 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`converge-versions.sh` had no downgrade guard of its own.** It survived a
+  Talos/Kubernetes downgrade attempt only by accident, on two layers it does
+  not own (the talos provider's forced PKI replacement, and
+  `secrets_prevent_destroy` turning that into a hard refusal — a variable that
+  is explicitly false in `tofu test`). It now refuses a pin that is
+  semver-lower than what the fleet runs, naming both, before calling either
+  `infra-apply` or `cluster-roll`. [#90](https://github.com/dis-bzh/OpenAether-infra/issues/90)
+
 - **`task local-down` refused to run on a clone that had only this repository.**
   `test-talos-local.sh` resolves `APPS_DIR` and exits 1 when it cannot find
   `OpenAether-apps/apps/flux/local` — before it reads `--destroy`, which never

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -328,6 +328,9 @@ tasks:
       # the ENVIRONMENT chooses, and any of them returning non-zero leaves the
       # session with no tools at all — a failure nothing would connect to Docker.
       - ./scripts/dev/test-session-start.sh
+      # converge-versions.sh had no downgrade guard of its own — it only
+      # survived one by accident, on two layers upstream it does not own.
+      - ./scripts/dev/test-converge-versions.sh
 
   test:
     desc: Run OpenTofu tests (cluster root)

--- a/scripts/dev/test-converge-versions.sh
+++ b/scripts/dev/test-converge-versions.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Unit tests for converge-versions.sh's downgrade guard (#90).
+#
+# Before this guard, converge-versions.sh had none of its own: it only
+# survived a downgrade attempt by accident, on two layers upstream of it that
+# are not its to depend on (the talos provider's forced PKI replacement below
+# a lower version, caught only because secrets_prevent_destroy turns that into
+# a hard refusal — and that variable is explicitly false in `tofu test`). This
+# proves the guard directly: a pin below what the fleet runs is refused, with
+# a message naming both, BEFORE either `task infra-apply` or `task
+# cluster-roll` is called — never inferred from what those tasks would have
+# done.
+#
+# No cluster, no cloud: kubectl and task are stubbed on PATH, and the tfvars
+# read is a throwaway fixture under the real cluster envs/ dir (the script
+# derives that path from its own location, not from an env var).
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/internal/converge-versions.sh"
+STUB_DIR="$(mktemp -d)"
+ROLE=stubtest
+PROVIDER=fixture
+TFVARS="$ROOT/infrastructure/opentofu/cluster/envs/${ROLE}-${PROVIDER}.tfvars"
+cleanup() { rm -rf "$STUB_DIR"; rm -f "$TFVARS"; }
+trap cleanup EXIT
+
+PASS=0 FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+# --- stubs ----------------------------------------------------------------
+# kubectl answers only the two fields oa_fleet_versions asks for, from
+# STUB_TALOS / STUB_K8S (comma-separated for a mixed fleet). task records
+# every invocation and does nothing else — the guard must never let one
+# through on a downgrade.
+cat >"$STUB_DIR/kubectl" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *osImage*)
+    IFS=',' read -ra vs <<<"${STUB_TALOS:-}"
+    for v in "${vs[@]}"; do printf 'Talos (%s)\n' "$v"; done
+    ;;
+  *kubeletVersion*)
+    IFS=',' read -ra vs <<<"${STUB_K8S:-}"
+    for v in "${vs[@]}"; do printf '%s\n' "$v"; done
+    ;;
+  *) exit 1 ;;
+esac
+STUB
+cat >"$STUB_DIR/task" <<STUB
+#!/usr/bin/env bash
+echo "task \$*" >>"$STUB_DIR/task.log"
+exit 0
+STUB
+chmod +x "$STUB_DIR/kubectl" "$STUB_DIR/task"
+
+# <pin-talos> <pin-k8s> <running-talos> <running-k8s> [--check]
+run() {
+  : >"$STUB_DIR/task.log"
+  cat >"$TFVARS" <<EOF
+talos_version      = "$1"
+kubernetes_version = "$2"
+EOF
+  PATH="$STUB_DIR:$PATH" STUB_TALOS="$3" STUB_K8S="$4" \
+    "$SCRIPT" "$PROVIDER" "$ROLE" /dev/null ${5:+--check} 2>&1
+}
+
+echo "=== converge-versions.sh: the downgrade guard is its own, not borrowed ==="
+
+# --- Talos downgrade --------------------------------------------------------
+out="$(run v1.13.8 v1.36.3 v1.13.9 v1.36.3)"; rc=$?
+if [ "$rc" -ne 0 ]; then ok "Talos pin below the running fleet is refused (rc=${rc})"
+else bad "Talos pin below the running fleet was NOT refused"; fi
+grep -qi 'downgrade' <<<"$out" && ok "the refusal is named a downgrade" ||
+  bad "the refusal never says 'downgrade'"
+grep -q 'v1.13.8' <<<"$out" && grep -q 'v1.13.9' <<<"$out" &&
+  ok "the message names both the pin and the running version" ||
+  bad "the message does not name both versions"
+[ -s "$STUB_DIR/task.log" ] && bad "task was invoked despite the downgrade — the guard ran too late" ||
+  ok "neither infra-apply nor cluster-roll was called"
+
+# --- Kubernetes downgrade ----------------------------------------------------
+out="$(run v1.13.9 v1.36.2 v1.13.9 v1.36.3)"; rc=$?
+if [ "$rc" -ne 0 ]; then ok "Kubernetes pin below the running fleet is refused (rc=${rc})"
+else bad "Kubernetes pin below the running fleet was NOT refused"; fi
+[ -s "$STUB_DIR/task.log" ] && bad "task was invoked despite the Kubernetes downgrade" ||
+  ok "neither infra-apply nor cluster-roll was called (Kubernetes case)"
+
+# --- mixed fleet: pin matches the LOWER node, still a downgrade from the other
+out="$(run v1.13.8 v1.36.3 v1.13.8,v1.13.9 v1.36.3)"; rc=$?
+if [ "$rc" -ne 0 ]; then ok "a pin below even one node of a mixed fleet is refused (rc=${rc})"
+else bad "a mixed fleet with one node above the pin was NOT refused"; fi
+
+# --- --check also refuses, before any approval is asked ---------------------
+out="$(run v1.13.8 v1.36.3 v1.13.9 v1.36.3 --check)"; rc=$?
+if [ "$rc" -ne 0 ]; then ok "--check refuses a downgrade too (rc=${rc})"
+else bad "--check let a downgrade through"; fi
+
+# --- a legitimate upgrade is not blocked by the guard ------------------------
+out="$(run v1.13.9 v1.36.3 v1.13.8 v1.36.2)"; rc=$?
+grep -qi 'downgrade' <<<"$out" && bad "an upgrade (pin above running) was misread as a downgrade" ||
+  ok "an upgrade (pin above running) is not flagged as a downgrade"
+[ -s "$STUB_DIR/task.log" ] && ok "the guard let a real upgrade proceed to infra-apply/cluster-roll" ||
+  bad "a legitimate upgrade never reached infra-apply/cluster-roll"
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/internal/converge-versions.sh
+++ b/scripts/internal/converge-versions.sh
@@ -55,6 +55,35 @@ if [ -z "$have_talos" ] && [ -z "$have_k8s" ]; then
   Check the cluster, then: task cluster-verify PROVIDER=${PROVIDER} ROLE=${ROLE}"
 fi
 
+# Refuse a pin that is semver-LOWER than what is running, before anything below
+# calls infra-apply or cluster-roll. This script has no downgrade guard of its
+# own otherwise — it only survives one today by accident, on two layers it does
+# not own: the pinned talos provider forces a PKI replacement on a lower
+# version, and secrets_prevent_destroy turns that into a hard refusal. Neither
+# is this script's to depend on; secrets_prevent_destroy is explicitly false in
+# `tofu test`, and nothing here would notice on a config where it were false for
+# real. A fleet can be MIXED mid-roll (comma-separated), so a pin counts as a
+# downgrade against ANY node still running above it, not only the lowest one.
+downgrade() { # <pin> <running-csv> — 0 if pin is a downgrade from any of running
+  local pin="$1" running="$2" v
+  [ -n "$pin" ] && [ -n "$running" ] || return 1
+  IFS=',' read -ra _running_vs <<<"$running"
+  for v in "${_running_vs[@]}"; do
+    oa_semver_lt "$pin" "$v" && return 0
+  done
+  return 1
+}
+if downgrade "$want_talos" "$have_talos"; then
+  fail "the config pins Talos ${want_talos}, the fleet runs ${have_talos} — that is a DOWNGRADE.
+  converge-versions.sh does not build a downgrade path (cluster-upgrade.sh refuses one for
+  the same reason). Revert the pin, or roll the cluster forward instead."
+fi
+if downgrade "$want_k8s" "$have_k8s"; then
+  fail "the config pins Kubernetes ${want_k8s}, the fleet runs ${have_k8s} — that is a DOWNGRADE.
+  converge-versions.sh does not build a downgrade path (cluster-upgrade.sh refuses one for
+  the same reason). Revert the pin, or roll the cluster forward instead."
+fi
+
 drift=0
 [ -n "$want_talos" ] && [ "$have_talos" != "$want_talos" ] && drift=1
 [ -n "$want_k8s" ]   && [ "$have_k8s"   != "$want_k8s"   ] && drift=1

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -223,6 +223,21 @@ oa_fleet_versions() {
     sed -E 's/^Talos \((v[^)]+)\)$/\1/' | grep -E '^v' | sort -u | paste -sd, - || true
 }
 
+# Is version A strictly semver-lower than version B? Compares major.minor.patch
+# numerically, ignoring a leading "v"; a missing component reads as 0 (so v1.13
+# sorts as v1.13.0). Usage: oa_semver_lt <a> <b>
+oa_semver_lt() {
+  local a="${1#v}" b="${2#v}" i x y
+  local -a av bv
+  IFS=. read -r -a av <<<"$a"
+  IFS=. read -r -a bv <<<"$b"
+  for i in 0 1 2; do
+    x="${av[i]:-0}"; y="${bv[i]:-0}"
+    [ "$x" -eq "$y" ] || { [ "$x" -lt "$y" ]; return; }
+  done
+  return 1
+}
+
 # The tfvars wins, `variables.tf` is the tracked fallback: envs/management-*.tfvars
 # deliberately omit the pins on some clusters to inherit the default, so an empty
 # tfvars answer is a legitimate "use the default", never an error.


### PR DESCRIPTION
## Summary

`converge-versions.sh` had no downgrade guard of its own ([#90](https://github.com/dis-bzh/OpenAether-infra/issues/90)). It survived a downgrade attempt only by accident, on two layers upstream of it that are not its to depend on:

1. The pinned `terraform-provider-talos` (`~> 0.11.0`): `talos_machine_secrets` forces a replacement — `RequiresReplace` — only when `semver.Compare(new, old) < 0`.
2. `secrets_prevent_destroy`, which wraps that resource in `lifecycle { prevent_destroy = true }`, turning the forced replacement into a hard refusal.

Both did their job on the live incident that opened the issue — but `secrets_prevent_destroy` is explicitly `false` in `tofu test`, and nothing in `converge-versions.sh` itself would notice or refuse a downgrade if that variable were ever `false` on real infrastructure.

- `scripts/lib/common.sh`: new `oa_semver_lt <a> <b>` helper — is version A strictly semver-lower than B, comparing major.minor.patch numerically.
- `scripts/internal/converge-versions.sh`: refuses a pin that is semver-lower than any node the fleet currently runs (a mixed, mid-roll fleet is a comma-separated list — the guard checks against all of them, not only the lowest), naming both the pin and the running version, before calling either `infra-apply` or `cluster-roll`. Applies in `--check` too, so the operator sees the refusal before approving anything.
- `scripts/dev/test-converge-versions.sh` (new): stubs `kubectl` and `task` on `PATH`, drives the script against a throwaway tfvars fixture. Covers a Talos downgrade, a Kubernetes downgrade, a mixed fleet where the pin matches the lower node but not the higher one, `--check` refusing too, and confirms a legitimate upgrade is not misread as a downgrade and does reach `infra-apply`/`cluster-roll`.
- Wired into `task test-scripts`; `CHANGELOG.md` updated.

## Test plan

- [x] `task lint` — green
- [x] `task test-scripts` — green (new harness: 10/10; full suite green)
- [x] `task test` — green (52 passed) — unrelated to this change, run per the standing checklist
- [x] `task render-check` — green
- [x] `task validate ROOT=cluster` — green
- [x] `task validate ROOT=talos-image` — green (pre-existing proxmox provider deprecation warning only)
- [x] `task security` — checkov (16 passed) and gitleaks (no leaks, rules self-check 6/6) green; `trivy` could not run in this sandbox (network-restricted — same gap noted in #103), relies on CI
- [x] Mutation check: reverted the guard and the helper, re-ran `test-converge-versions.sh` — 4 of the 10 assertions specific to the guard go red (message never says "downgrade", `task` gets invoked despite the downgrade, `--check` lets it through), confirming the test actually exercises this fix and not something else

Mocked rung reached, as the issue asks for. Emulated (`task feint-*`) and real-cloud rungs skipped — no provider/cluster OpenTofu code was touched, only shell.

## What was deliberately left out

Nothing from the issue's own "Closes" criterion; the two incidental layers described in the issue (`talos_machine_secrets`' plan modifier, `secrets_prevent_destroy`) are left exactly as they are — this PR adds the guard `converge-versions.sh` was missing, not a change to either of them.

Closes #90

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_