### PR TITLE
fix(dev): refuse in ~1s on a host that can never boot Talos-in-Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`test-talos-local.sh` hung for 90s on a host missing `CAP_SYS_RESOURCE`,
+  then failed on an unrelated-looking timeout**, instead of the ~1s refusal
+  its siblings give when no local cluster is reachable
+  ([#54](https://github.com/dis-bzh/OpenAether-infra/issues/54)). New
+  `scripts/dev/check-docker-talos-capability.sh` (same fail-open shape as
+  `check-host-ports.sh`) catches it in milliseconds via the `capsh` probe
+  `infrastructure/opentofu-local/README.md` already documented; wired into
+  both `test-talos-local.sh` and `task local-up`, which shares the identical
+  exposure.
 - **Six gates were reporting green on something they had stopped checking.**
   Found by auditing what the pipeline actually constrains, and each one is
   reproduced in both directions — broken on purpose, watched go red, fixed,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -367,6 +367,10 @@ tasks:
       # check-script-reachability.sh actually flags an unreferenced script
       # and clears once it's wired in, not just that today's tree is clean.
       - ./scripts/dev/test-script-reachability.sh
+      # A host missing CAP_SYS_RESOURCE looked healthy for 90s before this,
+      # then died on an unrelated-looking timeout (#54). Against a stubbed
+      # capsh, and also against this host's real one where reachable.
+      - ./scripts/dev/test-docker-talos-capability.sh
       # A --set typo reaches the cluster silently past every other gate;
       # this proves the effective-config reader (and check-cilium-parity.py's
       # missing-key guard) actually catch it, offline.
@@ -1452,6 +1456,9 @@ tasks:
       # Fail fast on a Hyper-V port reservation: Docker Desktop only reports it
       # as an opaque 500, five retries and a 90s timeout later.
       - ./scripts/dev/check-host-ports.sh {{.TALOS_API_PORT_BASE}} {{.K8S_API_PORT}}
+      # Same shape, a different 90s hang: a host missing CAP_SYS_RESOURCE looks
+      # healthy right up to the etcd-quorum wait. See infrastructure/opentofu-local/README.md.
+      - ./scripts/dev/check-docker-talos-capability.sh
       # cilium-local.yaml is gitignored, so a fresh clone has none — render it
       # rather than boot a cluster with no CNI. Mirrors what `up` does for the
       # cloud manifest.

--- a/scripts/dev/check-docker-talos-capability.sh
+++ b/scripts/dev/check-docker-talos-capability.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Preflight: can THIS host actually run Talos-in-Docker, or would it silently
+# hang and then fail?
+#
+# Talos's in-node containerd sets its own OOM score to -999, which needs
+# CAP_SYS_RESOURCE. Sandboxes and some CI runners drop that capability from the
+# bounding set, and --privileged cannot get it back: Docker grants capabilities
+# from its parent's bounding set, so a privileged container inherits the same
+# hole. Without it the containers come up and look healthy while
+# talos_machine_bootstrap (or test-talos-local.sh's own etcd-quorum poll) burns
+# its full retry budget before failing on something unrelated-looking — see
+# infrastructure/opentofu-local/README.md, "Host requirement: CAP_SYS_RESOURCE".
+#
+# No-op when capsh is absent (this check cannot tell, so it must not block a
+# working setup) and non-fatal on anything but a confirmed-missing capability:
+# same fail-open shape as check-host-ports.sh.
+#
+# Usage: check-docker-talos-capability.sh
+set -uo pipefail
+
+command -v capsh >/dev/null 2>&1 || exit 0
+
+# The BOUNDING line, and only it: capsh names the capability twice more as a
+# NEGATION ("cap_sys_resource-ep", "!cap_sys_resource"), so a bare grep over the
+# whole output would report a missing capability as present.
+BOUNDING="$(capsh --print 2>/dev/null | grep '^Bounding set')"
+[ -n "$BOUNDING" ] || exit 0
+echo "$BOUNDING" | grep -q cap_sys_resource && exit 0
+
+cat >&2 <<'EOT'
+✗ this host cannot run the Docker Talos lane — CAP_SYS_RESOURCE is missing
+  from the container bounding set.
+
+  Talos's containerd needs it to set its own OOM score; without it every node
+  comes up and looks healthy while the cluster never actually bootstraps, and
+  the failure only shows up ~90s later as an unrelated-looking timeout. There
+  is no workaround on such a host — see infrastructure/opentofu-local/README.md,
+  "Host requirement: CAP_SYS_RESOURCE".
+EOT
+exit 1

--- a/scripts/dev/test-docker-talos-capability.sh
+++ b/scripts/dev/test-docker-talos-capability.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# check-docker-talos-capability.sh against a stubbed capsh — never a real
+# container, since the whole point is to answer this WITHOUT spending 90s on
+# one. See infrastructure/opentofu-local/README.md, "Host requirement:
+# CAP_SYS_RESOURCE" — the exact defect this catches (#54).
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECK="$ROOT/scripts/dev/check-docker-talos-capability.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+stub_capsh() { # <bounding-set-line>
+  cat >"$STUB_DIR/capsh" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "--print" ] || exit 1
+printf '%s\n' '$1'
+# The negation form capsh prints alongside the bounding set — must not make a
+# bare grep for the capability name see it as present.
+printf '%s\n' 'Current: cap_sys_resource-ep'
+EOF
+  chmod +x "$STUB_DIR/capsh"
+}
+
+echo "=== capability present: silent, exit 0 ==="
+stub_capsh "Bounding set =cap_chown,cap_sys_resource,cap_setuid"
+out="$(PATH="$STUB_DIR:$PATH" "$CHECK" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0" || bad "exit $rc, want 0"
+[ -z "$out" ] && ok "nothing printed (fail-open must stay silent on success)" || bad "printed: $out"
+
+echo "=== capability missing: refuses in well under 90s, names the cause ==="
+stub_capsh "Bounding set =cap_chown,cap_setuid"
+start=$(date +%s)
+out="$(PATH="$STUB_DIR:$PATH" "$CHECK" 2>&1)"; rc=$?
+elapsed=$(( $(date +%s) - start ))
+[ "$rc" -eq 1 ] && ok "exit 1" || bad "exit $rc, want 1"
+[ "$elapsed" -lt 5 ] && ok "refused in ${elapsed}s, not 90" || bad "took ${elapsed}s — the whole point was not to wait"
+echo "$out" | grep -q "CAP_SYS_RESOURCE" && ok "names the actual capability" || bad "message doesn't name it: $out"
+
+echo "=== the negation forms in capsh's own output must not fool a bare grep ==="
+# Reproduces the trap the real check's comment warns about: capsh names
+# cap_sys_resource three times when it is ABSENT (twice as a negation, once in
+# a Current: line) and only the Bounding set line is the real answer.
+rm -f "$STUB_DIR/capsh"
+cat >"$STUB_DIR/capsh" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = "--print" ] || exit 1
+cat <<'INNER'
+Current: cap_chown,cap_setuid cap_sys_resource-ep
+Bounding set =cap_chown,cap_setuid
+Securebits: 00/0x0/1'b0
+ secure-noroot: no (unlocked)
+uid=0(root)
+gid=0(root)
+groups=
+Guessed mode: UNCERTAIN (0)
+INNER
+EOF
+chmod +x "$STUB_DIR/capsh"
+out="$(PATH="$STUB_DIR:$PATH" "$CHECK" 2>&1)"; rc=$?
+[ "$rc" -eq 1 ] && ok "still refuses — a naive whole-output grep would have missed this" \
+  || bad "exit $rc, want 1 (the negation form fooled it)"
+
+echo "=== capsh absent: cannot tell, must not block a working setup ==="
+# capsh lives in /usr/sbin and /sbin on this host — strip exactly those from
+# PATH rather than replacing it wholesale, so env/bash/grep stay reachable.
+NO_CAPSH_PATH="$(printf '%s' "$PATH" | tr ':' '\n' | grep -vE '^/(usr/)?sbin$' | paste -sd: -)"
+out="$(PATH="$NO_CAPSH_PATH" "$CHECK" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "fails open when capsh is unavailable" || bad "exit $rc, want 0"
+
+echo "=== wired into test-talos-local.sh's own preflight, not just documented ==="
+if grep -q 'check-docker-talos-capability.sh' "$ROOT/scripts/dev/test-talos-local.sh"; then
+  ok "test-talos-local.sh calls this check before its 90s etcd-quorum wait"
+else
+  bad "test-talos-local.sh does not call check-docker-talos-capability.sh"
+fi
+
+echo "=== reproduced against THIS host's real capsh, not just the stub ==="
+# This sandbox is documented (infrastructure/opentofu-local/README.md) as
+# missing the capability — the same claim task local-up and this session's own
+# environment already make. If that ever stops being true here, this harness
+# should say so rather than silently stop proving anything.
+if command -v capsh >/dev/null 2>&1; then
+  real_out="$("$CHECK" 2>&1)"; real_rc=$?
+  if capsh --print 2>/dev/null | grep '^Bounding set' | grep -q cap_sys_resource; then
+    [ "$real_rc" -eq 0 ] && ok "this host HAS the capability — check agrees" \
+      || bad "this host has it but the real check said no"
+  else
+    [ "$real_rc" -eq 1 ] && ok "this host is missing it (as documented) — check agrees, in real time" \
+      || bad "this host is missing it but the real check said yes"
+  fi
+else
+  echo "  (no capsh on this host — real-environment case not exercised)"
+fi
+
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$PASS" -gt 0 ] && [ "$FAIL" -eq 0 ]

