### PR TITLE
chore(deps): bump feint to 0.12.0 and plumber to v0.4.48

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
+          persist-credentials: false
           # cz needs the range, and the default single-commit checkout has none.
           fetch-depth: 0
 
@@ -73,6 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install gitleaks
@@ -104,6 +106,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
 
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
@@ -169,6 +173,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
 
       - name: Install Helm (pinned + checksum-verified)
         env:
@@ -200,6 +206,8 @@ jobs:
         root: [cluster, talos-image]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
 
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
@@ -225,6 +233,8 @@ jobs:
     needs: validate
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
 
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
@@ -263,6 +273,8 @@ jobs:
         provider: [scaleway, outscale]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
 
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
@@ -299,6 +311,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
 
       # The repository's own installer, so this job cannot validate configs with
       # a talosctl the clusters do not run. It reads talos-version.sh, the one
@@ -337,6 +351,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
 
       - name: Run Trivy IaC scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -87,7 +87,7 @@ jobs:
       # a control with something to check, not a formality.
       - name: Plumber
         # renovate: datasource=github-releases depName=getplumber/plumber
-        uses: getplumber/plumber@031bc86d1e5f661626e2000f4f8779912d608d5f  # v0.4.39
+        uses: getplumber/plumber@3feac69e925e9771f8a495f4177af754d568c1ad  # v0.4.48
         with:
           # Publishing the score sends this repository's name to a hosted badge
           # service. That is a decision to take on purpose, not a CI default.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
+          persist-credentials: false
           fetch-depth: 0  # Full history for better detection
 
       - name: Install gitleaks (pinned + checksum-verified)
@@ -69,6 +70,8 @@ jobs:
       security-events: write  # SARIF upload to Code Scanning
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
 
       # Deliberately no .plumber.yaml. A config file REPLACES the built-in policy
       # instead of extending it: a minimal one, measured on 2026-08-11, left 22 of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,24 @@ in git. 0.1.0 is the first entry describing something proven.
   egress policy refuses `www.talos.dev`, where the old installer took the whole
   bootstrap down with it at step 2 under `set -e`.
 
+- **`stephrobert/feint` 0.10.0 → 0.12.0, and `getplumber/plumber` v0.4.39 →
+  v0.4.48** — checked by hand at the maintainer's request, not from a Cléa
+  "probed green" verdict: feint's own probe had failed only on doc drift (the
+  installer/upgrade checks all passed), fixed here alongside the bump; plumber
+  isn't `clea bump`-safe at all — its anchor is a SHA-pinned `uses:` line where
+  the tool only rewrites the trailing `# vX.Y.Z` comment, which would leave the
+  old commit pinned under a new-looking version. Bumped past what Cléa's stale
+  report knew about (0.11.0) once a direct check of `stephrobert/feint`'s tags
+  showed 0.12.0 already released; plumber's new commit SHA was read straight
+  from its `v0.4.48` tag and verified against the tag's own commit before
+  writing it, never derived from the version string. Proof: `task lint`,
+  `task render-check`, `task test-scripts`, `task validate` (`cluster` and
+  `talos-image`), `task test`, checkov and gitleaks (`trivy` unreachable from
+  this sandbox) all green, plus `task feint-test` — a full create / verify /
+  empty-replan / destroy cycle against the real v0.12.0 binary, both Scaleway
+  and Outscale. `plumber`'s own audit is unexercised outside GitHub Actions;
+  this PR's CI run is what proves that pin.
+
 - **Renovate moves from a six-hour weekly window to a daily one**, and
   `dependencyDashboard` becomes explicit. It has proposed nothing since its
   config landed on 2026-07-30 — its nine pull requests were created three hours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,15 @@ in git. 0.1.0 is the first entry describing something proven.
   and Outscale. `plumber`'s own audit is unexercised outside GitHub Actions;
   this PR's CI run is what proves that pin.
 
+  The plumber bump itself surfaced a real, if low-severity, finding: v0.4.48
+  added a control ("Checkout must not persist credentials", `ISSUE-307`)
+  that v0.4.39 never evaluated, and it was right — 11 `actions/checkout` steps
+  across `ci.yml` and `security.yml` left `GITHUB_TOKEN` in `.git/config` for
+  the rest of their job with no later step needing it (none of them push).
+  `persist-credentials: false` added to all 11, the same fix `clea.yml`
+  already carries on the two checkouts that DO push — this is every read-only
+  job catching up to that pattern.
+
 - **Renovate moves from a six-hour weekly window to a daily one**, and
   `dependencyDashboard` becomes explicit. It has proposed nothing since its
   config landed on 2026-07-30 — its nine pull requests were created three hours

--- a/docs/emulated-cloud.fr.md
+++ b/docs/emulated-cloud.fr.md
@@ -116,7 +116,7 @@ régressions de câblage avant de dépenser.
 
 ## Manques connus
 
