### PR TITLE
fix(dev): stop building gitleaks from source in the pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,11 +32,24 @@ repos:
       - id: check-merge-conflict
       - id: detect-private-key
 
-  # Secret detection
+  # Secret detection. gitleaks-system, not the default `gitleaks` hook: that one
+  # is `language: golang` and pre-commit builds it from source on first use —
+  # which panics inside wasilibs/go-re2's WASM regex engine in this project's
+  # sandbox (`invalid table access`, in wazero), reproduced across a full
+  # go-build-cache wipe and two Go toolchains. gitleaks-system shells out to
+  # the pinned, checksum-verified binary scripts/internal/install-gitleaks.sh
+  # installs instead — the exact same version, built upstream, carries no
+  # such defect. See #126.
   - repo: https://github.com/gitleaks/gitleaks
     rev: b69b5157a01fe4234a74a9acd186044152a80c43  # v8.22.1
     hooks:
-      - id: gitleaks
+      - id: gitleaks-system
+        # Unlike its `gitleaks`/`gitleaks-docker` siblings, upstream's own
+        # gitleaks-system hook omits this — so pre-commit's default (true)
+        # appends every changed file as a positional arg, and gitleaks' `git`
+        # subcommand accepts at most one ("accepts at most 1 arg(s), received
+        # 60"). It scans the whole staged diff itself; it needs no filenames.
+        pass_filenames: false
 
   # OpenTofu / Terraform formatting
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,22 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **The `gitleaks` pre-commit hook could not run at all in some sandboxes**,
+  blocking every local commit. `.pre-commit-config.yaml` used the upstream
+  `gitleaks` hook (`language: golang`), which pre-commit compiles from source
+  on first use; that build panics inside `wasilibs/go-re2`'s WASM regex
+  engine (`invalid table access`, in `wazero`) on at least one environment —
+  reproduced across a full `go`-build-cache wipe and two Go toolchains, while
+  the exact same version as an official release binary runs clean against the
+  same tree. New `scripts/internal/install-gitleaks.sh` (pinned,
+  checksum-verified, same shape as `install-task.sh`) installs that binary;
+  `.pre-commit-config.yaml` now uses upstream's own `gitleaks-system` hook id
+  against it instead of building one, with the `pass_filenames: false`
+  upstream's `gitleaks-system` entry omits (without it pre-commit appends
+  every changed file as a positional arg, and gitleaks' `git` subcommand
+  accepts at most one). `check-version-drift.sh` now compares the two pins.
+  [#126](https://github.com/dis-bzh/OpenAether-infra/issues/126)
+
 - **`outscale.py`'s purge never looked at leftover snapshots**, so a
   duplicate snapshot from a failed image build sat in the account while
   "account is clean" was true of everything the script asked and false of

--- a/scripts/dev/check-version-drift.sh
+++ b/scripts/dev/check-version-drift.sh
@@ -47,11 +47,17 @@ TOFU_CI="$(sed -nE 's/^[[:space:]]*tofu_version:[[:space:]]*"([^"]+)".*/\1/p' .g
 # is not part of the zero floor below for that reason.
 TALOS_CLUSTER="$(scripts/internal/talos-version.sh 2>/dev/null || true)"
 TALOS_CI="$(sed -nE 's/^[[:space:]]*TALOS_VERSION:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/p' .github/workflows/ci.yml | head -1)"
+GITLEAKS_INSTALL="$(pin scripts/internal/install-gitleaks.sh GITLEAKS_VERSION)"
+# The rev: line right after the gitleaks repo: line, not "the Nth rev: in the
+# file" — order-independent, so adding or reordering another repo: block
+# cannot silently start comparing the wrong pin.
+GITLEAKS_PRECOMMIT="$(awk '/repo:.*gitleaks\/gitleaks/{f=1; next} f && /rev:/{print; exit}' \
+  .pre-commit-config.yaml | sed -nE 's/.*#[[:space:]]*v([0-9][^[:space:]]*).*/\1/p')"
 
 # ZERO FLOOR. If the extractors return nothing the comparisons below all pass
 # vacuously, and this file becomes a green line that proves nothing — the exact
 # shape it is written against.
-for v in CILIUM HELM_MAJOR FEINT HELM_SETUP HELM_CI TOFU_SETUP TOFU_CI TALOS_CLUSTER; do
+for v in CILIUM HELM_MAJOR FEINT HELM_SETUP HELM_CI TOFU_SETUP TOFU_CI TALOS_CLUSTER GITLEAKS_INSTALL GITLEAKS_PRECOMMIT; do
   [ -n "${!v}" ] || { echo "✗ could not extract ${v} — the extractor is broken, not the repository" >&2; exit 1; }
 done
 
@@ -103,6 +109,15 @@ elif [ "$CHART" = "$CILIUM" ]; then
   ok "Cilium ${CILIUM}: the pin and the committed manifest agree"
 else
   bad "Cilium: ${RENDER} pins ${CILIUM}, the committed manifest is ${CHART}"
+fi
+
+# gitleaks: the pre-commit rev versus the pinned binary install-gitleaks.sh
+# fetches for the gitleaks-system hook. Diverge and a contributor's local hook
+# runs a different gitleaks than the one pre-commit's metadata claims.
+if [ "$GITLEAKS_INSTALL" = "$GITLEAKS_PRECOMMIT" ]; then
+  ok "gitleaks ${GITLEAKS_INSTALL}: install-gitleaks.sh and .pre-commit-config.yaml agree"
+else
+  bad "gitleaks: install-gitleaks.sh pins ${GITLEAKS_INSTALL}, .pre-commit-config.yaml pins ${GITLEAKS_PRECOMMIT}"
 fi
 
 echo "=== the documentation states the same pins ==="

--- a/scripts/internal/install-gitleaks.sh
+++ b/scripts/internal/install-gitleaks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Install gitleaks, pinned and checksum-verified.
+#
+# `.pre-commit-config.yaml` names gitleaks as a `language: golang` hook, which
+# pre-commit builds from source on first use. In this project's sandbox that
+# build panics inside `wasilibs/go-re2`'s WASM regex engine (`invalid table
+# access`, in wazero) — reproduced 6+ times across a full go-build-cache wipe,
+# two Go toolchains (1.24.7 and 1.25.1) and GOMAXPROCS=1. The exact same
+# version as an official RELEASE binary runs clean against the same tree
+# (`no leaks found`) — the defect is in compiling gitleaks' WASM path from
+# source here, not in gitleaks itself or in anything it scans. See #126.
+#
+# One way now, the same shape as every other tool here: a pinned version, the
+# project's own checksums file, and no third party in the path. The
+# `.pre-commit-config.yaml` gitleaks hook becomes a `language: system` hook
+# that shells out to this binary instead of building one.
+#
+# Usage: install-gitleaks.sh [bin-dir]        (default: /usr/local/bin, else ~/.local/bin)
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v(?<version>.*)$
+GITLEAKS_VERSION="8.22.1"
+
+# shellcheck source=scripts/lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
+
+BIN_DIR="${1:-$(oa_bin_dir)}"
+SUDO="$(oa_sudo_for "$BIN_DIR")"
+
+if command -v gitleaks >/dev/null 2>&1 &&
+  gitleaks version 2>/dev/null | grep -qE "(^|[^0-9.])${GITLEAKS_VERSION//./\\.}([^0-9.]|\$)"; then
+  echo "gitleaks v${GITLEAKS_VERSION} already installed"
+  exit 0
+fi
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" ;;
+  Linux-aarch64 | Linux-arm64) asset="gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz" ;;
+  Darwin-x86_64) asset="gitleaks_${GITLEAKS_VERSION}_darwin_x64.tar.gz" ;;
+  Darwin-arm64) asset="gitleaks_${GITLEAKS_VERSION}_darwin_arm64.tar.gz" ;;
+  *) echo "✗ no published gitleaks binary for $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/checksums.txt" "$base/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+# --ignore-missing: the file lists every platform, and without it the check fails
+# on the ones we did not download — which reads like a bad binary.
+(cd "$tmp" && sha256sum -c checksums.txt --ignore-missing)
+
+tar xzf "$tmp/$asset" -C "$tmp" gitleaks
+mkdir -p "$BIN_DIR" 2>/dev/null || $SUDO mkdir -p "$BIN_DIR"
+$SUDO install -m 0755 "$tmp/gitleaks" "$BIN_DIR/gitleaks"
+echo "installed gitleaks v${GITLEAKS_VERSION} → $BIN_DIR/gitleaks"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -381,6 +381,16 @@ if ! check_cmd checkov; then
     install_checkov
 fi
 