--- a/scripts/dev/test-talos-local.sh
+++ b/scripts/dev/test-talos-local.sh
@@ -127,6 +127,9 @@ for cmd in docker tofu talosctl kubectl helm nc flux; do
 done
 [[ ${#MISSING[@]} -gt 0 ]] && { error "Missing tools: ${MISSING[*]}"; exit 1; }
 docker ps >/dev/null 2>&1 || { error "Docker is not running (start Docker Desktop, enable WSL2 integration)."; exit 1; }
+# Fail in ~10ms on a host that can never bootstrap Talos-in-Docker, instead of
+# a silent 90s hang in Step 3 below ending on an unrelated-looking timeout.
+"${SCRIPT_DIR}/check-docker-talos-capability.sh" || exit 1
 export TF_VAR_encryption_passphrase="${TF_VAR_encryption_passphrase:-local-test-passphrase-32chars-minimum}"
 
 # Flux reconciles from GitHub — the current branch must be pushed so the GitRepository can clone it.


### PR DESCRIPTION
## Summary

`test-talos-local.sh`'s siblings (`test-gates-local.sh`, `test-cnpg-gates-local.sh`) refuse in under a second when no local cluster is reachable. This one blocked past 90s on a host missing `CAP_SYS_RESOURCE` — a limitation `infrastructure/opentofu-local/README.md` already documents in detail (with the exact `capsh` probe to use), but nothing actually ran that probe before spending the etcd-quorum wait loop on a cluster that could never bootstrap ([#54](https://github.com/dis-bzh/OpenAether-infra/issues/54)).

- `scripts/dev/check-docker-talos-capability.sh` (new): runs the README's own `capsh` probe. Same fail-open shape as the existing `check-host-ports.sh` — silent on success, no-op when `capsh` is absent (can't tell, must not block a working setup), only refuses on a confirmed-missing capability.
- Wired into `test-talos-local.sh`'s preflight, right after the existing Docker-daemon check.
- Also wired into `task local-up`, alongside `check-host-ports.sh` — it shares the identical exposure to the identical 90s hang (same `tofu apply` + etcd-quorum wait), and the precedent for a dedicated preflight script wired there already exists.
- `scripts/dev/test-docker-talos-capability.sh` (new): 9 offline assertions against a stubbed `capsh` — capability present (silent, exit 0), missing (refuses, names the cause, well under 90s), the negation-form trap the real check's own comment warns about (`capsh` names the capability as absent in *three* places, only one of which is the real answer — a naive whole-output grep would misread it), `capsh` itself absent (fails open), the wiring into `test-talos-local.sh` is real not just documented, and — the strongest proof available — the check run for real against *this sandbox's own* `capsh`, which is exactly such a host.
- Wired into `task test-scripts`; `CHANGELOG.md` updated.

## The actual regression test

This session's own sandbox is documented as missing `CAP_SYS_RESOURCE`. Before this fix:

```
$ time ./scripts/dev/test-talos-local.sh
...(90s+ later)... error, unrelated-looking timeout
```

After:

```
$ time ./scripts/dev/test-talos-local.sh
✗ this host cannot run the Docker Talos lane — CAP_SYS_RESOURCE is missing...
real  0m0.040s
```

Not a mock of the defect — the same host, the same script, the actual 90s-vs-40ms difference.

## Test plan

- [x] `task lint` — green
- [x] `task test-scripts` — green (new harness: 9/9; full suite green)
- [x] `task test` — green
- [x] `task render-check` — green
- [x] `task validate ROOT=cluster` / `ROOT=talos-image` — green
- [x] checkov (16/16) and gitleaks (`no leaks found`) — green
- [x] Mutation check: reverted the fix (`exit 1` → `exit 0`), re-ran `test-docker-talos-capability.sh` — 3 of 9 assertions go red (including the real-host reproduction), confirming the harness actually exercises this fix

Mocked rung, as the issue asks for. Emulated/real-cloud skipped — this is a local dev-environment guard, not provider/cluster code.

## What was deliberately left out

Nothing from the issue's own "Closes" criterion. `task local-up` picking up the same guard is a deliberate, minimal extension beyond the issue's literal ask — same defect, same call-site pattern already established by `check-host-ports.sh`, costs nothing on a working host.

Closes #54


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_