### PR TITLE
fix(clea): repair the feint probe's PATH, and give plumber a safe watcher

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,6 +86,7 @@ jobs:
       # 2026-08-20 — 13 required checks, no force-push, no deletions — so this is
       # a control with something to check, not a formality.
       - name: Plumber
+        # renovate: datasource=github-releases depName=getplumber/plumber
         uses: getplumber/plumber@031bc86d1e5f661626e2000f4f8779912d608d5f  # v0.4.39
         with:
           # Publishing the score sends this repository's name to a hosted badge

--- a/clea.toml
+++ b/clea.toml
@@ -29,6 +29,20 @@ config = "renovate.json5"
 # itself and reports anchors that do not exist.
 exclude = ["renovate.json5"]
 
+# `action-sha` (`uses: owner/action@<sha>  # vY`) and `precommit-rev`
+# (`rev: <sha>  # vY`) pin a commit that the anchor's own value never touches —
+# a customManagers entry matching either shape could only rewrite the trailing
+# comment, leaving the digest stale and the pin lying about what it runs.
+# `cmd_bump` refuses to write either shape for that reason. Renovate's BUILT-IN
+# managers already update the digest and the comment together — github-actions
+# with `helpers:pinGitHubActionDigests` (extended above), pre-commit with
+# `pinDigests` (packageRules above) — with no anchor needed at all. This is
+# that fact, declared: the two forms it names are watched by that native
+# manager, not by anything in renovate.json5's customManagers.
+[[inventory]]
+kind = "renovate-native"
+forms = ["action-sha", "precommit-rev"]
+
 # --- Tools this repository installs itself -----------------------------------
 # Two probes are derived from each row, and the engine needs nothing else:
 #   install : bare container, bump first, run the installer once

--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -183,6 +183,16 @@ VALUE_FORMS: list[tuple[str, re.Pattern[str]]] = [
     ("action-sha", re.compile(r"^\s*(?:-\s*)?uses:\s*\S+@\S+\s*#\s*(?P<v>\S+)")),
 ]
 
+# These two forms pin a commit — the `@sha` in `action-sha`, the `rev: sha` in
+# `precommit-rev` — and capture only the human tag AFTER it as `value`. `bump`
+# rewrites exactly the span it captured, so bumping one of these would move the
+# tag comment and leave the commit it is supposed to describe untouched: a pin
+# that CLAIMS the new version while still RUNNING the old one, which is worse
+# than not tracking it at all — it looks bumped. `cmd_bump` refuses both shapes
+# outright rather than write that. See `renovate-native` in `inventory_coverage`
+# for the other half: what makes leaving them untracked unnecessary.
+UNSAFE_BUMP_FORMS = frozenset({"action-sha", "precommit-rev"})
+
 # How far below the anchor the value may sit. Renovate's own regexes allow one
 # line; three covers a YAML `env:` key that opens its block on the next line.
 VALUE_WINDOW = 3
