### PR TITLE
feat(dev): task pipeline-audit — the CI policy scanner, before pushing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,7 @@ __pycache__/
 # Cléa writes this on a local `task clea-scan`; on a probe branch the committed
 # artefact is clea-probe.json, not this.
 clea-state.json
+
+# task pipeline-audit's own output — a local run's report, not an artefact
+# this repository commits.
+plumber-report.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,14 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Added
 
+- **`task pipeline-audit`** runs the CI policy scanner (plumber) locally —
+  before this, the only way to see its verdict before pushing was to fetch
+  the binary by hand ([#52](https://github.com/dis-bzh/OpenAether-infra/issues/52)).
+  New `scripts/internal/install-plumber.sh` (pinned, checksum-verified, same
+  shape as `install-gitleaks.sh`); wired into `task security`, last, since
+  without `GH_TOKEN` it legitimately exits 3 ("incomplete data" — branch
+  protection cannot be evaluated) and must not swallow the checks that CAN
+  succeed offline.
 - **`task purge-orphans PROVIDER=… [APPLY=1]`.** `docs/release-checklist.md`
   already told the reader to run it; it did not exist. The scripts it wraps are
   the last sentence between a failed teardown and a bill, and they were reachable

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -225,8 +225,24 @@ tasks:
       # no error in the CAPI CR. Two deployments were lost to it.
       - python3 scripts/ops/preflight-quotas.py {{.PROVIDER}} {{.CLI_ARGS}}
 
+  pipeline-audit:
+    desc: >-
+      Run the CI policy scanner (plumber) locally — same gate as
+      "Pipeline audit" in security.yml, before pushing.
+    cmds:
+      - |
+        command -v plumber >/dev/null 2>&1 || {
+          echo "✗ plumber not installed — run ./scripts/setup.sh, or: ./scripts/internal/install-plumber.sh" >&2
+          exit 1
+        }
+        # GH_TOKEN is optional here: without one, branch-protection controls
+        # cannot be evaluated and the run reports degraded/incomplete rather
+        # than refusing outright — same shape CI's own token-scope fallback
+        # already documents (security.yml, "branchMustBeProtected").
+        plumber analyze --output plumber-report.json
+
   security:
-    desc: "Run security scans (Trivy, Checkov, Gitleaks)"
+    desc: "Run security scans (Trivy, Checkov, Gitleaks, pipeline audit)"
     cmds:
       # Skip the upstream-vendored Cilium/Flux bootstrap manifests (not our
       # config to fix; reviewed at render time). Matches the CI Trivy step.
@@ -258,6 +274,11 @@ tasks:
       # test fixtures use synthetic-but-routable quads. This asserts they still
       # match; two of them once matched nothing and passed.
       - ./scripts/dev/check-gitleaks-rules.sh
+      # Last: without GH_TOKEN this legitimately exits 3 ("incomplete data" —
+      # branch protection cannot be evaluated), so it must not swallow the
+      # checks above it that CAN succeed offline. Set GH_TOKEN for a complete
+      # run; see task pipeline-audit's own description.
+      - task: pipeline-audit
 
   purge-orphans:
     desc: >-

--- a/scripts/dev/check-version-drift.sh
+++ b/scripts/dev/check-version-drift.sh
@@ -53,11 +53,14 @@ GITLEAKS_INSTALL="$(pin scripts/internal/install-gitleaks.sh GITLEAKS_VERSION)"
 # cannot silently start comparing the wrong pin.
 GITLEAKS_PRECOMMIT="$(awk '/repo:.*gitleaks\/gitleaks/{f=1; next} f && /rev:/{print; exit}' \
   .pre-commit-config.yaml | sed -nE 's/.*#[[:space:]]*v([0-9][^[:space:]]*).*/\1/p')"
+PLUMBER_INSTALL="$(pin scripts/internal/install-plumber.sh PLUMBER_VERSION)"
+PLUMBER_CI="$(sed -nE 's/.*getplumber\/plumber@[0-9a-f]+[[:space:]]*#[[:space:]]*v([0-9][^[:space:]]*).*/\1/p' \
+  .github/workflows/security.yml | head -1)"
 
 # ZERO FLOOR. If the extractors return nothing the comparisons below all pass
 # vacuously, and this file becomes a green line that proves nothing — the exact
 # shape it is written against.
-for v in CILIUM HELM_MAJOR FEINT HELM_SETUP HELM_CI TOFU_SETUP TOFU_CI TALOS_CLUSTER GITLEAKS_INSTALL GITLEAKS_PRECOMMIT; do
+for v in CILIUM HELM_MAJOR FEINT HELM_SETUP HELM_CI TOFU_SETUP TOFU_CI TALOS_CLUSTER GITLEAKS_INSTALL GITLEAKS_PRECOMMIT PLUMBER_INSTALL PLUMBER_CI; do
   [ -n "${!v}" ] || { echo "✗ could not extract ${v} — the extractor is broken, not the repository" >&2; exit 1; }
 done
 
@@ -118,6 +121,14 @@ if [ "$GITLEAKS_INSTALL" = "$GITLEAKS_PRECOMMIT" ]; then
   ok "gitleaks ${GITLEAKS_INSTALL}: install-gitleaks.sh and .pre-commit-config.yaml agree"
 else
   bad "gitleaks: install-gitleaks.sh pins ${GITLEAKS_INSTALL}, .pre-commit-config.yaml pins ${GITLEAKS_PRECOMMIT}"
+fi
+
+# plumber: `task pipeline-audit`'s own install versus the CI Action pin. Diverge
+# and a local run says something CI never checked.
+if [ "$PLUMBER_INSTALL" = "$PLUMBER_CI" ]; then
+  ok "plumber ${PLUMBER_INSTALL}: install-plumber.sh and security.yml agree"
+else
+  bad "plumber: install-plumber.sh pins ${PLUMBER_INSTALL}, security.yml pins ${PLUMBER_CI}"
 fi
 
 echo "=== the documentation states the same pins ==="

--- a/scripts/internal/install-plumber.sh
+++ b/scripts/internal/install-plumber.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Install plumber, pinned and checksum-verified — the CI policy scanner
+# (`.github/workflows/security.yml`, "Pipeline audit") that gates unpinned
+# actions, dangerous triggers and over-broad permissions in every workflow
+# file. Before this, the only way to see its verdict before pushing was to
+# fetch the binary by hand. See #52.
+#
+# Same shape as install-gitleaks.sh: a pinned version, the project's own
+# checksums file, no third party in the path. Plain binaries per platform —
+# plumber ships no tarball.
+#
+# Not verified here: the build-provenance (sigstore/SLSA) attestation the
+# GitHub Action also checks — that needs the `gh` CLI, which a plain
+# workstation install cannot assume. The sha256 checksum still guards
+# transit integrity against this exact release.
+#
+# Usage: install-plumber.sh [bin-dir]        (default: /usr/local/bin, else ~/.local/bin)
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=getplumber/plumber extractVersion=^v(?<version>.*)$
+PLUMBER_VERSION="0.4.39"
+
+# shellcheck source=scripts/lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
+
+BIN_DIR="${1:-$(oa_bin_dir)}"
+SUDO="$(oa_sudo_for "$BIN_DIR")"
+
+if command -v plumber >/dev/null 2>&1 &&
+  plumber version 2>/dev/null | grep -qE "(^|[^0-9.])${PLUMBER_VERSION//./\\.}([^0-9.]|\$)"; then
+  echo "plumber v${PLUMBER_VERSION} already installed"
+  exit 0
+fi
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) asset="plumber-linux-amd64" ;;
+  Linux-aarch64 | Linux-arm64) asset="plumber-linux-arm64" ;;
+  Darwin-x86_64) asset="plumber-darwin-amd64" ;;
+  Darwin-arm64) asset="plumber-darwin-arm64" ;;
+  *) echo "✗ no published plumber binary for $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+base="https://github.com/getplumber/plumber/releases/download/v${PLUMBER_VERSION}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL -o "$tmp/$asset" "$base/$asset"
+curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"
+# --ignore-missing: the file lists every platform, and without it the check fails
+# on the ones we did not download — which reads like a bad binary.
+(cd "$tmp" && sha256sum -c checksums.txt --ignore-missing)
+
+mkdir -p "$BIN_DIR" 2>/dev/null || $SUDO mkdir -p "$BIN_DIR"
+$SUDO install -m 0755 "$tmp/$asset" "$BIN_DIR/plumber"
+echo "installed plumber v${PLUMBER_VERSION} → $BIN_DIR/plumber"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -391,6 +391,13 @@ if ! check_cmd gitleaks; then
     "$(dirname "${BASH_SOURCE[0]}")/internal/install-gitleaks.sh"
 fi
 