+# 5d. gitleaks — `task security` runs it directly, and pre-commit's own
+# `language: golang` hook builds it from source on first use. In this
+# project's sandbox that build panics inside wasilibs/go-re2's WASM engine
+# (see #126); the pinned release binary does not carry the same defect. The
+# `.pre-commit-config.yaml` gitleaks hook is `language: system` for exactly
+# this reason — it shells out to whatever this installs.
+if ! check_cmd gitleaks; then
+    "$(dirname "${BASH_SOURCE[0]}")/internal/install-gitleaks.sh"
+fi
+
 # 6. Check Talos image + backup tools (used by `task image-build` and the S3 backups)
 MISSING_IMG_TOOLS=0
 for t in curl zstd qemu-img aws gpg jq; do


### PR DESCRIPTION
## Summary

The upstream `gitleaks` pre-commit hook is `language: golang`, so pre-commit compiles it from source on first use. That build panics inside `wasilibs/go-re2`'s WASM regex engine (`invalid table access`, in `wazero`) in at least one sandbox this project runs sessions in — reproduced across a full `go`-build-cache wipe and two Go toolchains (1.24.7 and 1.25.1), while the exact same version as an official release binary runs clean against the same tree ([#126](https://github.com/dis-bzh/OpenAether-infra/issues/126)). It blocked every local commit in that environment, including two other same-day fixes that had to sit uncommitted.

