### PR TITLE
fix(ops): outscale.py's purge reports leftover snapshots, correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,18 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`outscale.py`'s purge never looked at snapshots or images**, so a
+  duplicate snapshot from a failed image build sat in the account while
+  "account is clean" was true of everything the script asked and false of
+  the account. It now lists both (`ReadSnapshots`/`ReadImages`) and refuses
+  to claim clean while either is present — reported, never auto-deleted:
+  same policy `scaleway.py` already documents for Talos build artifacts, and
+  `fleet-down.sh`'s own "left standing on purpose" list. Two paths used to
+  say "clean" wrongly: an account with nothing else at all (`TOTAL == 0`),
+  and — found while fixing the first — the successful `--apply` path itself,
+  which said "resource(s) deleted, the account is clean" even with an image
+  still sitting there.
+  [#71](https://github.com/dis-bzh/OpenAether-infra/issues/71)
 - **`ovh.py`'s purge could not tell a refused endpoint from an empty account.**
   `scaleway.py` and `outscale.py` both count a refused call and refuse to
   claim "clean" on zero findings and zero reachable endpoints; `ovh.py` had no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,18 +141,25 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
-- **`outscale.py`'s purge never looked at snapshots or images**, so a
+- **`outscale.py`'s purge never looked at leftover snapshots**, so a
   duplicate snapshot from a failed image build sat in the account while
   "account is clean" was true of everything the script asked and false of
-  the account. It now lists both (`ReadSnapshots`/`ReadImages`) and refuses
-  to claim clean while either is present — reported, never auto-deleted:
-  same policy `scaleway.py` already documents for Talos build artifacts, and
-  `fleet-down.sh`'s own "left standing on purpose" list. Two paths used to
-  say "clean" wrongly: an account with nothing else at all (`TOTAL == 0`),
-  and — found while fixing the first — the successful `--apply` path itself,
-  which said "resource(s) deleted, the account is clean" even with an image
-  still sitting there.
-  [#71](https://github.com/dis-bzh/OpenAether-infra/issues/71)
+  the account. It now lists them (`ReadSnapshots`) and refuses to claim clean
+  while any are present — reported, never auto-deleted: same policy
+  `scaleway.py` already documents for Talos build artifacts, and
+  `fleet-down.sh`'s own "left standing on purpose" list. Images are
+  deliberately still not enumerated — `ReadImages`' documented default scope
+  can include Outscale's own public OMI catalogue, and scoping that safely
+  needs verification against a live account, tracked separately as
+  [#107](https://github.com/dis-bzh/OpenAether-infra/issues/107). Two paths
+  used to say "clean" wrongly: an account with nothing else at all
+  (`TOTAL == 0`), and — found while fixing the first — the successful
+  `--apply` path itself, which said "resource(s) deleted, the account is
+  clean" even with a snapshot still sitting there; a REFUSED `ReadSnapshots`
+  call after a successful purge fell through the same way and is now
+  reported as unconfirmed rather than silently clean.
+  Refs [#71](https://github.com/dis-bzh/OpenAether-infra/issues/71) — the
+  issue's own bar is real cloud; this closes the mocked-rung defect only.
 - **`ovh.py`'s purge could not tell a refused endpoint from an empty account.**
   `scaleway.py` and `outscale.py` both count a refused call and refuse to
   claim "clean" on zero findings and zero reachable endpoints; `ovh.py` had no

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -60,8 +60,10 @@ docker run --rm -v /tmp/repo.tar:/tmp/repo.tar:ro ubuntu:24.04 bash -c '
       script that no longer exists.
 - [ ] no bucket is orphaned by a rename in this release. `…-talos-staging` became
       `…-talos-import` (2026-08-20): the old one still holds every QCOW2 it was
-      ever given, on every cloud built from. `task purge-orphans PROVIDER=…` lists
-      it; emptying and deleting it is by hand.
+      ever given, on every cloud built from. `python3
+      scripts/ops/purge-orphans/<provider>.py` lists it (there is no `task`
+      wrapper — see the script's own README); emptying and deleting it is by
+      hand.
 
 ## 2. Local Docker — the credential-free rung
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -60,10 +60,9 @@ docker run --rm -v /tmp/repo.tar:/tmp/repo.tar:ro ubuntu:24.04 bash -c '
       script that no longer exists.
 - [ ] no bucket is orphaned by a rename in this release. `…-talos-staging` became
       `…-talos-import` (2026-08-20): the old one still holds every QCOW2 it was
-      ever given, on every cloud built from. `python3
-      scripts/ops/purge-orphans/<provider>.py` lists it (there is no `task`
-      wrapper — see the script's own README); emptying and deleting it is by
-      hand.
+      ever given, on every cloud built from. No script enumerates buckets — see
+      `verify-provider-clean.py`'s own `UNCHECKED` list and `purge-orphans/`'s
+      README — so check and empty each cloud's bucket by hand.
 
 ## 2. Local Docker — the credential-free rung
 

--- a/scripts/dev/test-purge-orphans.sh
+++ b/scripts/dev/test-purge-orphans.sh
@@ -199,6 +199,91 @@ else
   bad "ovh.py: it never reached its own summary — the refusal ended the run early"
 fi
 
+# --- outscale.py: Talos snapshots/images are visible, and "clean" stops lying -
+# The core of #71: a duplicate snapshot from a failed image build sat in the
+# account while outscale.py never even asked ReadSnapshots/ReadImages, so
+# "account is clean" was true of everything it looked at and false of the
+# account. Three scenarios below; the first is the regression guard (this fix
+# must not cry wolf on the ordinary empty case), the other two are #71 itself
+# and its twin in the --apply success path.
+echo
+echo "=== outscale.py: snapshot/image artifacts are seen, not silently skipped ==="
+
+run_osc_canned() { # <CANNED python-dict-literal as a string> [extra argv...]
+  local canned="$1"; shift
+  env OUTSCALE_ACCESS_KEY_ID=stub OUTSCALE_SECRET_KEY=stub OSC_REGION=eu-west-2 \
+      python3 - "$ROOT/scripts/ops/purge-orphans/outscale.py" "$@" <<PY 2>&1
+import runpy, sys, json, io, urllib.request, urllib.error
+
+CANNED = $canned
+
+def fake(req, *a, **k):
+    action = req.full_url.rsplit('/', 1)[-1]
+    return io.BytesIO(json.dumps(CANNED.get(action, {})).encode())
+
+urllib.request.urlopen = fake
+sys.argv = sys.argv[1:]
+try:
+    runpy.run_path(sys.argv[0], run_name='__main__')
+except SystemExit as e:
+    sys.exit(e.code if isinstance(e.code, int) else 1)
+PY
+}
+
+# 1. Genuinely empty account — every Read* (including the two new ones)
+#    returns nothing. Must still say "clean": the case this fix must not break.
+out="$(run_osc_canned '{}')"; rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "outscale.py: a genuinely empty account (incl. no snapshots/images) still exits 0"
+else
+  bad "outscale.py: a genuinely empty account no longer exits 0 (rc=${rc}) — false positive"
+fi
+if grep -qiE 'account is clean' <<<"$out"; then
+  ok "outscale.py: it still says clean when nothing at all is present"
+else
+  bad "outscale.py: it stopped saying clean on a genuinely empty account"
+fi
+
+# 2. Only a leftover snapshot — every Net-dependency listing is empty
+#    (TOTAL stays 0), but ReadSnapshots answers one. This is #71 itself.
+ONLY_SNAPSHOT='{"ReadSnapshots": {"Snapshots": [{"SnapshotId": "snap-orphan", "State": "completed", "VolumeSize": 10}]}}'
+out="$(run_osc_canned "$ONLY_SNAPSHOT")"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  ok "outscale.py: an orphan snapshot with nothing else present exits non-zero (rc=${rc})"
+else
+  bad "outscale.py: an orphan snapshot present and it still exited 0 — the #71 bug"
+fi
+if grep -qiE 'account is clean' <<<"$out"; then
+  bad "outscale.py: it said the account is clean while an orphan snapshot sat there"
+else
+  ok "outscale.py: it does not claim clean while the snapshot is present"
+fi
+if grep -q 'snap-orphan' <<<"$out"; then
+  ok "outscale.py: it names the orphan snapshot in its output"
+else
+  bad "outscale.py: the snapshot was found but never named — a transcript reader can't act on it"
+fi
+
+# 3. Net resources purged successfully AND an image is left over — the
+#    "N resource(s) deleted. The account is clean." branch must not lie either.
+DELETED_PLUS_IMAGE='{"ReadNets": {"Nets": [{"NetId": "vpc-stub", "IpRange": "10.0.0.0/16"}]}, "ReadImages": {"Images": [{"ImageId": "ami-orphan", "ImageName": "old-talos-build"}]}}'
+out="$(run_osc_canned "$DELETED_PLUS_IMAGE" --apply)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  ok "outscale.py --apply: resources deleted but an image remains still exits non-zero (rc=${rc})"
+else
+  bad "outscale.py --apply: an image remained after a successful purge and it exited 0"
+fi
+if grep -qiE 'account is clean' <<<"$out" && ! grep -qiE 'NOT fully clean' <<<"$out"; then
+  bad "outscale.py --apply: claimed clean while ami-orphan was still listed"
+else
+  ok "outscale.py --apply: does not claim a plain clean while the image remains"
+fi
+if grep -q 'ami-orphan' <<<"$out"; then
+  ok "outscale.py --apply: names the leftover image after a successful net purge"
+else
+  bad "outscale.py --apply: the leftover image was never named post-purge"
+fi
+
 echo
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/dev/test-purge-orphans.sh
+++ b/scripts/dev/test-purge-orphans.sh
@@ -199,15 +199,19 @@ else
   bad "ovh.py: it never reached its own summary — the refusal ended the run early"
 fi
 
-# --- outscale.py: Talos snapshots/images are visible, and "clean" stops lying -
+# --- outscale.py: leftover snapshots are visible, and "clean" stops lying ----
 # The core of #71: a duplicate snapshot from a failed image build sat in the
-# account while outscale.py never even asked ReadSnapshots/ReadImages, so
-# "account is clean" was true of everything it looked at and false of the
-# account. Three scenarios below; the first is the regression guard (this fix
-# must not cry wolf on the ordinary empty case), the other two are #71 itself
-# and its twin in the --apply success path.
+# account while outscale.py never even asked ReadSnapshots, so "account is
+# clean" was true of everything it looked at and false of the account. Images
+# are deliberately out of scope here — see the comment in outscale.py for why.
+#
+# Five scenarios: #1 is the regression guard (must not cry wolf on the
+# ordinary empty case), #2 is #71 itself, #3 is its twin in the --apply
+# success path, #4 reproduces the bug review actually caught — a REFUSED
+# ReadSnapshots after some other resource was purged clean — and #5 checks
+# that a failed deletion still wins the exit code over a leftover snapshot.
 echo
-echo "=== outscale.py: snapshot/image artifacts are seen, not silently skipped ==="
+echo "=== outscale.py: snapshot artifacts are seen, not silently skipped ==="
 
 run_osc_canned() { # <CANNED python-dict-literal as a string> [extra argv...]
   local canned="$1"; shift
@@ -219,6 +223,34 @@ CANNED = $canned
 
 def fake(req, *a, **k):
     action = req.full_url.rsplit('/', 1)[-1]
+    return io.BytesIO(json.dumps(CANNED.get(action, {})).encode())
+
+urllib.request.urlopen = fake
+sys.argv = sys.argv[1:]
+try:
+    runpy.run_path(sys.argv[0], run_name='__main__')
+except SystemExit as e:
+    sys.exit(e.code if isinstance(e.code, int) else 1)
+PY
+}
+
+# Same as run_osc_canned, but any action named in FAIL_ACTIONS raises HTTP 403
+# instead of answering — needed to reproduce a REFUSED call (not just an empty
+# one) alongside other calls that succeed normally.
+run_osc_canned_fail() { # <CANNED python-dict-literal> <FAIL_ACTIONS python-list-literal> [extra argv...]
+  local canned="$1"; local fail_actions="$2"; shift 2
+  env OUTSCALE_ACCESS_KEY_ID=stub OUTSCALE_SECRET_KEY=stub OSC_REGION=eu-west-2 \
+      python3 - "$ROOT/scripts/ops/purge-orphans/outscale.py" "$@" <<PY 2>&1
+import runpy, sys, json, io, urllib.request, urllib.error
+
+CANNED = $canned
+FAIL_ACTIONS = $fail_actions
+
+def fake(req, *a, **k):
+    action = req.full_url.rsplit('/', 1)[-1]
+    if action in FAIL_ACTIONS:
+        raise urllib.error.HTTPError(req.full_url, 403, 'Forbidden', {},
+                                     io.BytesIO(b'{"message":"denied"}'))
     return io.BytesIO(json.dumps(CANNED.get(action, {})).encode())
 
 urllib.request.urlopen = fake
@@ -264,24 +296,63 @@ else
   bad "outscale.py: the snapshot was found but never named — a transcript reader can't act on it"
 fi
 
-# 3. Net resources purged successfully AND an image is left over — the
+# 3. Net resources purged successfully AND a snapshot is left over — the
 #    "N resource(s) deleted. The account is clean." branch must not lie either.
-DELETED_PLUS_IMAGE='{"ReadNets": {"Nets": [{"NetId": "vpc-stub", "IpRange": "10.0.0.0/16"}]}, "ReadImages": {"Images": [{"ImageId": "ami-orphan", "ImageName": "old-talos-build"}]}}'
-out="$(run_osc_canned "$DELETED_PLUS_IMAGE" --apply)"; rc=$?
+DELETED_PLUS_SNAPSHOT='{"ReadNets": {"Nets": [{"NetId": "vpc-stub", "IpRange": "10.0.0.0/16"}]}, "ReadSnapshots": {"Snapshots": [{"SnapshotId": "snap-leftover", "State": "completed", "VolumeSize": 5}]}}'
+out="$(run_osc_canned "$DELETED_PLUS_SNAPSHOT" --apply)"; rc=$?
 if [ "$rc" -ne 0 ]; then
-  ok "outscale.py --apply: resources deleted but an image remains still exits non-zero (rc=${rc})"
+  ok "outscale.py --apply: resources deleted but a snapshot remains still exits non-zero (rc=${rc})"
 else
-  bad "outscale.py --apply: an image remained after a successful purge and it exited 0"
+  bad "outscale.py --apply: a snapshot remained after a successful purge and it exited 0"
 fi
 if grep -qiE 'account is clean' <<<"$out" && ! grep -qiE 'NOT fully clean' <<<"$out"; then
-  bad "outscale.py --apply: claimed clean while ami-orphan was still listed"
+  bad "outscale.py --apply: claimed clean while snap-leftover was still listed"
 else
-  ok "outscale.py --apply: does not claim a plain clean while the image remains"
+  ok "outscale.py --apply: does not claim a plain clean while the snapshot remains"
 fi
-if grep -q 'ami-orphan' <<<"$out"; then
-  ok "outscale.py --apply: names the leftover image after a successful net purge"
+if grep -q 'snap-leftover' <<<"$out"; then
+  ok "outscale.py --apply: names the leftover snapshot after a successful net purge"
 else
-  bad "outscale.py --apply: the leftover image was never named post-purge"
+  bad "outscale.py --apply: the leftover snapshot was never named post-purge"
+fi
+
+# 4. The bug review actually caught: a Net is purged successfully (TOTAL>0,
+#    FAILED==0) AND ReadSnapshots itself is REFUSED (not merely empty) — a
+#    first fix attempt fell through this exact combination to the plain
+#    "account is clean" message, because the unreachable-artifacts check only
+#    guarded the TOTAL==0 branch.
+ONE_NET='{"ReadNets": {"Nets": [{"NetId": "vpc-stub", "IpRange": "10.0.0.0/16"}]}}'
+out="$(run_osc_canned_fail "$ONE_NET" "['ReadSnapshots']" --apply)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  ok "outscale.py --apply: net purged + ReadSnapshots refused still exits non-zero (rc=${rc})"
+else
+  bad "outscale.py --apply: net purged + ReadSnapshots refused exited 0 — the exact bug review caught"
+fi
+if grep -qiE '^[0-9]+ resource\(s\) deleted\. The account is clean\.$' <<<"$out"; then
+  bad "outscale.py --apply: claimed a plain clean while snapshot visibility was refused"
+else
+  ok "outscale.py --apply: does not claim a plain clean when snapshot visibility was refused"
+fi
+if grep -qiE 'visibility was refused|refused, unconfirmed' <<<"$out"; then
+  ok "outscale.py --apply: says snapshot visibility was refused, not silently clean"
+else
+  bad "outscale.py --apply: a refused ReadSnapshots after a successful purge left no trace in the output"
+fi
+
+# 5. A deletion FAILS in the same run a snapshot is ALSO present — the failed
+#    deletion (exit 3) must win over the milder "leftover snapshot" wording
+#    (exit 1): FAILED is checked first in outscale.py on purpose.
+NET_PLUS_SNAPSHOT='{"ReadNets": {"Nets": [{"NetId": "vpc-stub", "IpRange": "10.0.0.0/16"}]}, "ReadSnapshots": {"Snapshots": [{"SnapshotId": "snap-alongside", "State": "completed", "VolumeSize": 5}]}}'
+out="$(run_osc_canned_fail "$NET_PLUS_SNAPSHOT" "['DeleteNet']" --apply)"; rc=$?
+if [ "$rc" -eq 3 ]; then
+  ok "outscale.py --apply: a failed deletion alongside a leftover snapshot exits 3, not 1"
+else
+  bad "outscale.py --apply: expected exit 3 (failed deletion wins), got rc=${rc}"
+fi
+if grep -qiE 'deletion\(s\) failed' <<<"$out"; then
+  ok "outscale.py --apply: reports the failed deletion, not just the leftover snapshot"
+else
+  bad "outscale.py --apply: the failed-deletion message is missing when a snapshot is also present"
 fi
 
 echo

--- a/scripts/ops/purge-orphans/outscale.py
+++ b/scripts/ops/purge-orphans/outscale.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Purges an orphaned Outscale Net (CAPI): dependencies first, then the Net.
 Order imposed by Outscale: LBU → NAT → route tables → internet service →
-security groups → subnets → net. Usage: purge-orphans-osc.py [--apply]"""
+security groups → subnets → net. Also REPORTS (never deletes) leftover
+snapshots and images — see the ARTIFACTS block below.
+Usage: purge-orphans-osc.py [--apply]"""
 import os, sys, json, hmac, hashlib, datetime, urllib.request
 
 APPLY = '--apply' in sys.argv
@@ -102,12 +104,42 @@ for sn in call('ReadSubnets').get('Subnets', []):
     do('DeleteSubnet', {'SubnetId': sn['SubnetId']}, f"subnet {sn['SubnetId']}")
 for net in call('ReadNets').get('Nets', []):
     do('DeleteNet', {'NetId': net['NetId']}, f"net {net['NetId']} ({net.get('IpRange')})")
+
+# Snapshots and images are Talos build artifacts, deliberately never deleted by
+# this script — same policy scaleway.py already documents, and the reason
+# fleet-down.sh's own step 3 only LISTS them (see docs, "Left standing on
+# purpose"). Rebuilding an image costs about an hour on Outscale; a wrong
+# guess here is not recoverable the way a re-run of the loop above is.
+#
+# Called with no Filters, like every other Read* above: none of them scope to
+# the caller's account explicitly either, and this script has always trusted
+# that Outscale's auth signature does that scoping — extending, not inventing,
+# an assumption the rest of the file already makes for Nets and security groups.
+#
+# What this closes: a duplicate snapshot from a failed image build sat in the
+# account while this script never looked, so "account is clean" was true of
+# everything it asked and false of the account (#71, 2026-08-19). A resource
+# class this script cannot see is a resource class it cannot report on.
+ARTIFACTS = call('ReadSnapshots').get('Snapshots', []) + call('ReadImages').get('Images', [])
+if ARTIFACTS:
+    print(f"\n⚠ {len(ARTIFACTS)} snapshot/image artifact(s) present — never auto-purged, review by hand:")
+    for a in ARTIFACTS:
+        if 'SnapshotId' in a:
+            print(f"    snapshot {a['SnapshotId']} ({a.get('State', '?')}, {a.get('VolumeSize', '?')}GB)")
+        else:
+            print(f"    image {a.get('ImageId')} ({a.get('ImageName') or a.get('State', '?')})")
+
 if TOTAL == 0 and UNREACHABLE:
     print(f"\n✗ {UNREACHABLE} call(s) refused — found nothing, but nothing was actually asked.")
     print("  This is NOT an all-clear: check OUTSCALE_ACCESS_KEY_ID / _SECRET_KEY and re-run.")
     sys.exit(2)
-if TOTAL == 0:
+if TOTAL == 0 and not ARTIFACTS:
     print("Nothing to purge — the account is clean.")
+elif TOTAL == 0:
+    # Only artifacts were found. They are never counted into TOTAL/--apply —
+    # see the block above — but "the account is clean" would still be a lie.
+    print(f"\n{len(ARTIFACTS)} artifact(s) present — the account is NOT fully clean (see above).")
+    sys.exit(1)
 elif not APPLY:
     print(f"\n{TOTAL} resource(s) targeted. Re-run with --apply to delete them.")
     # Non-zero: see the note in scaleway.py. Callers read this exit code as
@@ -116,5 +148,8 @@ elif not APPLY:
 elif FAILED:
     print(f"\n✗ {FAILED} of {TOTAL} deletion(s) failed — the account is NOT clean.")
     sys.exit(3)
+elif ARTIFACTS:
+    print(f"\n{TOTAL} resource(s) deleted. {len(ARTIFACTS)} artifact(s) still present (see above) — not fully clean.")
+    sys.exit(1)
 else:
     print(f"\n{TOTAL} resource(s) deleted. The account is clean.")

--- a/scripts/ops/purge-orphans/outscale.py
+++ b/scripts/ops/purge-orphans/outscale.py
@@ -2,7 +2,8 @@
 """Purges an orphaned Outscale Net (CAPI): dependencies first, then the Net.
 Order imposed by Outscale: LBU → NAT → route tables → internet service →
 security groups → subnets → net. Also REPORTS (never deletes) leftover
-snapshots and images — see the ARTIFACTS block below.
+snapshots — see the ARTIFACTS block below. Images are deliberately NOT
+enumerated here yet; see that block for why.
 Usage: purge-orphans-osc.py [--apply]"""
 import os, sys, json, hmac, hashlib, datetime, urllib.request
 
@@ -105,40 +106,66 @@ for sn in call('ReadSubnets').get('Subnets', []):
 for net in call('ReadNets').get('Nets', []):
     do('DeleteNet', {'NetId': net['NetId']}, f"net {net['NetId']} ({net.get('IpRange')})")
 
-# Snapshots and images are Talos build artifacts, deliberately never deleted by
-# this script — same policy scaleway.py already documents, and the reason
-# fleet-down.sh's own step 3 only LISTS them (see docs, "Left standing on
-# purpose"). Rebuilding an image costs about an hour on Outscale; a wrong
-# guess here is not recoverable the way a re-run of the loop above is.
+# Snapshots are Talos build artifacts, deliberately never deleted by this
+# script — same policy scaleway.py already documents, and the reason
+# fleet-down.sh's own step 3 only LISTS artifacts (see docs, "Left standing on
+# purpose"). Rebuilding one costs about an hour on Outscale; a wrong guess
+# here is not recoverable the way a re-run of the delete loop above is.
 #
-# Called with no Filters, like every other Read* above: none of them scope to
-# the caller's account explicitly either, and this script has always trusted
-# that Outscale's auth signature does that scoping — extending, not inventing,
-# an assumption the rest of the file already makes for Nets and security groups.
+# Images are NOT enumerated here, on purpose, unlike snapshots: ReadImages'
+# documented default scope is every OMI you hold LAUNCH PERMISSIONS on, which
+# — unlike a Net or a security group — can include Outscale's own public
+# catalogue. An unscoped call risks flooding this report with images that were
+# never this account's to begin with, teaching an operator to ignore it. That
+# needs an account-id filter verified against a live account before it is
+# safe to add (#107); snapshots have no such public-catalogue precedent and
+# are scoped the same way every other Read* call in this file already is.
 #
-# What this closes: a duplicate snapshot from a failed image build sat in the
+# What THIS closes: a duplicate snapshot from a failed image build sat in the
 # account while this script never looked, so "account is clean" was true of
 # everything it asked and false of the account (#71, 2026-08-19). A resource
-# class this script cannot see is a resource class it cannot report on.
-ARTIFACTS = call('ReadSnapshots').get('Snapshots', []) + call('ReadImages').get('Images', [])
+# class this script cannot see is a resource class it cannot report on — and
+# that cuts both ways: a REFUSED question is not a clean answer either, so
+# ARTIFACTS_UNVERIFIED tracks a failed ReadSnapshots call separately from a
+# genuinely empty one. Measured in review: without this, a refused
+# ReadSnapshots call after some OTHER resource was found and deleted fell
+# through every branch below to the same false "the account is clean" this
+# fix exists to stop.
+_unreachable_before_artifacts = UNREACHABLE
+ARTIFACTS = call('ReadSnapshots').get('Snapshots', [])
+ARTIFACTS_UNVERIFIED = UNREACHABLE > _unreachable_before_artifacts
 if ARTIFACTS:
-    print(f"\n⚠ {len(ARTIFACTS)} snapshot/image artifact(s) present — never auto-purged, review by hand:")
-    for a in ARTIFACTS:
-        if 'SnapshotId' in a:
-            print(f"    snapshot {a['SnapshotId']} ({a.get('State', '?')}, {a.get('VolumeSize', '?')}GB)")
-        else:
-            print(f"    image {a.get('ImageId')} ({a.get('ImageName') or a.get('State', '?')})")
+    print(f"\n⚠ {len(ARTIFACTS)} snapshot(s) present — never auto-purged, review by hand:")
+    for s in ARTIFACTS:
+        print(f"    snapshot {s.get('SnapshotId')} ({s.get('State', '?')}, {s.get('VolumeSize', '?')}GB)")
+elif ARTIFACTS_UNVERIFIED:
+    print("\n⚠ snapshot visibility was refused — cannot confirm the account holds none.")
 
-if TOTAL == 0 and UNREACHABLE:
+# TOTAL>0 is NOT "dirty" on its own — a successful purge (below, FAILED==0)
+# with TOTAL>0 is the ordinary clean-after-work case, same as before this
+# fix. Only the two branches that already claimed "clean" (nothing to purge,
+# and everything purged with nothing failed) need to also ask about
+# snapshots; the other two (dry-run, a failed delete) were already non-zero
+# and stay exactly as they were. A blanket "is anything at all non-zero"
+# flag was tried here first and wrongly turned a plain, fully successful
+# purge into a false "not fully clean" — a second bug shaped like the first.
+def _artifact_reason():
+    return f"{len(ARTIFACTS)} snapshot(s)" if ARTIFACTS else "snapshot visibility (refused, unconfirmed)"
+
+
+if UNREACHABLE and TOTAL == 0 and not ARTIFACTS:
+    # Nothing else was found ANYWHERE and something refused to answer — fires
+    # whether the refusal was the snapshot call or an earlier one. A
+    # CONFIRMED snapshot below already proves dirty on its own and takes
+    # priority (the `not ARTIFACTS` guard), so the two messages never talk
+    # over each other the way an unconditional check here used to.
     print(f"\n✗ {UNREACHABLE} call(s) refused — found nothing, but nothing was actually asked.")
     print("  This is NOT an all-clear: check OUTSCALE_ACCESS_KEY_ID / _SECRET_KEY and re-run.")
     sys.exit(2)
-if TOTAL == 0 and not ARTIFACTS:
+if TOTAL == 0 and not ARTIFACTS and not ARTIFACTS_UNVERIFIED:
     print("Nothing to purge — the account is clean.")
 elif TOTAL == 0:
-    # Only artifacts were found. They are never counted into TOTAL/--apply —
-    # see the block above — but "the account is clean" would still be a lie.
-    print(f"\n{len(ARTIFACTS)} artifact(s) present — the account is NOT fully clean (see above).")
+    print(f"\n{_artifact_reason()} present — the account is NOT fully clean (see above).")
     sys.exit(1)
 elif not APPLY:
     print(f"\n{TOTAL} resource(s) targeted. Re-run with --apply to delete them.")
@@ -148,8 +175,14 @@ elif not APPLY:
 elif FAILED:
     print(f"\n✗ {FAILED} of {TOTAL} deletion(s) failed — the account is NOT clean.")
     sys.exit(3)
-elif ARTIFACTS:
-    print(f"\n{TOTAL} resource(s) deleted. {len(ARTIFACTS)} artifact(s) still present (see above) — not fully clean.")
+elif ARTIFACTS or ARTIFACTS_UNVERIFIED:
+    # TOTAL>0, APPLY, nothing failed — this is the branch reviewers found
+    # unreachable: a refused ReadSnapshots after some OTHER resource was
+    # deleted used to fall straight to the final "clean" else below with
+    # ARTIFACTS silently empty. Checked AFTER FAILED on purpose: a deletion
+    # failure is the more urgent fact and must not be downgraded to a
+    # leftover snapshot's milder "not fully clean" wording.
+    print(f"\n{TOTAL} resource(s) deleted. {_artifact_reason()} still present (see above) — not fully clean.")
     sys.exit(1)
 else:
     print(f"\n{TOTAL} resource(s) deleted. The account is clean.")


### PR DESCRIPTION
## What this fixes

`outscale.py` never called `ReadSnapshots`, so a duplicate snapshot from a
failed image build could sit in the account while "account is clean" was
true of everything the script asked and false of the account (#71,
2026-08-19). It now lists leftover snapshots and refuses to claim clean
while any are present — reported only, never auto-deleted, same policy
`scaleway.py` already documents for Talos build artifacts.

Two paths said "clean" wrongly, not one: an account with nothing else at
all (`TOTAL == 0`), and the successful `--apply` path itself, which said
"N resource(s) deleted. The account is clean." even with a snapshot still
sitting there.

An earlier version of this branch also called `ReadImages`. It's dropped
here: `ReadImages`' documented default scope is every OMI held launch
permissions on, which — unlike a Net, a security group, or a snapshot —
can include Outscale's own public OMI catalogue. An unscoped call risks
flooding the report with images that were never this account's, teaching
an operator to ignore it. The account-id filter that would prevent that
needs verification against a live account first, tracked separately as
#107.

## A bug caught before it shipped

The first fix attempt guarded the "was artifact visibility itself refused"
check only on the `TOTAL == 0` branch. A Net purged successfully
(`TOTAL > 0`, `FAILED == 0`) with `ReadSnapshots` itself refused fell
through every branch to the same false "the account is clean" this script
exists to stop. Fixed by checking `ARTIFACTS`/`ARTIFACTS_UNVERIFIED` in
both branches that claim "clean", not just the first — see the comment
above the exit-code block in `outscale.py` for the full reasoning
(including a second, narrower bug introduced while fixing the first, also
caught and reverted before shipping).

## Also fixed

`docs/release-checklist.md` claimed `python3 scripts/ops/purge-orphans/<provider>.py`
"lists" the orphaned `-talos-staging` bucket. It doesn't — no purge-orphans
script enumerates buckets at all (confirmed via
`scripts/ops/verify-provider-clean.py`'s own `UNCHECKED` list). Found while
scoping #73; that issue is untouched by this PR — deliberately a human,
real-cloud action, no code gap to close.

## Rung and proof

**Rung: mocked.** `ReadSnapshots` is called with no `Filters`, the same
account-scoping assumption the script already makes for every other `Read*`
call — reasoned from Outscale's documented API shape, not exercised
against a live account. This does not close #71 (its own stated bar is
real cloud); it fixes the mocked-rung defect the issue names.

- `scripts/dev/test-purge-orphans.sh`: scenario 3 rewritten from images to
  snapshots; two new scenarios added — #4 reproduces the blocking bug
  exactly (net purged, `ReadSnapshots` refused), #5 checks a failed
  deletion still wins the exit code over a leftover snapshot present in the
  same run. 26 assertions, 0 failed.
- Mutation-checked against the previous (unpushed) commit on this branch:
  reverting to it turns exactly the 3 assertions tied to scenario #4 red,
  everything else (including scenario #5) stays green.
- `task lint`, `task test-scripts`, `task test` (52/52), `task render-check`,
  `task validate ROOT=cluster`, `task validate ROOT=talos-image` all green.
- `task security`: checkov 16/16 and gitleaks (dir scan + env-data rule
  check) both clean. `trivy` could not install in this sandbox
  (network-restricted) — not run here, relies on CI.

Refs #71. Follow-up for images: #107.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QiC6JGaTecmJVqE9GfDgjA)_