+# 5e. plumber — `task pipeline-audit` runs it directly; before this it was the
+# CI policy scanner nobody could see the verdict of without fetching the
+# binary by hand (#52).
+if ! check_cmd plumber; then
+    "$(dirname "${BASH_SOURCE[0]}")/internal/install-plumber.sh"
+fi
+
 # 6. Check Talos image + backup tools (used by `task image-build` and the S3 backups)
 MISSING_IMG_TOOLS=0
 for t in curl zstd qemu-img aws gpg jq; do


### PR DESCRIPTION
## Summary

Every other checker here has a task (`task security`, `task lint`, `task test-scripts`) except plumber, the CI policy scanner that gates unpinned actions, dangerous triggers and over-broad permissions in every workflow file ([#52](https://github.com/dis-bzh/OpenAether-infra/issues/52)). Before this, the only way to see its verdict before pushing was to fetch the binary by hand.

- `scripts/internal/install-plumber.sh` (new): pinned, checksum-verified, same shape as `install-gitleaks.sh`. Installs the plain per-platform binary plumber ships (no tarball, unlike gitleaks).
- `task pipeline-audit` (new): runs `plumber analyze --output plumber-report.json` — the same command the "Pipeline audit" CI job runs.
- Wired into `task security`, **last**: without `GH_TOKEN` the run legitimately exits 3 ("incomplete data" — branch protection cannot be evaluated), the exact token-scope limitation `security.yml`'s own comments already document for the CI job. Placed last so it doesn't swallow the checks above it (trivy, checkov, gitleaks) that CAN succeed offline.
- `scripts/dev/check-version-drift.sh`: new comparison between `install-plumber.sh`'s pin and `security.yml`'s action pin, same pattern as the existing gitleaks comparison.
- `plumber-report.json` gitignored (a local run's own output, like `clea-state.json`).

## What "wired into task security" actually looks like locally

Without a token (this session's sandbox has none):

```
$ task pipeline-audit
...
⚠ Data collection was incomplete — results may be partial:
  • branch protection could not be fetched; branch controls were not evaluated
Status: INCOMPLETE — data collection failed
task: Failed to run task "pipeline-audit": exit status 3
```

This is plumber's own documented behavior (matches `security.yml`'s "Deliberately no `.plumber.yaml`" comment block), not a defect in this PR — a developer with `GH_TOKEN` set gets a complete local run; one without gets an honest "incomplete" instead of nothing at all, which is strictly more than existed before.

## Test plan

- [x] `task lint` — green (plumber pin now covered by `check-version-drift.sh` and the anchor-coverage report)
- [x] `task test-scripts` — green (full suite; no new harness needed — this is an installer + task wiring, no new logic to unit-test)
- [x] `task test` — green
- [x] `task render-check` — green
- [x] `task validate ROOT=cluster` / `ROOT=talos-image` — green
- [x] checkov (16/16) and gitleaks (`no leaks found`) — green, run individually (`trivy` still not reachable from this sandbox — pre-existing, unrelated gap noted in every prior PR)
- [x] `task pipeline-audit` reproduced end to end against this real repo: downloads the pinned binary, verifies its checksum, runs `plumber analyze`, writes `plumber-report.json`, and reports the exact degraded/incomplete verdict `security.yml`'s comments already predict for an unauthenticated run

Mocked rung, as the issue asks for — dev tooling, no provider/cluster code touched.

## What was deliberately left out

The build-provenance (sigstore/SLSA) attestation the GitHub Action also verifies — that needs the `gh` CLI, which a plain workstation install cannot assume. The sha256 checksum (verified against the release's own `checksums.txt`) still guards transit integrity for this exact pinned release; noted explicitly in `install-plumber.sh`'s own header comment.

Closes #52


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_