- `scripts/internal/install-gitleaks.sh` (new) — pinned, checksum-verified, same shape as `install-task.sh`: downloads the official release binary + its checksums file, `sha256sum -c`.
- `.pre-commit-config.yaml` — the gitleaks hook now uses upstream's own `gitleaks-system` hook id (`language: system`, ships in the same `.pre-commit-hooks.yaml` this repo already pins) against that installed binary, instead of the default `gitleaks` id that builds from source. Also sets `pass_filenames: false`, which upstream's `gitleaks-system` entry omits unlike its `gitleaks`/`gitleaks-docker` siblings — without it pre-commit appends every changed file as a positional arg and gitleaks' `git` subcommand accepts at most one (`accepts at most 1 arg(s), received 60`, found while testing this).
- `scripts/setup.sh` — installs it alongside the other pinned tools (`task security` already assumed `gitleaks` was on `PATH`; nothing here ever put it there).
- `scripts/dev/check-version-drift.sh` — new comparison between `install-gitleaks.sh`'s pin and `.pre-commit-config.yaml`'s `rev` comment, same pattern as the existing helm/OpenTofu checks.

## Test plan

- [x] `task lint` — green (24 anchors watched, including the new one)
- [x] `task test-scripts` — green (full suite)
- [x] `task test` — green (52 passed)
- [x] `task render-check` — green
- [x] `task validate ROOT=cluster` — green
- [x] `task validate ROOT=talos-image` — green (pre-existing proxmox deprecation warning only)
- [x] checkov (16 passed) and gitleaks (`no leaks found`, using the newly-installed binary) — green; `trivy` still not reachable from this sandbox (pre-existing, unrelated gap), relies on CI
- [x] **The actual regression test**: `rm -rf ~/.cache/pre-commit && git commit` — panicked before this change (6 times, reproduced on this exact diff); passes clean after it, including a full `pre-commit run --all-files` from a wiped cache

Mocked rung — this is dev tooling, no provider/cluster code touched.

## What was deliberately left out

A separate, unrelated pre-commit friction point hit in the same sandbox — the `pre-commit-hooks` (trim-whitespace etc.) Python environment fails to build (`AttributeError: install_layout`) unless `SETUPTOOLS_USE_DISTUTILS=stdlib` is set — is not fixed here. It's a different root cause (a Debian-patched-distutils / setuptools mismatch, not `wazero`), it has a working per-invocation env-var workaround, and it doesn't block every commit the way the gitleaks crash did.

Closes #126

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_