@@ -372,6 +382,50 @@ def renovate_coverage(root: Path, config: str, exclude: list[str]) -> set[tuple[
                 for m in rx.finditer(text):
                     covered.add((rel, text[: m.start()].count("\n") + 1))
     return covered
+
+
+def inventory_coverage(root: Path, scan: dict,
+                       inventories: list[dict]) -> dict[str, set[tuple[str, int]]]:
+    """Anchor positions each declared inventory can see, one set per kind.
+
+    `renovate` cross-checks a real Renovate config's `customManagers`, byte
+    for byte — the same question `renovate_coverage` always answered.
+
+    `renovate-native` is not a cross-check at all: it is the list of `form`s
+    (from VALUE_FORMS) that Renovate's OWN built-in managers already read
+    without any anchor, via `helpers:pinGitHubActionDigests` for `action-sha`
+    and `pinDigests` for `precommit-rev`. Both update the commit AND the tag
+    comment in one write. A `customManagers` entry matching the same line
+    could only ever move the comment — `cmd_bump` refuses exactly these two
+    forms for that reason (`UNSAFE_BUMP_FORMS`) — so routing them through
+    `renovate` coverage would demand the one kind of watcher that is unsafe to
+    build, for a dependency a different, safe watcher already has. Naming the
+    form here is what keeps this an explicit, per-project claim rather than a
+    blanket exemption: a form not listed still has to be seen by `renovate`.
+    """
+    seen: dict[str, set[tuple[str, int]]] = {}
+    for inventory in inventories:
+        kind = inventory.get("kind")
+        if kind == "renovate":
+            seen["renovate"] = renovate_coverage(
+                root, inventory["config"], scan["exclude"] + inventory.get("exclude", []))
+        elif kind == "renovate-native":
+            forms = set(inventory.get("forms", []))
+            if not forms:
+                raise CleaError(
+                    'clea.toml: [[inventory]] kind = "renovate-native" needs a '
+                    "non-empty forms list — naming which VALUE_FORMS shapes it vouches for")
+            known = {form for form, _ in VALUE_FORMS}
+            unknown = forms - known
+            if unknown:
+                raise CleaError(
+                    f"clea.toml: renovate-native names unknown form(s) {sorted(unknown)} "
+                    f"— known forms are {sorted(known)}")
+            anchors, _ = scan_anchors(root, scan["marker"], scan["exclude"], scan["include"])
+            seen["renovate-native"] = {a.key for a in anchors if a.form in forms}
+        else:
+            raise CleaError(f"clea.toml: unknown inventory kind {kind!r}")
+    return seen
 
 
 # ---------------------------------------------------------------------------
@@ -672,14 +726,7 @@ def cmd_coverage(args) -> int:
               "not the repository", file=sys.stderr)
         return 1
 
-    seen: dict[str, set[tuple[str, int]]] = {}
-    for inventory in cfg["inventory"]:
-        kind = inventory.get("kind")
-        if kind == "renovate":
-            seen["renovate"] = renovate_coverage(
-                root, inventory["config"], scan["exclude"] + inventory.get("exclude", []))
-        else:
-            raise CleaError(f"clea.toml: unknown inventory kind {kind!r}")
+    seen = inventory_coverage(root, scan, cfg["inventory"])
 
     failures = 0
     print(f"=== {len(anchors)} anchors read, {len(novalue)} carrying no version ===")
@@ -690,16 +737,24 @@ def cmd_coverage(args) -> int:
               "something could.")
         failures += 1
 
+    # An anchor fails only if NO declared inventory reaches it. `renovate` and
+    # `renovate-native` watch disjoint, complementary shapes by design — each
+    # legitimately misses what the other covers, and requiring every kind to
+    # see every anchor would fail both halves for doing their job.
+    combined: set[tuple[str, int]] = set().union(*seen.values()) if seen else set()
     for name, covered in seen.items():
         missing = [a for a in anchors if a.key not in covered]
         if missing:
             print(f"\n  {name} cannot see {len(missing)} of {len(anchors)}:")
             for anchor in missing:
+                flag = ("  ← no inventory sees this one"
+                        if len(seen) > 1 and anchor.key not in combined else "")
                 print(f"  ✗ {anchor.path}:{anchor.line} — {anchor.dep} = {anchor.value} "
-                      f"({anchor.form})")
-            failures += len(missing)
+                      f"({anchor.form}){flag}")
         else:
             print(f"  ✓ {name} sees all {len(anchors)}")
+    if seen:
+        failures += len([a for a in anchors if a.key not in combined])
 
     print()
     if failures:
@@ -833,22 +888,22 @@ def cmd_scan(args) -> int:
         "probes": previous.get("probes", []),
     }
 
-    for inventory in cfg["inventory"]:
-        if inventory.get("kind") != "renovate":
-            continue
-        try:
-            covered = renovate_coverage(
-                root, inventory["config"],
-                scan["exclude"] + inventory.get("exclude", []))
+    # Union across every declared inventory kind: `renovate` and
+    # `renovate-native` watch disjoint, complementary shapes (see
+    # `inventory_coverage`), so a dependency is watched if EITHER sees it.
+    try:
+        seen = inventory_coverage(root, scan, cfg["inventory"])
+        if seen:
+            covered = set().union(*seen.values())
             state["unwatched"] = [
                 {"dep": a.dep, "file": a.path, "line": a.line,
-                 "current": a.value, "inventory": "renovate"}
+                 "current": a.value, "inventory": ",".join(sorted(seen))}
                 for a in anchors if a.key not in covered]
             watched = {(a.path, a.line) for a in anchors if a.key in covered}
             for entry in deps:
                 entry["watched"] = (entry["file"], entry["line"]) in watched
