### PR TITLE
fix(dev): stop citing the deleted backlog doc, add a checker so it stays fixed

### DIFF
--- a/.deadreferencesignore
+++ b/.deadreferencesignore
@@ -1,0 +1,23 @@
+# Paths check-dead-references.sh (#118) has decided are not stale references,
+# each scoped to one file:candidate pair — narrower than .languageignore's
+# whole-file scope, because both files below also cite real paths that must
+# stay checked. A pair here needs a reason above it — an entry with no reason
+# is a silenced defect, which is what this file exists NOT to become.
+
+# CLAUDE.md narrates docs/backlog.md's own removal in the past tense, right
+# next to "Il est supprimé" — a correct sentence about a file that no longer
+# exists, not a stale reference. CLAUDE.md is off-limits to autonomous edits
+# (project instructions), so this narrows scope instead of rewriting it.
+CLAUDE.md:docs/backlog.md
+
+# scripts/clea/README.md's [lane] example is illustrative config-schema
+# documentation for a portable tool meant to be copied into OTHER projects
+# ("Copy scripts/clea/, write a clea.toml..."). The path is an example value,
+# not a claim about this repository — this repo's own clea.toml points at
+# scripts/bootstrap/render-bootstrap-manifests.sh instead.
+scripts/clea/README.md:./scripts/render.sh
+
+# "Their docs/proxy.md measures it" — same sentence names "their #76", and
+# "their" is stephrobert/feint (the emulator this script drives), not this
+# repository. Verified present at stephrobert/feint@docs/proxy.md.
+scripts/dev/feint.sh:docs/proxy.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,21 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Added
 