-Épinglé sur **Feint 0.10.0** (`scripts/dev/feint.sh`). Ce que cette voie ne peut
+Épinglé sur **Feint 0.12.0** (`scripts/dev/feint.sh`). Ce que cette voie ne peut
 toujours pas porter, tout consigné dans [les issues ouvertes](https://github.com/dis-bzh/OpenAether-infra/issues) :
 
 | Non exercé | Pourquoi |

--- a/docs/emulated-cloud.md
+++ b/docs/emulated-cloud.md
@@ -112,7 +112,7 @@ the only proof of a deployment; this catches wiring regressions before spending.
 
 ## Known gaps
 
-Pinned to **Feint 0.10.0** (`scripts/dev/feint.sh`). What this lane still cannot
+Pinned to **Feint 0.12.0** (`scripts/dev/feint.sh`). What this lane still cannot
 carry, all recorded in [the open issues](https://github.com/dis-bzh/OpenAether-infra/issues):
 
 | Not exercised | Why |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -97,7 +97,7 @@ baseline and not a picture of what was already there.
 
 ## 3. Emulated cloud — no account, real provider binaries
 
-The lane is pinned to Feint 0.10.0, running against the same Scaleway provider
+The lane is pinned to Feint 0.12.0, running against the same Scaleway provider
 version the clusters run.
 
 ```bash

--- a/scripts/dev/feint.sh
+++ b/scripts/dev/feint.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # renovate: datasource=github-releases depName=stephrobert/feint extractVersion=^v(?<version>.*)$
-FEINT_VERSION="0.10.0"
+FEINT_VERSION="0.12.0"
 FEINT_ENDPOINT="${FEINT_ENDPOINT:-http://127.0.0.1:4599}"
 BIN_DIR="${FEINT_BIN_DIR:-$HOME/.local/bin}"
 

--- a/scripts/internal/install-plumber.sh
+++ b/scripts/internal/install-plumber.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 # renovate: datasource=github-releases depName=getplumber/plumber extractVersion=^v(?<version>.*)$
-PLUMBER_VERSION="0.4.39"
+PLUMBER_VERSION="0.4.48"
 
 # shellcheck source=scripts/lib/common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"


### PR DESCRIPTION
## What

Checked `stephrobert/feint` and `getplumber/plumber` directly against upstream at the maintainer's request (no open PR covered either). Both were behind, and neither could go through the normal Cléa-bump path:

| dependency | old | new | where |
|---|---|---|---|
| `stephrobert/feint` | `0.10.0` | `0.12.0` | `scripts/dev/feint.sh:13` |
| `getplumber/plumber` | `v0.4.39` (`031bc86…`) | `v0.4.48` (`3feac69…`) | `.github/workflows/security.yml:90` |

## Why these two, and why not `clea bump`

Cléa's own report (issue #104) is stale relative to upstream — it only knew about feint `0.11.0`, and that probe had failed solely on doc drift (the install/upgrade functional checks all passed: `docs/emulated-cloud.md`, `docs/emulated-cloud.fr.md`, `docs/release-checklist.md` all still said `0.10.0`). Checking `stephrobert/feint`'s tags directly showed `0.12.0` already released, so this goes straight there instead of stopping at `0.11.0`.

`getplumber/plumber` isn't `clea bump`-safe at all: its anchor is a SHA-pinned `uses: getplumber/plumber@<sha>  # vX.Y.Z` line, and `clea bump` only rewrites the trailing version comment (confirmed by reading `cmd_bump` — it rewrites exactly the regex-captured span, which for the `action-sha` anchor kind is only the comment). Running it here would have left the **old** commit pinned under a **new-looking** version label — a silent supply-chain desync, not a bump. Done by hand instead: the new commit SHA was read from `getplumber/plumber`'s `v0.4.48` tag directly (`git ls-remote --tags`) and the tag's own commit message verified (`chore(release): 0.4.48`) before writing it — same for confirming the old SHA actually matches `v0.4.39`.

## Proof

- `task lint`, `task render-check`, `task test-scripts`, `task validate ROOT=cluster`, `task validate ROOT=talos-image`, `task test` — all green.
- `task security`: checkov (16/16) and gitleaks (`no leaks found`, `check-gitleaks-rules.sh` green) both pass; **`trivy` could not run — not installed and unreachable from this sandbox.**
- `task feint-test` — the actual point of the feint bump: a full create → verify → empty re-plan → destroy cycle against the real **v0.12.0** binary, on both Scaleway and Outscale:
  ```
  ✓ scaleway: apply / empty re-plan / destroy, confirmed against the API
  ✓ outscale: apply / empty re-plan / destroy, confirmed against the API
  ```
- `plumber`'s own pipeline audit only runs inside GitHub Actions (`pipeline-audit` job) — this PR's own CI run is what proves the new pin, there is no local equivalent.

This is the mocked/emulated rung (`task test` plus a real `task feint-test` run) — no provider code touched, no real-cloud rung applies here.

## Related (not closed by this)

No open issue asks for this specific bump, so nothing here is a "Closes". Two are adjacent context, unresolved by a version bump alone:

- #76 ("Two feint gaps, both of them recordings we do not have") explicitly says its measurements "predate feint 0.10.0 and must be re-run" — now doubly true at 0.12.0, but the gap itself (real LB/gateway data-plane support in the emulator) is unchanged.
- #52 ("Nothing local runs the pipeline audit") asks for a `task pipeline-audit` wired into `task security` so plumber's policy can be checked before pushing — this PR still leaves that check reachable only from CI.

Assisted-by: Claude Code
