### PR TITLE
fix(ops): count refused endpoints in ovh.py's purge, like its siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,14 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`ovh.py`'s purge could not tell a refused endpoint from an empty account.**
+  `scaleway.py` and `outscale.py` both count a refused call and refuse to
+  claim "clean" on zero findings and zero reachable endpoints; `ovh.py` had no
+  such counter, so a partial refusal — one endpoint answering 403 while the
+  others still worked — crashed the run instead of being counted and
+  continuing. It now shares the same `UNREACHABLE` counter and exit code.
+  [#63](https://github.com/dis-bzh/OpenAether-infra/issues/63)
+
 - **`task local-down` refused to run on a clone that had only this repository.**
   `test-talos-local.sh` resolves `APPS_DIR` and exits 1 when it cannot find
   `OpenAether-apps/apps/flux/local` — before it reads `--destroy`, which never

--- a/scripts/dev/test-purge-orphans.sh
+++ b/scripts/dev/test-purge-orphans.sh
@@ -129,6 +129,76 @@ if grep -qiE 'resource\(s\) deleted\. The account is clean' <<<"$out"; then
 else
   ok "outscale.py --apply: it does not claim a deletion that did not happen"
 fi
+
+# --- ovh.py: auth succeeds, servers are found, one other endpoint is refused --
+# ovh.py's get() raises rather than swallowing, so a TOTAL auth failure already
+# crashes non-zero — not this gap (verified below, unchanged). The gap is a
+# PARTIAL refusal: auth works, servers list fine, then floating-ips answers
+# 403. Before the fix that exception propagated out of get() uncaught: the run
+# died mid-listing with a traceback, never reaching routers/networks/security
+# groups or its own summary — which is not "clean", but the run's own findings
+# vanished with it. It must count the refusal and keep going, like its
+# siblings, and still report what it DID find.
+echo
+echo "=== ovh.py: auth OK, servers found, floating-ips refused 403 ==="
+
+run_403_ovh_partial() {
+  env OS_AUTH_URL=https://stub.invalid/v3 OS_USERNAME=stub OS_PASSWORD=stub \
+      OS_PROJECT_ID=stub OS_REGION_NAME=stub \
+      python3 - "$ROOT/scripts/ops/purge-orphans/ovh.py" <<'PY' 2>&1
+import runpy, sys, json, io, urllib.request, urllib.error
+
+class FakeResp(io.BytesIO):
+    def __init__(self, data, headers=None):
+        super().__init__(data)
+        self.headers = headers or {}
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+CATALOG = {"token": {"catalog": [
+    {"type": "network", "endpoints": [{"interface": "public", "region": "stub", "url": "https://stub.invalid/network"}]},
+    {"type": "compute", "endpoints": [{"interface": "public", "region": "stub", "url": "https://stub.invalid/compute"}]},
+]}}
+
+def fake(req, *a, **k):
+    u = req.full_url
+    if u.endswith('/auth/tokens'):
+        return FakeResp(json.dumps(CATALOG).encode(), headers={'X-Subject-Token': 'stub'})
+    if u.endswith('/servers'):
+        return FakeResp(json.dumps({'servers': [{'id': 'srv-stub', 'name': 'stub-server'}]}).encode())
+    raise urllib.error.HTTPError(u, 403, 'Forbidden', {}, io.BytesIO(b'{}'))
+
+urllib.request.urlopen = fake
+sys.argv = [sys.argv[1]]
+try:
+    runpy.run_path(sys.argv[0], run_name='__main__')
+except SystemExit as e:
+    sys.exit(e.code if isinstance(e.code, int) else 1)
+PY
+}
+
+out="$(run_403_ovh_partial)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  ok "ovh.py: found resources + a refused endpoint still exits non-zero (rc=${rc})"
+else
+  bad "ovh.py: exited 0 with a refused endpoint in the middle of the run"
+fi
+if grep -qi 'traceback' <<<"$out"; then
+  bad "ovh.py: a refused endpoint crashed the run instead of being counted — later listings never ran"
+else
+  ok "ovh.py: a refused endpoint does not crash the run"
+fi
+if grep -qiE 'unreachable' <<<"$out"; then
+  ok "ovh.py: it names the refusal in its output"
+else
+  bad "ovh.py: it refused silently — a transcript reader cannot tell"
+fi
+if grep -qiE 'resource\(s\) targeted' <<<"$out"; then
+  ok "ovh.py: it still reaches its own summary after the refusal"
+else
+  bad "ovh.py: it never reached its own summary — the refusal ended the run early"
+fi
+
 echo
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/ops/purge-orphans/ovh.py
+++ b/scripts/ops/purge-orphans/ovh.py
@@ -28,6 +28,28 @@ def get(u):
     return json.load(urllib.request.urlopen(urllib.request.Request(u, headers=H), timeout=60))
 
 
+# Counted, not just printed — same reasoning as scaleway.py/outscale.py. A total
+# auth failure above still crashes non-zero (get() raises, uncaught), which is
+# not this gap; what get() left open is a PARTIAL refusal, one endpoint 403 while
+# the others answer, which used to crash the whole run instead of being counted
+# and continuing like its siblings do.
+UNREACHABLE = 0
+
+
+def listing(url, key):
+    global UNREACHABLE
+    try:
+        return get(url).get(key, [])
+    except urllib.error.HTTPError as e:
+        UNREACHABLE += 1
+        print(f"  ⚠ unreachable: {url.split('?')[0]} (HTTP {e.code})")
+        return []
+    except Exception as e:
+        UNREACHABLE += 1
+        print(f"  ⚠ unreachable: {url.split('?')[0]} ({str(e)[:60]})")
+        return []
+
+
 # Counted so a clean project SAYS it is clean. This script is the last thing
 # standing between a failed teardown and a bill, and it used to report that by
 # printing nothing at all — which reads like a finding, not like an all-clear.
@@ -60,21 +82,21 @@ except StopIteration:
     lb_ep = None
 
 # 1. servers (VMs block the deletion of ports/networks)
-for s in get(comp + '/servers')['servers']:
+for s in listing(comp + '/servers', 'servers'):
     delete(comp + f"/servers/{s['id']}", f"server {s['name']}")
 
 # 2. load balancers Octavia
 if lb_ep:
-    for lb in get(lb_ep + '/v2.0/lbaas/loadbalancers')['loadbalancers']:
+    for lb in listing(lb_ep + '/v2.0/lbaas/loadbalancers', 'loadbalancers'):
         delete(lb_ep + f"/v2.0/lbaas/loadbalancers/{lb['id']}?cascade=true", f"LB {lb['name']}")
 
 # 3. floating IPs
-for f in get(net + '/v2.0/floatingips')['floatingips']:
+for f in listing(net + '/v2.0/floatingips', 'floatingips'):
     delete(net + f"/v2.0/floatingips/{f['id']}", f"FIP {f['floating_ip_address']}")
 
 # 4. routers (detach the interfaces first)
-for r in get(net + '/v2.0/routers')['routers']:
-    for p in get(net + f"/v2.0/ports?device_id={r['id']}")['ports']:
+for r in listing(net + '/v2.0/routers', 'routers'):
+    for p in listing(net + f"/v2.0/ports?device_id={r['id']}", 'ports'):
         if p.get('device_owner', '').startswith('network:router_interface'):
             if APPLY:
                 body = json.dumps({"port_id": p['id']}).encode()
@@ -90,13 +112,17 @@ for r in get(net + '/v2.0/routers')['routers']:
     delete(net + f"/v2.0/routers/{r['id']}", f"router {r['name']}")
 
 # 5. networks + security groups
-for n in get(net + '/v2.0/networks')['networks']:
+for n in listing(net + '/v2.0/networks', 'networks'):
     if n.get('project_id') == os.environ['OS_PROJECT_ID']:
         delete(net + f"/v2.0/networks/{n['id']}", f"network {n['name']}")
-for g in get(net + '/v2.0/security-groups')['security_groups']:
+for g in listing(net + '/v2.0/security-groups', 'security_groups'):
     if g['name'] != 'default' and g.get('project_id') == os.environ['OS_PROJECT_ID']:
         delete(net + f"/v2.0/security-groups/{g['id']}", f"SG {g['name']}")
 
+if TOTAL == 0 and UNREACHABLE:
+    print(f"\n✗ {UNREACHABLE} endpoint(s) refused to answer — found nothing, but nothing was")
+    print("  actually asked. This is NOT an all-clear: check the credentials and re-run.")
+    sys.exit(2)
 if TOTAL == 0:
     print("Nothing to purge — the project is clean.")
 elif not APPLY:


### PR DESCRIPTION
## Summary

`scaleway.py` and `outscale.py` both count a refused API call and refuse to claim the account is "clean" when nothing was found AND nothing was actually reachable; `ovh.py` had no such counter ([#63](https://github.com/dis-bzh/OpenAether-infra/issues/63)). Its `get()` raises rather than swallowing, so a *total* auth failure was already correct — it crashes non-zero rather than reporting clean, which is why the issue calls this a gap and not the same defect as the other two. What was actually open: a *partial* refusal — auth succeeds, one endpoint answers 403 while the others still work — used to propagate an uncaught `HTTPError` out of the listing loop, killing the run before it reached routers/networks/security-groups or its own summary, taking whatever it had already found down with it.

- `scripts/ops/purge-orphans/ovh.py`: added a `listing(url, key)` helper (mirrors `scaleway.py`'s) that catches the exception, counts `UNREACHABLE`, prints the same `⚠ unreachable` line, and returns `[]` so the run continues; every read-only `get(...)[key]` call site now goes through it. Added the same `if TOTAL == 0 and UNREACHABLE: ... sys.exit(2)` closing check.
- `scripts/dev/test-purge-orphans.sh`: extended with a partial-refusal scenario for `ovh.py` — a fake auth exchange succeeds, `servers` lists one resource, `floating-ips` (and everything after it) refuses 403. Asserts: exits non-zero, no `Traceback` in the output (proves the run didn't crash), the refusal is named, and the run still reaches its own "N resource(s) targeted" summary.
- `CHANGELOG.md` updated.

## Test plan

- [x] `task lint` — green
- [x] `task test-scripts` — green (`test-purge-orphans.sh`: 13/13, full suite green)
- [x] `task test` — green (52 passed) — unrelated to this change, run per the standing checklist
- [x] `task render-check` — green
- [x] `task validate ROOT=cluster` — green
- [x] `task validate ROOT=talos-image` — green (pre-existing proxmox provider deprecation warning only)
- [x] `task security` — checkov (16 passed) and gitleaks (no leaks, rules self-check 6/6) green; `trivy` could not run in this sandbox (network-restricted — same gap noted in #103), relies on CI
- [x] Mutation check: stashed the `ovh.py` fix, re-ran `test-purge-orphans.sh` against the unmodified script — 3 of the 4 new ovh.py assertions go red (a `Traceback` appears, the refusal is never named, the run never reaches its own summary), confirming the test catches exactly this regression

Mocked rung reached, as the issue asks for (`provider:ovh` label, but `rung:mocked` — no real OVH account touched, no network). Emulated (`task feint-*`) and real-cloud rungs skipped — feint does not emulate OVH, and this is a purge script, not provider/cluster OpenTofu code.

## What was deliberately left out

The initial OVH auth token exchange (`urllib.request.urlopen` at the top of the file) is untouched — a total auth failure crashing non-zero is the issue's own stated "not a defect" case, and changing it isn't part of what #63 closes on.

Closes #63

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_