+- **`check-dead-references.sh`, wired into `task lint` (#118).** A path stops
+  resolving and nothing notices — read once in a comment, or read (and
+  copy-pasted) on every run in a printed string. lychee finds none of this:
+  this repository writes commands as bare paths inside fences, not Markdown
+  links, and lychee reads neither comments nor printed strings. Scope is
+  deliberately PATHS only, inside a fenced block, a backtick span, a code
+  comment, or a printed string — `task [a-z-]+` alone gave ~45 false positives
+  ("task is", "task and", "task was") against real ones while scoping this.
+  First run on this tree found two real stale references, both citing the
+  now-deleted docs/backlog.md: `scripts/setup.sh` and
+  `scripts/ops/verify-provider-clean.py`, now fixed.
+  `.deadreferencesignore` allowlists what a regex genuinely cannot see (a doc
+  narrating its own removed file's name, an example value in a portable
+  tool's own README, a cross-repo path stated bare) — scoped per
+  file:candidate pair, never a whole file, and each entry carries a reason.
 - **`task purge-orphans PROVIDER=… [APPLY=1]`.** `docs/release-checklist.md`
   already told the reader to run it; it did not exist. The scripts it wraps are
   the last sentence between a failed teardown and a bill, and they were reachable

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -156,6 +156,9 @@ tasks:
       # A script nobody invokes is the failure mode task test-scripts exists
       # for, one level up: the check does the work, it is simply never asked.
       - ./scripts/dev/check-script-reachability.sh
+      # A path stops resolving and nothing notices — in a comment, read once,
+      # or a printed string, read (and copy-pasted) on every run (#118).
+      - ./scripts/dev/check-dead-references.sh
 
   fmt:
     desc: Format OpenTofu code
@@ -367,6 +370,11 @@ tasks:
       # check-script-reachability.sh actually flags an unreferenced script
       # and clears once it's wired in, not just that today's tree is clean.
       - ./scripts/dev/test-script-reachability.sh
+      # Same isolation, for check-dead-references.sh (#118): proves fences,
+      # backtick spans, comments and printed strings are checked, plain prose
+      # and fixture-writing redirects are not, and .deadreferencesignore
+      # scopes to the one file:candidate pair it names.
+      - ./scripts/dev/test-dead-references.sh
       # A --set typo reaches the cluster silently past every other gate;
       # this proves the effective-config reader (and check-cilium-parity.py's
       # missing-key guard) actually catch it, offline.

--- a/scripts/dev/check-dead-references.sh
+++ b/scripts/dev/check-dead-references.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Nothing notices a path that stopped resolving — in a README, in a code
+# comment, or worst, in a string a script prints at runtime. A comment is
+# read once; a printed line is read on every run, then copy-pasted and
+# answered "No such file or directory" (#118).
+#
+# lychee finds none of this: this repository writes commands as bare paths
+# inside fences, not as Markdown links, and lychee reads neither code
+# comments nor printed strings.
+#
+# Scope is deliberately narrow, the same lesson check-language.sh already
+# paid for: a naive regex over ALL prose is unusable. `task [a-z-]+` alone
+# gave ~45 false positives ("task is", "task and", "task was") against 3
+# real ones — measured while scoping this file, `task` names hits a second,
+# harder-to-bound ambiguity even restricted to comments and printed strings:
+# `variables.tf` and `outputs.tf` both use "task infra" / "task
+# register-spoke" as informal shorthand for a FUTURE, not-yet-built flow —
+# flagging those would be wrong in the other direction, calling a design
+# note a stale reference. So: PATHS only, and only inside a fenced code
+# block, an inline `backtick span`, a code comment, or a printed string —
+# never a plain sentence, and never a line that WRITES a path rather than
+# reading it (a test fixture's own `printf ... >"$TMP/repo/foo.sh"`).
+#
+# .deadreferencesignore, if present, lists file:candidate pairs decided to be
+# not-stale for a reason that regexes cannot see (a doc narrating a file's own
+# removal, an illustrative example in a portable tool's own README) — scoped
+# per-pair, not per-file, because both files it currently exempts also cite
+# real paths that must stay checked. Same allowlist-not-silencer contract as
+# .languageignore: an entry needs a reason above it.
+#
+# Usage: check-dead-references.sh [root-dir]   (default: repo root)
+set -uo pipefail
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$ROOT" || exit 1
+
+MISSING=0
+
+# This checker and its test necessarily contain the very patterns they hunt —
+# example paths in comments, and (in the test) synthetic fixture literals that
+# trip the HCL heredoc-body scan by simply containing the string
+# `description = <<-EOT`. Same self-exemption check-language.sh takes on
+# itself, for the same reason: scanning either file finds only its own
+# examples, never a stale reference in the rest of the tree.
+self() { case "$1" in scripts/dev/check-dead-references.sh|scripts/dev/test-dead-references.sh) return 0 ;; esac; return 1; }
+
+ignored() { # <file> <candidate>
+  local file="$1" cand="$2" pattern
+  [ -f "$ROOT/.deadreferencesignore" ] || return 1
+  while IFS= read -r pattern; do
+    case "$pattern" in ''|\#*) continue ;; esac
+    [ "$pattern" = "$file:$cand" ] && return 0
+  done < "$ROOT/.deadreferencesignore"
+  return 1
+}
+
+report() { # <file> <line> <reason>
+  echo "✗ $1:$2: $3"
+  MISSING=$((MISSING + 1))
+}
+
+# Repo-root-relative when it starts with a known top-level directory — that
+# is how every citation in this repository is written. ${path.module}/...
+# (Terraform's own way of saying "this file's directory") resolves relative
+# to the FILE instead — the one true-but-relative path the issue names by
+# example, and the reason this cannot just be "resolve everything from the
+# repo root". `apps/` is a SEPARATE repository (OpenAether-apps, per
+# CLAUDE.md) — never present in this checkout, so a reference into it is out
+# of scope here, not a defect this check can see. A path this checkout would
+# gitignore (envs/*.tfvars, kubeconfigs, ...) is meant to be created by the
+# reader, not to exist yet — checked, not assumed absent.
+resolve_path() { # <file> <candidate> -> 0 ok, 1 missing, 2 out of scope
+  local file="$1" cand="$2" rel
+  case "$cand" in
+    '${path.module}'/*)
+      rel="${cand#'${path.module}'/}"
+      [ -e "$(dirname "$file")/$rel" ] && return 0 || return 1
+      ;;
+    apps/*) return 2 ;;
+    # OpenAether-apps' own profile picker (README.md: "a modular pick from
+    # OpenAether-apps (scripts/pick.py)") — cited bare, without an apps/
+    # prefix, because it is invoked from that repo's own root. It does not
+    # and cannot exist in this checkout.
+    scripts/pick.py) return 2 ;;
+    ./*) cand="${cand#./}" ;;
+  esac
+  case "$cand" in
+    scripts/* | infrastructure/* | docs/* | .github/*)
+      [ -e "$cand" ] && return 0
+      git check-ignore -q "$cand" 2>/dev/null && return 2
+      return 1
+      ;;
+    *)
+      [ -e "$(dirname "$file")/$cand" ] && return 0 || return 1
+      ;;
+  esac
+}
+
+check_candidates() { # <file> <line-number> <text>
+  local file="$1" line="$2" text="$3" m rc
+  # A path: a token under a known root, ending in a plausible extension —
+  # bounded so it cannot swallow trailing prose ("scripts/foo.sh and the").
+  # A template placeholder ({{...}}, ${VAR}, <name>) is not a literal
+  # reference and is excluded, ${path.module} aside (handled above).
+  while read -r m; do
+    [ -n "$m" ] || continue
+    case "$m" in *'{{'*|'<'*|*'$'*'{'*) [ "${m#'${path.module}'}" = "$m" ] && continue ;; esac
+    ignored "$file" "$m" && continue
+    resolve_path "$file" "$m"; rc=$?
+    [ "$rc" -eq 1 ] && report "$file" "$line" "no such path: $m"
+  done < <(grep -oE '(\./)?(\$\{path\.module\}/)?(scripts|infrastructure|docs|apps|\.github)/[A-Za-z0-9_./-]+\.[A-Za-z0-9]+' <<<"$text")
+}
+
+# --- Markdown: fenced blocks and inline `backtick spans`, never plain prose --
+scan_markdown() {
+  local f
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    while IFS=: read -r ln rest; do
+      check_candidates "$f" "$ln" "$rest"
+    done < <(awk '
+      /^[[:space:]]*```/ { fence = !fence; next }
+      fence { print NR ":" $0; next }
+      {
+        line = $0
+        while (match(line, /`[^`]+`/)) {
+          rest = substr(line, RSTART + RLENGTH)
+          # `text`](https://...) is Markdown LINK TEXT for an external URL —
+          # the href is the actual reference, the backtick span just happens
+          # to look like a path (docs/emulated-cloud.md linking to feint
+          # upstream docs/limits.md). Not a claim about this repository.
+          if (rest !~ /^\]\(https?:\/\//) {
+            print NR ":" substr(line, RSTART + 1, RLENGTH - 2)
+          }
+          line = rest
+        }
+      }' "$ROOT/$f")
+  done < <(git ls-files '*.md')
+}
+
+# --- Code: comment lines and printed strings, the same prose check-language.sh
+# already reads (heredoc `description = <<-EOT` bodies included) — minus any
+# line that WRITES a path (a redirect target) rather than stating one; that
+# is a test fixture building its own throwaway tree, not a claim about this
+# repository's. ------------------------------------------------------------
+scan_code() {
+  local f
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    self "$f" && continue
+    while IFS=: read -r ln rest; do
+      check_candidates "$f" "$ln" "$rest"
+    done < <(awk '
+      /description[[:space:]]*=[[:space:]]*<<-?[A-Za-z_]+/ {
+        match($0, /<<-?[A-Za-z_]+/)
+        term = substr($0, RSTART, RLENGTH)
+        sub(/^<<-?/, "", term)
+        in_doc = 1
+      }
+      in_doc && $0 ~ ("^[[:space:]]*" term "[[:space:]]*$") { in_doc = 0; next }
+      {
+        comment = ($0 ~ /^[[:space:]]*(#|\/\/|\*)/)
+        printed = (!comment && $0 ~ /((echo|print|printf|puts)[[:space:](]|(help|description)=)/)
+        if (!comment && !printed && !in_doc) next
+        if ($0 ~ /[^=]>>?[[:space:]]*["$'"'"'\/]/) next
+        print NR ":" $0
+      }' "$ROOT/$f")
+  done < <(git ls-files '*.tf' '*.tftpl' '*.sh' '*.py')
+}
+
+scan_markdown
+scan_code
+
+if [ "$MISSING" -gt 0 ]; then
+  echo
+  echo "✗ ${MISSING} reference(s) to a path that does not resolve." >&2
+  echo "  A comment is read once; a printed line is read on every run and then" >&2
+  echo "  copy-pasted. Fix the reference, or delete the line if it is stale." >&2
+  exit 1
+fi
+echo "OK — every path referenced in fenced code, backtick spans, comments and printed strings resolves."

--- a/scripts/dev/test-dead-references.sh
+++ b/scripts/dev/test-dead-references.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Unit tests for #118: check-dead-references.sh, against an isolated,
+# throwaway git repo — never this one, so the fixtures cannot collide with a
+# real path and the test needs no network.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT/scripts/dev/check-dead-references.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+fixture_repo() { # sets up $TMP/repo, a fresh throwaway git repo
+  rm -rf "$TMP/repo"
+  mkdir -p "$TMP/repo/scripts" "$TMP/repo/docs"
+  git -C "$TMP/repo" init -q
+  git -C "$TMP/repo" config user.email test@example.invalid
+  git -C "$TMP/repo" config user.name test
+}
+commit() { git -C "$TMP/repo" add -A && git -C "$TMP/repo" commit -q -m fixture; }
+
+echo "=== Markdown: a fenced code block citing a missing path is flagged ==="
+
+fixture_repo
+printf '# doc\n\n```\nscripts/gone.sh --help\n```\n' >"$TMP/repo/docs/a.md"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "a missing path inside a fence fails (rc=${rc})" ||
+  bad "a missing path inside a fence passed"
+grep -q 'scripts/gone.sh' <<<"$out" && ok "the missing path is named" ||
+  bad "the missing path is never named: ${out}"
+
+echo
+echo "=== Markdown: an inline backtick span citing a missing path is flagged ==="
+
+fixture_repo
+printf 'Run `scripts/gone.sh` first.\n' >"$TMP/repo/docs/a.md"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "a missing path in a backtick span fails (rc=${rc})" ||
+  bad "a missing path in a backtick span passed"
+
+echo
+echo "=== Markdown: plain prose is never checked, even path-shaped ==="
+
+fixture_repo
+printf 'scripts/gone.sh used to exist, with no backticks or fence around it.\n' \
+  >"$TMP/repo/docs/a.md"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "plain prose outside fences/backticks is not checked (rc=0)" ||
+  bad "plain prose was checked — false positive: ${out}"
+
+echo
+echo "=== Markdown: link text before an external URL is not a local claim ==="
+
+fixture_repo
+printf 'See [\x60docs/gone.md\x60](https://example.invalid/docs/gone.md) upstream.\n' \
+  >"$TMP/repo/docs/a.md"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "backtick text that is an external link's label is not checked (rc=0)" ||
+  bad "an external link's own label was flagged — false positive: ${out}"
+
+echo
+echo "=== Code: a comment line citing a missing path is flagged, code itself is not ==="
+
+fixture_repo
+printf '#!/usr/bin/env bash\n# see scripts/gone.sh for details\nscripts/gone.sh --run\n' \
+  >"$TMP/repo/scripts/a.sh"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "a missing path in a comment fails (rc=${rc})" ||
+  bad "a missing path in a comment passed"
+[ "$(grep -c 'scripts/gone.sh' <<<"$out")" -eq 1 ] && ok "only the comment line is reported, not the code line" ||
+  bad "reported more than the one comment line: ${out}"
+
+echo
+echo "=== Code: a printed string citing a missing path is flagged ==="
+
+fixture_repo
+printf '#!/usr/bin/env bash\necho "read scripts/gone.sh first"\n' >"$TMP/repo/scripts/a.sh"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "a missing path in a printed string fails (rc=${rc})" ||
+  bad "a missing path in a printed string passed"
+
+echo
+echo "=== Code: an HCL heredoc description body is checked ==="
+
+fixture_repo
+cat >"$TMP/repo/scripts/a.tf" <<'EOF'
+variable "x" {
+  description = <<-EOT
+    See docs/gone.md for details.
+  EOT
+}
+EOF
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "a missing path in an HCL description heredoc fails (rc=${rc})" ||
+  bad "a missing path in a description heredoc passed"
+
+echo
+echo "=== Code: a line WRITING a path (redirect) is a fixture, not a claim ==="
+
+fixture_repo
+printf '#!/usr/bin/env bash\n# fixture setup\nprintf x >"$TMP/repo/scripts/gone.sh"\n' \
+  >"$TMP/repo/scripts/a.sh"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "a redirect target is not checked (rc=0)" ||
+  bad "a test fixture's own redirect target was flagged — false positive: ${out}"
+
+echo
+echo "=== \${path.module}/... resolves relative to the citing file, not repo root ==="
+
+fixture_repo
+mkdir -p "$TMP/repo/scripts/sub"
+printf 'x' >"$TMP/repo/scripts/sub/here.sh"
+printf '#!/usr/bin/env bash\n# see ${path.module}/here.sh\n' >"$TMP/repo/scripts/sub/a.sh"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "a \${path.module} reference resolves next to its own file (rc=0)" ||
+  bad "a real \${path.module} sibling was reported missing: ${out}"
+
+echo
+echo "=== apps/... is a separate repository, always out of scope ==="
+
+fixture_repo
+printf '#!/usr/bin/env bash\n# see apps/base/does/not/exist.yaml\n' >"$TMP/repo/scripts/a.sh"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "an apps/ path is never checked, even absent (rc=0)" ||
+  bad "an apps/ path was checked against this checkout: ${out}"
+
+echo
+echo "=== a gitignored path is expected to not exist yet, not a defect ==="
+
+fixture_repo
+printf 'infrastructure/opentofu/cluster/envs/*.tfvars\n' >"$TMP/repo/.gitignore"
+printf '#!/usr/bin/env bash\n# copy infrastructure/opentofu/cluster/envs/real.tfvars\n' \
+  >"$TMP/repo/scripts/a.sh"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "a gitignored path is not reported missing (rc=0)" ||
+  bad "a gitignored, not-yet-created path was flagged — false positive: ${out}"
+
+echo
+echo "=== .deadreferencesignore suppresses one file:candidate pair, not the path everywhere ==="
+
+fixture_repo
+printf '#!/usr/bin/env bash\n# see docs/gone.md\n' >"$TMP/repo/scripts/a.sh"
+printf '#!/usr/bin/env bash\n# see docs/gone.md\n' >"$TMP/repo/scripts/b.sh"
+printf '# reason\nscripts/a.sh:docs/gone.md\n' >"$TMP/repo/.deadreferencesignore"
+commit
+out="$("$CHECKER" "$TMP/repo" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "the un-listed file:candidate pair still fails (rc=${rc})" ||
+  bad "the ignore file silenced a file it does not name"
+grep -q 'scripts/a.sh' <<<"$out" && bad "the ignored pair was still reported: ${out}" ||
+  ok "the ignored pair (scripts/a.sh) is not reported"
+grep -q 'scripts/b.sh' <<<"$out" && ok "the same candidate in another file is still reported" ||
+  bad "scripts/b.sh's own citation was silenced too — over-broad ignore: ${out}"
+
+echo
+echo "=== proof against reality: this repository's own tree is clean today ==="
+
+out="$("$CHECKER" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "every reference in THIS repo resolves (rc=0)" ||
+  bad "this repository has a dead reference the checker caught: ${out}"
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/ops/verify-provider-clean.py
+++ b/scripts/ops/verify-provider-clean.py
@@ -155,8 +155,8 @@ CHECKS = {"openstack": openstack_leftovers, "outscale": outscale_leftovers}
 
 # What each check actually enumerates, and what it does not. Printed on success
 # because a teardown proof that says NOTHING when the account is clean looks
-# exactly like one that did not run — `docs/backlog.md` lists that shape twice,
-# once for a purge script and once for "an empty server list is not an empty
+# exactly like one that did not run — that shape has bitten twice already:
+# once for a purge script, and once for "an empty server list is not an empty
 # account", where seven block volumes billed for three days behind a clean
 # instance list.
 SCOPE = {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -51,7 +51,7 @@ HELM_VERSION="4.2.3"
 #
 # Only the tools this file PINS get the second argument. For the others there is
 # no version to compare against, and inventing one would be a check that cannot
-# fail; pinning them is a separate decision, in docs/backlog.md.
+# fail; pinning them is a separate decision, not made here.
 check_cmd() {
     local tool="$1" want="${2:-}" version
     if ! command -v "$tool" &> /dev/null; then


### PR DESCRIPTION
## Summary

`scripts/setup.sh` and `scripts/ops/verify-provider-clean.py` both still
pointed at `docs/backlog.md`, deleted when it was split into
`docs/status.md` and issues. Nothing in this repo catches that class of
defect: lychee reads Markdown links, not the bare paths this repo writes
inside fences, code comments, or printed strings — so a path can stop
resolving and nothing notices until it's copy-pasted and answered "No
such file or directory".

`check-dead-references.sh`, wired into `task lint`, closes that gap:
fenced code, inline backtick spans, comments, and printed strings only —
never plain prose, and never a line that *writes* a path (a test
fixture's own redirect target) rather than citing one.

## Scope cut from #118 — read before merging

#118 also asks for `task <name>` detection, scoped to the same
fence/backtick/comment/printed-string contexts as paths. I tried that
and it does not survive contact with this tree even inside that
narrowed scope: `variable`/`output` descriptions in
`infrastructure/opentofu/cluster/{variables,outputs}.tf` use "task
infra" / "task register-spoke" / "task failover" as forward-looking
shorthand for not-yet-built commands (flagging those calls a design note
a stale reference — wrong in the other direction), and plain-English
"task is" / "task and" / "task must" still turns up inside real
comments elsewhere. Measured on this tree: real path defects were 3 out
of 85 raw hits before narrowing scope; task-name detection alone was
never going to clear that bar cleanly. Shipping it half-right defeats
the point of a gate people are supposed to trust, so I left it out
rather than land it broken. **This PR does not close #118** — I've left
a comment there with what's left, so it stays open for that scope
specifically rather than being reopened later.

## `.deadreferencesignore`

A handful of citations look identical to a stale path syntactically but
aren't, for reasons a regex can't see:

- `CLAUDE.md` narrates `docs/backlog.md`'s own removal, in the past
  tense, right next to "Il est supprimé" — correct, not stale. (`CLAUDE.md`
  is off-limits to autonomous edits, so this narrows scope instead of
  rewriting it.)
- `scripts/clea/README.md`'s example `[lane]` config is documentation for
  a portable tool meant to be copied into *other* projects — the path in
  it is an example value, not a claim about this repository.
- `scripts/dev/feint.sh` says "Their docs/proxy.md measures it", in the
  same sentence as "their #76" — "their" is `stephrobert/feint`, not this
  repository. Verified present at `stephrobert/feint@docs/proxy.md`.

Scoped per `file:candidate` pair, never a whole file — two of these three
files also cite real paths that must stay checked, so a whole-file
exemption would have hidden a real future defect. Same
allowlist-not-silencer contract as `.languageignore`: every entry carries
a reason.

Two more false-positive classes turned out to be fixable in the checker
itself rather than needing an allowlist entry, so they are: a backtick
span that is Markdown *link text* pointing at an external URL (`docs/emulated-cloud.md`
linking upstream to feint's own `docs/limits.md`), and
`scripts/pick.py`, which lives in `OpenAether-apps` and is cited bare
from this repo's own docs.

## Test plan

- [x] `task lint` — green, including the new check on this tree
- [x] `task test-scripts` — green, `test-dead-references.sh` included (17
  assertions against an isolated throwaway repo)
- [x] Mutation-tested two of those assertions by hand: reverted the
  external-link-text fix and the `.deadreferencesignore` per-pair scoping
  in turn, confirmed the matching test goes red, restored, confirmed
  green again
- [x] `task validate` (cluster root) — green
- [x] `task render-check` — green
- [x] `checkov` (16/16) and `gitleaks` (`no leaks found`) — green
- [ ] `trivy` — not installed in this sandbox (pre-existing gap, unrelated
  to this change)

Mocked rung — doc/tooling-only change, no provider or cluster code
touched.

Refs #118


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_