### PR TITLE
docs(claude): an audit is not a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,16 @@ mocké → `task feint-*` émulé → cloud réel.
 Un constat sans changement à proposer est une **issue**, pas une PR. Une PR
 propose un changement ; c'est ce qui distingue les deux.
 
+**Un audit n'est pas une PR.** Une session qui balaie le dépôt à la recherche
+de défauts (revue de pipeline, de gates, etc.) doit soit corriger ce qu'elle
+trouve dans la même session (une PR par lot cohérent, comme la routine
+quotidienne), soit s'arrêter à 2 issues comme toute autre session — jamais
+ouvrir un lot au-delà sans un budget de fermeture en face. Le 2026-08-28, une
+session d'audit a ouvert 15 issues (#111–#125) en 9 minutes et laissé un
+commit correctif de 51 fichiers sur une branche jamais transformée en PR :
+aucune de ces issues n'a été refermée par ce travail. Le déséquilibre
+entrée/sortie est le signal à surveiller, pas le nombre d'issues en lui-même.
+
 Il y a eu `docs/backlog.md`, un tracker tenu à la main jusqu'à 696 lignes, et
 illisible bien avant. Il est supprimé, et son contenu réparti selon sa nature :
 


### PR DESCRIPTION
## Summary

- Codifies the rule Vincent asked for after `open issues: 48 → 65`: an audit session either fixes what it finds in the same session (one PR per coherent batch, like the daily routine), or caps itself at 2 issues like any other session.
- Names the incident that prompted it: 2026-08-28's audit opened 15 issues (#111–#125) in 9 minutes and left a 51-file fix on a branch that was never turned into a PR — none of those issues were closed by that work.
- Points at the actual signal to watch: the entry/exit imbalance, not the raw issue count.

## Context

That orphan branch has since been reviewed independently and opened as #131 (does not close most of the 15 — see its own description for what it does and doesn't cover).

## Test plan

- [x] `pre-commit` hooks (commitizen, trailer check, secret detection) passed on the commit.
- Doc-only change to `CLAUDE.md`; no code/gate impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_