### PR TITLE
fix(ops): 18 ruff findings in scripts nothing ever read

### DIFF
--- a/scripts/clea/clea.py
+++ b/scripts/clea/clea.py
@@ -48,7 +48,7 @@ try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:  # pragma: no cover - only on very old interpreters
     print("clea needs Python 3.11 or newer (tomllib)", file=sys.stderr)
-    raise SystemExit(1)
+    raise SystemExit(1) from None
 
 USER_AGENT = "clea/1 (+https://github.com/dis-bzh/OpenAether-infra)"
 SKIP_DIRS = {".git", "node_modules", ".terraform", ".terraform-validate", "vendor"}
@@ -378,7 +378,7 @@ def renovate_coverage(root: Path, config: str, exclude: list[str]) -> set[tuple[
                 try:
                     rx = re.compile(pattern, re.MULTILINE)
                 except re.error as exc:
-                    raise CleaError(f"{config}: unusable matchString {match_string!r}: {exc}")
+                    raise CleaError(f"{config}: unusable matchString {match_string!r}: {exc}") from exc
                 for m in rx.finditer(text):
                     covered.add((rel, text[: m.start()].count("\n") + 1))
     return covered
@@ -496,7 +496,7 @@ def http_get(url: str, token: str | None = None, accept: str | None = None) -> b
         body = ""
         try:
             body = exc.read().decode("utf-8", "replace")[:200]
-        except Exception:  # pragma: no cover - the status alone is enough
+        except OSError:  # pragma: no cover - the status alone is enough
             pass
         if exc.code in (401, 403, 429):
             # Never let this read as "no new version". Unauthenticated GitHub
@@ -612,8 +612,10 @@ def latest_terraform_provider(dep: str, _token: str | None,
     if not versions:
         raise CleaError(f"terraform-provider {dep}: no version at {base}")
     tag = max(versions, key=version_key)
+    namespace = dep.split("/", 1)[0]
+    name = dep.rsplit("/", 1)[-1]
     return {"tag": tag, "released_at": None,
-            "notes_url": f"https://github.com/{dep.split('/')[0]}/terraform-provider-{dep.split('/')[-1]}/releases/tag/v{tag}"}
+            "notes_url": f"https://github.com/{namespace}/terraform-provider-{name}/releases/tag/v{tag}"}
 
 
 def latest_url_text(dep: str, _token: str | None, url: str | None = None,

--- a/scripts/ops/check-alert-metrics.py
+++ b/scripts/ops/check-alert-metrics.py
@@ -112,7 +112,7 @@ def query(session_url: str, expr: str) -> int:
     try:
         with urllib.request.urlopen(url, timeout=20) as fh:
             return len(json.load(fh)["data"]["result"])
-    except Exception:
+    except (urllib.error.URLError, TimeoutError, ValueError, KeyError):
         return -1
 
 

--- a/scripts/ops/purge-orphans/outscale.py
+++ b/scripts/ops/purge-orphans/outscale.py
@@ -5,7 +5,13 @@ security groups → subnets → net. Also REPORTS (never deletes) leftover
 snapshots — see the ARTIFACTS block below. Images are deliberately NOT
 enumerated here yet; see that block for why.
 Usage: purge-orphans-osc.py [--apply]"""
-import os, sys, json, hmac, hashlib, datetime, urllib.request
+import datetime
+import hashlib
+import hmac
+import json
+import os
+import sys
+import urllib.request
 
 APPLY = '--apply' in sys.argv
 AK, SK = os.environ['OUTSCALE_ACCESS_KEY_ID'], os.environ['OUTSCALE_SECRET_KEY']
@@ -70,7 +76,8 @@ def do(action, payload, label):
     global TOTAL, FAILED
     TOTAL += 1
     if not APPLY:
-        print("  [dry-run]", label); return
+        print("  [dry-run]", label)
+        return
     r = call(action, payload)
     if 'error' in r:
         FAILED += 1

--- a/scripts/ops/purge-orphans/ovh.py
+++ b/scripts/ops/purge-orphans/ovh.py
@@ -2,7 +2,10 @@
 """Purges ALL OVH project resources (servers, LBs, FIPs, routers, networks,
 security groups) — whole-account, no name filtering. See README.md.
 Usage: purge-orphans-ovh.py [--apply]   (dry-run by default)"""
-import os, sys, json, urllib.request
+import json
+import os
+import sys
+import urllib.request
 
 APPLY = '--apply' in sys.argv
 base = os.environ['OS_AUTH_URL'].rstrip('/')
@@ -44,7 +47,7 @@ def listing(url, key):
         UNREACHABLE += 1
         print(f"  ⚠ unreachable: {url.split('?')[0]} (HTTP {e.code})")
         return []
-    except Exception as e:
+    except (urllib.error.URLError, TimeoutError) as e:
         UNREACHABLE += 1
         print(f"  ⚠ unreachable: {url.split('?')[0]} ({str(e)[:60]})")
         return []
@@ -70,7 +73,7 @@ def delete(u, label):
     try:
         urllib.request.urlopen(urllib.request.Request(u, headers=H, method='DELETE'), timeout=90)
         print("  ✓ deleted:", label)
-    except Exception as e:
+    except (urllib.error.URLError, TimeoutError) as e:
         FAILED += 1
         print("  ⚠ failed:", label, str(e)[:80])
 
@@ -105,7 +108,7 @@ for r in listing(net + '/v2.0/routers', 'routers'):
                         net + f"/v2.0/routers/{r['id']}/remove_router_interface",
                         data=body, headers=H, method='PUT'), timeout=60)
                     print("  ✓ interface detached:", p['id'][:8])
-                except Exception as e:
+                except (urllib.error.URLError, TimeoutError) as e:
                     print("  ⚠ detach:", str(e)[:60])
             else:
                 print("  [dry-run] detach interface", p['id'][:8])

--- a/scripts/ops/purge-orphans/scaleway.py
+++ b/scripts/ops/purge-orphans/scaleway.py
@@ -50,7 +50,7 @@ def listing(url, key):
         UNREACHABLE += 1
         print(f"  ⚠ unreachable: {url.split('?')[0]} (HTTP {e.code})")
         return []
-    except Exception as e:
+    except (urllib.error.URLError, TimeoutError) as e:
         UNREACHABLE += 1
         print(f"  ⚠ unreachable: {url.split('?')[0]} ({str(e)[:60]})")
         return []
@@ -71,7 +71,7 @@ def act(label, fn):
     try:
         fn()
         print("  ✓ deleted:", label)
-    except Exception as e:
+    except (urllib.error.URLError, TimeoutError, ValueError) as e:
         FAILED += 1
         print("  ⚠ failed:", label, str(e)[:80])
 
@@ -82,14 +82,14 @@ for z in ZONES:
     for s in listing(f'{API}/instance/v1/zones/{z}/servers?project={PROJECT}', 'servers'):
         total += 1
         act(f"[{z}] server {s['name']}",
-            lambda i=s['id']: call(f'{API}/instance/v1/zones/{z}/servers/{i}/action',
+            lambda i=s['id'], z=z: call(f'{API}/instance/v1/zones/{z}/servers/{i}/action',
                                    'POST', {'action': 'terminate'}))
 
     # 2. load balancers — release_ip so the flexible IP does not survive.
     for lb in listing(f'{API}/lb/v1/zones/{z}/lbs?project_id={PROJECT}', 'lbs'):
         total += 1
         act(f"[{z}] LB {lb['name']}",
-            lambda i=lb['id']: call(f'{API}/lb/v1/zones/{z}/lbs/{i}?release_ip=true', 'DELETE'))
+            lambda i=lb['id'], z=z: call(f'{API}/lb/v1/zones/{z}/lbs/{i}?release_ip=true', 'DELETE'))
 
     # 3. flexible IPs left unattached.
     for ip in listing(f'{API}/instance/v1/zones/{z}/ips?project={PROJECT}', 'ips'):
@@ -97,7 +97,7 @@ for z in ZONES:
             continue
         total += 1
         act(f"[{z}] IP {ip['address']}",
-            lambda i=ip['id']: call(f'{API}/instance/v1/zones/{z}/ips/{i}', 'DELETE'))
+            lambda i=ip['id'], z=z: call(f'{API}/instance/v1/zones/{z}/ips/{i}', 'DELETE'))
 
     # 4. block volumes — the leak this script was written for. `references`
     #    is empty once nothing is attached; a volume in use is left alone.
@@ -106,7 +106,7 @@ for z in ZONES:
             continue
         total += 1
         act(f"[{z}] volume {v['name']} ({v['size'] // 10**9}GB)",
-            lambda i=v['id']: call(f'{API}/block/v1alpha1/zones/{z}/volumes/{i}', 'DELETE'))
+            lambda i=v['id'], z=z: call(f'{API}/block/v1alpha1/zones/{z}/volumes/{i}', 'DELETE'))
 
 # 5. private networks — regional, and only removable once the NICs are gone.
 for pn in listing(f'{API}/vpc/v2/regions/{REGION}/private-networks?project_id={PROJECT}',


### PR DESCRIPTION
## Summary

`task lint` runs `shellcheck -S error` over every tracked `.sh`; the 2558
lines of Python — including scripts that delete cloud resources — were
read by nothing (#115). Ruff's narrow selection the issue specifies
(`F,B023,B904,E401,E702,PLC0207,BLE001`) found 18 findings on this tree,
matching the issue's own count exactly. All 18 fixed here:

- **`purge-orphans/scaleway.py`: `B023` ×4** — the zone loop variable
  (`z`) wasn't bound in the deletion lambdas, only the resource id was
  (`lambda i=s['id']: ...`). `act()` happens to call `fn()` immediately
  today, so this was latent rather than live — but that's exactly what a
  closure bug is, right up until someone refactors the caller to defer
  calls, in the script that's the last sentence between a failed teardown
  and a bill. Fixed the same way the id already was: `lambda i=s['id'],
  z=z: ...`.
- **`ovh.py` / `scaleway.py` / `check-alert-metrics.py`: `BLE001` ×7** —
  `except Exception` narrowed to what each call site can actually raise
  (`urllib.error.URLError`, `TimeoutError`, and — where the caller also
  parses JSON — `ValueError`/`KeyError`). This is a real behavior change,
  not a suppression: a genuine bug in the script (a typo'd dict key, say)
  now crashes instead of being silently reported as "delete failed",
  which is what `BLE001` exists to catch.
- **`clea.py`: `B904` ×2** (`raise ... from exc` / `from None`),
  **`PLC0207` ×2** (unbounded `str.split`, twice on the same line —
  bounded with `split("/", 1)` / `rsplit("/", 1)`).
- **`outscale.py` / `ovh.py`: `E401` ×2** (one import per line),
  **`E702`** ×1 (one statement per line).

## Not included — read before merging

**Wiring `ruff check` into `task lint`**, which is what actually closes
#115. CI's `lint` job installs each tool it needs as an individual step
before running `task lint` (shellcheck, tflint, …) — adding ruff needs
the same treatment in `.github/workflows/ci.yml`, which this session does
not touch autonomously. Wiring the Taskfile line without that would turn
this PR's own CI red on a runner that has never had ruff, so I left both
the `Taskfile.yml` gate and the `scripts/setup.sh` installer out rather
than ship a change I can't get green myself. Once a CI step installs
ruff, both are a small, mechanical follow-up (I drafted them locally
while working this — happy to open that PR too, or hand off the two
lines).

## Test plan

- [x] `ruff check --select F,B023,B904,E401,E702,PLC0207,BLE001
  $(git ls-files '*.py')` — clean (was 18 findings)
- [x] `python3 -m py_compile` on every changed file — clean
- [x] `task lint` — green
- [x] `task test-scripts` — green, including `test-purge-orphans.sh` (26
  assertions, unchanged) and `test-clea.sh` (73, unchanged) — both
  exercise the narrowed exception handling directly (refused-API,
  refused-delete scenarios)
- [x] `task validate` (cluster root) — green
- [x] `task render-check` — green
- [x] `checkov` (16/16) and `gitleaks` (`no leaks found`) — green
- [ ] `trivy` — not installed in this sandbox (pre-existing gap,
  unrelated to this change)

Mocked rung, offline, as the issue asks for.

Refs #115


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_