-        except CleaError as exc:
-            errors.append(str(exc))
+    except CleaError as exc:
+        errors.append(str(exc))
 
     # The bot's heartbeat. Skipped loudly rather than quietly: "we did not ask"
     # and "the bot is fine" must not look the same in the report.
@@ -1161,6 +1216,14 @@ def cmd_bump(args) -> int:
     changed = 0
     for anchor in targets:
         new_value = apply_extract(args.version, anchor.attrs.get("extractVersion"))
+        if anchor.form in UNSAFE_BUMP_FORMS:
+            print(f"✗ {anchor.path}:{anchor.value_line} — {anchor.form} pins a commit "
+                  f"that this write does not touch: rewriting the comment to "
+                  f"{new_value!r} would claim that version while still running "
+                  f"whatever {anchor.value!r} already points at. Renovate resolves "
+                  "the commit and the comment together (helpers:pinGitHubActionDigests "
+                  "/ pinDigests) — bump this one there, or by hand.", file=sys.stderr)
+            return 1
         if not same_shape(anchor.value or "", new_value):
             print(f"✗ {anchor.path}:{anchor.value_line} — {anchor.value!r} and "
                   f"{new_value!r} do not carry the same v prefix; the consumers of "

--- a/scripts/clea/probe.sh
+++ b/scripts/clea/probe.sh
@@ -62,11 +62,21 @@ version_re() { printf '(^|[^0-9.])v?%s([^0-9.]|$)' "$(printf '%s' "${1#v}" | sed
 CA_ENV=""
 [ -n "$CA" ] && CA_ENV="export CURL_CA_BUNDLE=/etc/clea-ca.crt SSL_CERT_FILE=/etc/clea-ca.crt REQUESTS_CA_BUNDLE=/etc/clea-ca.crt; "
 
+# A workstation's login shell adds ~/.local/bin to PATH from a check in
+# /etc/skel/.profile — but only when the directory ALREADY EXISTS at shell
+# startup. `feint.sh install` creates it during THIS same `bash -lc`, one
+# command before the version check that needs it, which is one command too
+# late for that check to have seen it. Measured on the feint 0.11.0 probe: the
+# install itself reported "installed feint v0.11.0 → /root/.local/bin/feint",
+# exit 0, and the very next command in the same shell answered "feint:
+# command not found" — a real bump read back as a broken installer.
+PATH_ENV='export PATH="$HOME/.local/bin:$PATH"; '
+
 in_box() {
   if [ -n "$STDIN" ]; then
-    printf '%b' "$STDIN" | docker exec -i -w /repo "$NAME" bash -lc "${CA_ENV}$1"
+    printf '%b' "$STDIN" | docker exec -i -w /repo "$NAME" bash -lc "${PATH_ENV}${CA_ENV}$1"
   else
-    docker exec -w /repo "$NAME" bash -lc "${CA_ENV}$1"
+    docker exec -w /repo "$NAME" bash -lc "${PATH_ENV}${CA_ENV}$1"
   fi
 }
 

--- a/scripts/dev/test-clea.sh
+++ b/scripts/dev/test-clea.sh
@@ -307,6 +307,124 @@ expect 1 "an extracted form cannot move the site that keeps the v" \
   -- python3 "$CLEA" --root "$TMP/shapes" bump acme/twoshape 3.2.0
 
 echo
+echo "=== action-sha and precommit-rev: bump cannot move the digest they also pin ==="
+# Both shapes capture only the trailing comment (`# v1.0.0`) as the value — the
+# commit right before it is a SEPARATE identifier the reader never touches. A
+# naive bump would leave that stale: the tree would claim the new version and
+# keep running the old one, silently, which is worse than not tracking it at
+# all. Measured against a real anchor: this is exactly what a bare `# clea-test:`
+# marker over `uses: acme/action@<sha>  # v1.0.0` would do if bump did not refuse.
+cp -r "$TMP/basic" "$TMP/pin"
+cat > "$TMP/pin/.github/workflows/action.yml" <<'EOF'
+jobs:
+  a:
+    steps:
+      # clea-test: datasource=github-releases depName=acme/action
+      - uses: acme/action@1111111111111111111111111111111111111111  # v1.0.0
+EOF
+cat > "$TMP/pin/.pre-commit-config.yaml" <<'EOF'
+repos:
+  - repo: https://example.invalid/acme/hook
+    # clea-test: datasource=github-releases depName=acme/hook
+    rev: 2222222222222222222222222222222222222222  # v2.0.0
+EOF
+says "both new anchors are read, alongside the original seven" "9 anchors read" \
+  -- python3 "$CLEA" --root "$TMP/pin" coverage
+expect 1 "bumping the action refuses rather than orphan its digest" \
+  -- python3 "$CLEA" --root "$TMP/pin" bump acme/action v1.1.0
+says "and says why, not just that it can't" "still running" \
+  -- python3 "$CLEA" --root "$TMP/pin" bump acme/action v1.1.0
+if grep -q '1111111111111111111111111111111111111111.*# v1.0.0' "$TMP/pin/.github/workflows/action.yml"; then
+  ok "the line is untouched — no half-bumped pin left behind"
+else
+  bad "the refusal still wrote something: $(grep uses: "$TMP/pin/.github/workflows/action.yml")"
+fi
+expect 1 "bumping the pre-commit hook refuses the same way" \
+  -- python3 "$CLEA" --root "$TMP/pin" bump acme/hook v2.1.0
+if grep -q '2222222222222222222222222222222222222222.*# v2.0.0' "$TMP/pin/.pre-commit-config.yaml"; then
+  ok "the hook's rev is untouched too"
+else
+  bad "the refusal still wrote something: $(grep rev: "$TMP/pin/.pre-commit-config.yaml")"
+fi
+
+echo
+echo "=== renovate-native: an explicit, per-form claim, not a blanket exemption ==="
+# The two forms above can't be safely covered by a customManagers cross-check
+# (that's the point of the section above), so a project may instead vouch for
+# them by FORM: "Renovate's own github-actions / pre-commit managers already
+# read this shape, with no anchor at all." coverage must accept that claim only
+# for the forms actually named, and still demand the customManagers proof —
+# or a real gap — for everything else.
+cp -r "$TMP/pin" "$TMP/native"
+cat >> "$TMP/native/clea.toml" <<'EOF'
+[[inventory]]
+kind = "renovate-native"
+forms = ["action-sha"]
+EOF
+expect 1 "naming only action-sha still leaves precommit-rev, and the plain seven, unwatched" \
+  -- python3 "$CLEA" --root "$TMP/native" coverage
+OUT="$(python3 "$CLEA" --root "$TMP/native" coverage 2>&1)"
+if printf '%s' "$OUT" | grep -q 'acme/action ='; then
+  bad "the covered anchor (acme/action) still shows up as missing"
+else
+  ok "the covered anchor (acme/action) is not listed as missing"
+fi
+if printf '%s' "$OUT" | grep -q 'acme/hook ='; then
+  ok "the uncovered anchor (acme/hook) is still listed as missing"
+else
+  bad "acme/hook should still be reported unwatched"
+fi
+
+# Widen the customManagers side to the plain seven ONLY (excluded by filename,
+# not by luck): if it also reached the two pinned files, renovate-native's own
+# contribution to the union below would go untested.
+cp -r "$TMP/pin" "$TMP/native2"
+cat > "$TMP/native2/renovate.json5" <<'EOF'
+{
+  customManagers: [
+    { customType: "regex",
+      managerFilePatterns: ["scripts/*.sh", ".github/workflows/ci.yml", "infra/*.tf", "Taskfile.yml"],
+      matchStrings: ["# clea-test: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[a-z0-9/-]+)"] },
+  ],
+}
+EOF
+cat >> "$TMP/native2/clea.toml" <<'EOF'
+[[inventory]]
+kind = "renovate"
+config = "renovate.json5"
+exclude = ["renovate.json5"]
+
+[[inventory]]
+kind = "renovate-native"
+forms = ["action-sha", "precommit-rev"]
+EOF
+expect 0 "renovate covers the plain seven, renovate-native covers the two pinned ones — together, everything" \
+  -- python3 "$CLEA" --root "$TMP/native2" coverage
+# And each kind alone would still fail, proving the union is doing the work
+# rather than either kind quietly reaching everything on its own.
+rm "$TMP/native2/clea.toml"
+cp "$TMP/pin/clea.toml" "$TMP/native2/clea.toml"
+cat >> "$TMP/native2/clea.toml" <<'EOF'
+[[inventory]]
+kind = "renovate"
+config = "renovate.json5"
+exclude = ["renovate.json5"]
+EOF
+expect 1 "renovate alone does not reach the two pinned anchors" \
+  -- python3 "$CLEA" --root "$TMP/native2" coverage
+
+mkdir -p "$TMP/badform"; cp -r "$TMP/pin/." "$TMP/badform/"
+cat >> "$TMP/badform/clea.toml" <<'EOF'
+[[inventory]]
+kind = "renovate-native"
+forms = ["not-a-real-form"]
+EOF
+expect 1 "naming a form that does not exist is refused, not silently ignored" \
+  -- python3 "$CLEA" --root "$TMP/badform" coverage
+says "and it names the bad form, not just failing quietly" "not-a-real-form" \
+  -- python3 "$CLEA" --root "$TMP/badform" coverage
+
+echo
 echo "=== version comparison, and the pair every hand-rolled comparator gets wrong ==="
 python3 - "$CLEA" <<'PY'
 import importlib.util, sys, pathlib


### PR DESCRIPTION
## Summary

Two independent gaps found while auditing whether feint and plumber are actually up to date and watched — this PR fixes the *mechanisms*, not the pins themselves.

- **`scripts/clea/probe.sh` never put `~/.local/bin` on `PATH`** before checking a tool's version. `feint.sh install` installs there, so the upgrade-in-place lane ran the installer (exit 0, binary on disk), then immediately answered `feint: command not found` on the very next command in the *same* shell — a login shell's own `~/.local/bin` check runs once at startup, before the install had created the directory. This is exactly the failure recorded in [#91](https://github.com/dis-bzh/OpenAether-infra/issues/91) on the real `stephrobert/feint` 0.10.0 → 0.11.0 probe. Fixed by prepending `PATH_ENV` to every `in_box()` command.

- **`getplumber/plumber` (pinned by SHA in `security.yml`) carried no `# renovate:` anchor at all**, so Cléa's scan never saw it — five patches behind (`v0.4.39` → `v0.4.44`) and invisible to `clea coverage`, unlike every other pinned tool in this repo. Adding a plain anchor turned out to be unsafe for this shape: `action-sha` (and `precommit-rev`) capture only the trailing tag comment as their "value", so `clea bump` would rewrite the comment and leave the commit SHA before it untouched — a pin that *claims* a version it does not actually run. So:
  - `cmd_bump` now refuses to write either shape outright, with an error naming why.
  - A new `renovate-native` inventory kind lets `clea.toml` vouch for these forms *by name*: Renovate's own `github-actions`/`pre-commit` native managers already move the digest and the comment together (`pinGitHubActionDigests` / `pinDigests`, already enabled) — no anchor needed, and that's what actually keeps the pin correct. `clea coverage`'s pass/fail is now the union across every declared inventory kind, not "every kind must see every anchor" (which would have made `renovate` and `renovate-native` each fail on the other's legitimate gap).
  - Plumber's anchor is added; `clea coverage` on this tree now reports **23/23 anchors watched** (was invisible before).

Neither feint nor plumber is bumped in this PR — only the detection/probe mechanism, as asked.

## Test plan

- [x] Reproduced the exact probe failure live in a bare `ubuntu:24.04` container (curl+ca-certificates only, matching `probe.sh`'s own setup), confirmed the PATH fix resolves it.
- [x] Re-ran the *real* `stephrobert/feint` 0.10.0 → 0.11.0 bump through the patched `probe.sh` against a disposable clone: **3/3 passed** (cold install, upgrade-in-place, and the version check that used to fail).
- [x] `clea bump getplumber/plumber v0.4.44` on the real tree: refuses with the digest-desync reason, writes nothing.
- [x] `python3 scripts/clea/clea.py --root . coverage`: `23 anchors, every one watched.`
- [x] `task lint` — green (includes `clea coverage`, shellcheck, actionlint, yamllint, `check-version-drift.sh`).
- [x] `task test-scripts` — green, `scripts/dev/test-clea.sh` **73/73** (60 pre-existing + 13 new: action-sha/precommit-rev detection, bump refusal leaving the file untouched, `renovate-native` positive/negative cases including "each kind alone still fails" and "an unknown form name is refused").

Mocked rung (`task lint`/`task test-scripts`) reached; the feint probe itself was additionally proven against the real `stephrobert/feint` releases (not mocked). No cloud/emulated rung touched — this is a tooling fix, not a provider-module change.

Assisted-by: Claude Code (claude-sonnet-5)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TopkSW7xBdAJgzmhStUcd5)_