### PR TITLE
feat(checkov): custom checks for the three providers with no policy family

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -14,6 +14,15 @@
 framework:
   - terraform
 
+# The contract's own rules, expressed as checks (#123) — Checkov ships policy
+# families for AWS/Azure/GCP-shaped resources and essentially none for
+# Scaleway, Outscale or Proxmox, so without these three of this repo's four
+# providers pass through the hard gate in silence. The directory needs its
+# own __init__.py or Checkov registers nothing and still exits 0 — see the
+# comment on that file.
+external-checks-dir:
+  - infrastructure/opentofu/checkov-custom-checks
+
 # No global skips by default — surface everything.
 skip-check: []
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,22 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Added
 
+- **Two Checkov custom checks close the gap for the three providers Checkov
+  ships no policy family for (#123).** `.checkov.yaml` is a hard gate, but
+  measured on this tree Checkov's built-in rules land on OpenStack (OVH)
+  alone — 84 of 131 provider resources (Scaleway, Outscale, Proxmox) passed
+  through it in silence, indistinguishable in a CI log from a clean scan.
+  `infrastructure/opentofu/checkov-custom-checks/` expresses two rows of
+  `provider-contract.md` as checks instead of prose: `CKV_OA_1` (every
+  control_plane/worker node ignores its boot-image attribute — without it a
+  routine `tofu apply` after a `talosctl upgrade` replaces every node at
+  once, all control planes together, and etcd loses quorum) and `CKV_OA_2`
+  (a security group's inbound default policy must be `drop`). Both are
+  mutation-tested against the real tree (`test-checkov-custom-checks.sh`,
+  wired into `task security`): break either rule, watch it name the exact
+  resource, restore, watch it pass again. The directory's `__init__.py` is
+  load-bearing — without it Checkov registers nothing and still exits 0,
+  the exact false green this fix exists to close, confirmed by removing it.
 - **`task purge-orphans PROVIDER=… [APPLY=1]`.** `docs/release-checklist.md`
   already told the reader to run it; it did not exist. The scripts it wraps are
   the last sentence between a failed teardown and a bill, and they were reachable

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -243,6 +243,10 @@ tasks:
           exit 1
         }
         checkov -d infrastructure/opentofu --config-file .checkov.yaml
+      # The contract's own rules (#123), as checks (CKV_OA_1, CKV_OA_2) — proof
+      # each one actually fires: mutates real tracked files under a trap that
+      # always restores them, never left in the working tree either way.
+      - ./scripts/dev/test-checkov-custom-checks.sh
       # Only what git can see. Scanning the raw tree flagged .env.sh and the
       # *.kubeconfig files — gitignored on purpose — so this gate could never be
       # green on an operator's machine, only on a bare CI runner.

--- a/infrastructure/opentofu/checkov-custom-checks/README.md
+++ b/infrastructure/opentofu/checkov-custom-checks/README.md
@@ -1,0 +1,15 @@
+# Checkov custom checks
+
+The contract's own rules, expressed as checks instead of prose (#123).
+Checkov ships no policy family for Scaleway, Outscale or Proxmox, so
+without these three of this repository's four providers pass `.checkov.yaml`'s
+hard gate in silence.
+
+- `node_image_drift.py` — `CKV_OA_1`, provider-contract.md § "Node image drift".
+- `inbound_default_drop.py` — `CKV_OA_2`, provider-contract.md § "Security groups".
+
+Loaded via `.checkov.yaml`'s `external-checks-dir`. `__init__.py` is
+load-bearing: without it Checkov registers neither check and still exits 0.
+
+Tested against the real tree, mutated and restored, by
+`scripts/dev/test-checkov-custom-checks.sh` (`task security`).

--- a/infrastructure/opentofu/checkov-custom-checks/__init__.py
+++ b/infrastructure/opentofu/checkov-custom-checks/__init__.py
@@ -1,0 +1,3 @@
+# Load-bearing, not decorative: without this file Checkov's `--external-checks-dir`
+# prints its banner, registers nothing, and exits 0 — a false green inside the
+# fix for exactly that class of defect (#123).

--- a/infrastructure/opentofu/checkov-custom-checks/inbound_default_drop.py
+++ b/infrastructure/opentofu/checkov-custom-checks/inbound_default_drop.py
@@ -1,0 +1,43 @@
+"""provider-contract.md § 4, "Security groups": inbound default policy MUST
+be drop (#123).
+
+Two providers expose this as an actual attribute to check — Scaleway's
+`inbound_default_policy` and OpenStack's `delete_default_rules` (which
+removes OpenStack's own auto-created default-allow rules, the mechanism
+this project's own security.tf comments already name as the equivalent).
+Outscale's `outscale_security_group` has no such attribute at all: it is
+an AWS-style security group, default-deny on ingress by construction, with
+nothing to misconfigure — so it is deliberately not in scope below rather
+than checked against an attribute that does not exist. Proxmox declares no
+security-group-shaped resource in this repository yet; nothing to check
+until it does.
+"""
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+# resource type -> (attribute, required value)
+DROP_RULE = {
+    "scaleway_instance_security_group": ("inbound_default_policy", "drop"),
+    "openstack_networking_secgroup_v2": ("delete_default_rules", True),
+}
+
+
+class InboundDefaultDrop(BaseResourceCheck):
+    def __init__(self):
+        super().__init__(
+            name='Security group inbound default policy must be drop (provider-contract.md § "Security groups")',
+            id="CKV_OA_2",
+            categories=[CheckCategories.NETWORKING],
+            supported_resources=list(DROP_RULE.keys()),
+        )
+
+    def scan_resource_conf(self, conf):
+        attr, expected = DROP_RULE[self.entity_type]
+        value = conf.get(attr)
+        if not value or value[0] != expected:
+            return CheckResult.FAILED
+        return CheckResult.PASSED
+
+
+check = InboundDefaultDrop()

--- a/infrastructure/opentofu/checkov-custom-checks/node_image_drift.py
+++ b/infrastructure/opentofu/checkov-custom-checks/node_image_drift.py
@@ -1,0 +1,70 @@
+"""provider-contract.md § "Node image drift" (#123).
+
+Every control_plane/worker node resource must ignore its boot-image
+attribute. talosctl upgrade changes the running version without touching
+the cloud resource, so after an upgrade the two disagree by design — and
+without the ignore, a routine `tofu apply` replaces every node at once
+(all control planes together => etcd loses quorum). Bastions are exempt:
+they run plain Ubuntu, never `talosctl upgrade`d, so there is nothing to
+diverge.
+
+Checkov ships no policy family for Scaleway, Outscale or Proxmox, and
+gives OpenStack nothing that reads this project's own `lifecycle` block —
+this check is what makes the contract's rule enforced instead of merely
+documented, for all four providers checked here.
+"""
+
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+# One entry per node resource type this repository declares. The value is the
+# exact ignore_changes element the contract requires — verified against each
+# provider's own main.tf, not guessed: `image` (Scaleway), `image_id`
+# (OpenStack, Outscale), `disk[0].file_id` (Proxmox, where the image lives
+# inside a nested block, not a top-level attribute).
+IMAGE_ATTRIBUTE = {
+    "scaleway_instance_server": "image",
+    "openstack_compute_instance_v2": "image_id",
+    "outscale_vm": "image_id",
+    "proxmox_virtual_environment_vm": "disk[0].file_id",
+}
+
+
+class NodeImageDrift(BaseResourceCheck):
+    def __init__(self):
+        super().__init__(
+            name='Node resource must ignore boot-image drift (provider-contract.md "Node image drift")',
+            id="CKV_OA_1",
+            categories=[CheckCategories.GENERAL_SECURITY],
+            supported_resources=list(IMAGE_ATTRIBUTE.keys()),
+        )
+
+    def scan_resource_conf(self, conf):
+        # __address__ is "module.<provider>.<resource_type>.<local_name>" —
+        # the one place Checkov exposes the Terraform block name to a
+        # resource-level check, and how bastion instances (same resource
+        # TYPE, out of scope for this rule) are told apart from the two that
+        # matter. Split on "." first, THEN strip a for_each/count index —
+        # "control_plane" never carries one, but being liberal here costs
+        # nothing and a proxmox bastion's "bastion[0]" must not survive as
+        # a local name that happens to match neither branch by accident.
+        address = conf.get("__address__", "")
+        local_name = address.rsplit(".", 1)[-1].split("[", 1)[0]
+        if local_name not in ("control_plane", "worker"):
+            return CheckResult.PASSED
+
+        required = IMAGE_ATTRIBUTE.get(self.entity_type)
+        lifecycle = conf.get("lifecycle")
+        if not lifecycle or not isinstance(lifecycle, list) or not isinstance(lifecycle[0], dict):
+            return CheckResult.FAILED
+
+        ignore_changes = lifecycle[0].get("ignore_changes")
+        if not ignore_changes:
+            return CheckResult.FAILED
+        # HCL block-attribute wrapping: one list per block instance, so the
+        # actual entries are ignore_changes[0].
+        entries = ignore_changes[0] if isinstance(ignore_changes[0], list) else ignore_changes
+        return CheckResult.PASSED if required in entries else CheckResult.FAILED
+
+
+check = NodeImageDrift()

--- a/scripts/dev/test-checkov-custom-checks.sh
+++ b/scripts/dev/test-checkov-custom-checks.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Unit tests for #123: the checkov-custom-checks/ policies (CKV_OA_1, CKV_OA_2).
+#
+# Mutates REAL tracked files under a trap that always restores them, rather
+# than a synthetic fixture repo: a custom check keys on exact resource types
+# and attribute shapes (__address__, the nested lifecycle/ignore_changes
+# wrapping checkov's own HCL parser produces), and a hand-built minimal .tf
+# risks testing the fixture's idea of that shape instead of the real one.
+# check-provider-contract.sh has no dedicated test file for the same reason —
+# proof against the real tree, mutated and restored, is what these two rows
+# in provider-contract.md actually need.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT" || exit 1
+CHECKS_DIR="infrastructure/opentofu/checkov-custom-checks"
+SCW_MAIN="infrastructure/opentofu/modules/providers/scw/main.tf"
+SCW_SECURITY="infrastructure/opentofu/modules/providers/scw/security.tf"
+
+PASS=0
+FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+TMP="$(mktemp -d)"
+cp "$SCW_MAIN" "$TMP/scw-main.tf.orig"
+cp "$SCW_SECURITY" "$TMP/scw-security.tf.orig"
+restore() {
+  cp "$TMP/scw-main.tf.orig" "$SCW_MAIN"
+  cp "$TMP/scw-security.tf.orig" "$SCW_SECURITY"
+  [ -f "$TMP/init.py.bak" ] && mv "$TMP/init.py.bak" "$CHECKS_DIR/__init__.py"
+  rm -rf "$TMP"
+}
+trap restore EXIT
+
+run() { checkov -d infrastructure/opentofu --external-checks-dir "$CHECKS_DIR" --check CKV_OA_1,CKV_OA_2 2>/dev/null; }
+
+echo "=== the real, unmodified tree passes both custom checks ==="
+
+out="$(run)"
+echo "$out" | grep -qE 'Passed checks: 16, Failed checks: 0' && ok "16 passed, 0 failed (8 node resources + 4 bastions x2 checks, 4 security groups x1 check)" ||
+  bad "unexpected result on the real tree: $(echo "$out" | grep -E 'Passed checks|Failed checks')"
+
+echo
+echo "=== CKV_OA_1: removing a control_plane's ignore_changes is caught ==="
+
+python3 - "$SCW_MAIN" <<'PY'
+import sys
+path = sys.argv[1]
+text = open(path).read()
+needle = '''  # Boot image = initial medium only; talosctl upgrade owns the live version.
+  # See provider-contract.md § "Node image drift".
+  lifecycle {
+    ignore_changes = [image]
+  }
+  zone       = element(var.additional_zones, count.index)
+  project_id = var.project_id
+
+  root_volume {
+    volume_type           = var.root_volume_type
+    size_in_gb            = 20
+    delete_on_termination = true
+  }
+
+  # No public IP - private network only'''
+replacement = '''  zone       = element(var.additional_zones, count.index)
+  project_id = var.project_id
+
+  root_volume {
+    volume_type           = var.root_volume_type
+    size_in_gb            = 20
+    delete_on_termination = true
+  }
+
+  # No public IP - private network only'''
+assert needle in text, "fixture text not found — has scw/main.tf changed shape?"
+open(path, "w").write(text.replace(needle, replacement, 1))
+PY
+
+out="$(run)"
+echo "$out" | grep -q 'CKV_OA_1' && echo "$out" | grep -q 'FAILED for resource: module.scw.scaleway_instance_server.control_plane' &&
+  ok "the mutated control_plane is named FAILED under CKV_OA_1" ||
+  bad "the missing lifecycle block was not caught: $(echo "$out" | grep -E 'Passed checks|Failed checks')"
+echo "$out" | grep -q 'FAILED for resource: module.scw.scaleway_instance_server.worker' &&
+  bad "the untouched worker was flagged too — false positive" ||
+  ok "the untouched worker (same file, same resource type) is not flagged"
+
+cp "$TMP/scw-main.tf.orig" "$SCW_MAIN"
+
+echo
+echo "=== CKV_OA_2: flipping the security group's default policy is caught ==="
+
+sed -i 's/inbound_default_policy = "drop"/inbound_default_policy = "accept"/' "$SCW_SECURITY"
+out="$(run)"
+echo "$out" | grep -q 'CKV_OA_2' && echo "$out" | grep -q 'FAILED for resource: module.scw.scaleway_instance_security_group.this' &&
+  ok "the flipped security group is named FAILED under CKV_OA_2" ||
+  bad "the flipped default policy was not caught: $(echo "$out" | grep -E 'Passed checks|Failed checks')"
+
+cp "$TMP/scw-security.tf.orig" "$SCW_SECURITY"
+
+echo
+echo "=== the tree is clean again after both mutations ==="
+
+out="$(run)"
+echo "$out" | grep -qE 'Passed checks: 16, Failed checks: 0' && ok "back to 16 passed, 0 failed" ||
+  bad "restore left the tree dirty: $(echo "$out" | grep -E 'Passed checks|Failed checks')"
+
+echo
+echo "=== missing __init__.py is the documented false-green trap, guarded by its presence ==="
+
+mv "$CHECKS_DIR/__init__.py" "$TMP/init.py.bak"
+out="$(run)"
+echo "$out" | grep -q 'CKV_OA_1\|CKV_OA_2' &&
+  bad "a directory with no __init__.py still registered a check — the guard comment is now wrong" ||
+  ok "with no __init__.py, checkov finds neither check (registers nothing) — exactly why the file must stay"
+mv "$TMP/init.py.bak" "$CHECKS_DIR/__init__.py"
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

`.checkov.yaml` is a hard gate (`skip-check: []`), but measured on this tree
Checkov's built-in rules land on OpenStack (OVH) alone: 84 of 131 provider
resources across Scaleway, Outscale and Proxmox pass through it in silence —
indistinguishable, in a CI log, from a clean scan (#123).

`infrastructure/opentofu/checkov-custom-checks/` expresses two rows of
`provider-contract.md` as checks instead of prose, loaded via
`.checkov.yaml`'s `external-checks-dir`:

- **`CKV_OA_1`, "Node image drift"** — every `control_plane`/`worker`
  resource must ignore its boot-image attribute (`image` / `image_id` /
  `disk[0].file_id`, verified per provider against each module's actual
  `main.tf` rather than guessed). `talosctl upgrade` changes the running
  version without touching the cloud resource; without the ignore, a
  routine `tofu apply` after an upgrade replaces every node at once — all
  control planes together, etcd loses quorum. Bastions run plain Ubuntu
  and are deliberately out of scope: resolved via `__address__`
  (`module.<provider>.<type>.<local_name>`), the one place Checkov exposes
  the Terraform block name to a resource-level check — bastion and node
  share the same resource *type* in every provider here.
- **`CKV_OA_2`, "inbound default policy MUST be drop"** — checked where
  each provider actually exposes a knob for it: Scaleway's
  `inbound_default_policy` and OpenStack's `delete_default_rules` (the
  mechanism this repo's own `security.tf` comments already name as the
  equivalent). Outscale's security group has no such attribute at all —
  default-deny by construction, an AWS-style SG with nothing to
  misconfigure — and Proxmox declares no security-group-shaped resource
  in this repo yet. Neither is checked against an attribute that doesn't
  exist.

**The directory's `__init__.py` is load-bearing**, per the issue's own
warning: without it Checkov prints its banner, registers neither check,
and still exits 0. Confirmed by removing it (see test plan) — the exact
false green this fix exists to close, reproduced inside the fix for it.

## Test plan

- [x] Real, unmodified tree: `checkov -d infrastructure/opentofu
  --config-file .checkov.yaml` → **32 passed** (16 built-in + 16 custom: 8
  node resources + 4 bastions × 2 checks, 4 security groups × 1 check)
- [x] Mutation, `CKV_OA_1`: removed `scw/control_plane`'s `lifecycle`
  block → named `FAILED for resource:
  module.scw.scaleway_instance_server.control_plane`, its sibling
  `worker` untouched and not flagged; restored, green again
- [x] Mutation, `CKV_OA_2`: flipped `scw`'s `inbound_default_policy` to
  `"accept"` → named `FAILED`; restored, green again
- [x] Mutation, the `__init__.py` gotcha itself: removed it → Checkov
  finds **zero** results for either check ID (confirms the documented
  trap is real, not just asserted)
- [x] `scripts/dev/test-checkov-custom-checks.sh` (6 assertions covering
  all of the above, against real tracked files under a `trap` that always
  restores them) — wired into `task security`, right after the checkov
  step it tests
- [x] `task lint`, `task test-scripts` — green
  (`check-script-reachability.sh` required the new
  `checkov-custom-checks/README.md` — the two check files are discovered
  by directory, not named by filename anywhere else in the tree)
- [x] `task validate` (cluster root), `task render-check` — green
- [x] `gitleaks` (`no leaks found`) — green
- [ ] `trivy` — not installed in this sandbox (pre-existing gap,
  unrelated to this change)

Mocked rung, offline, as the issue asks for — the `--external-checks-dir`
flag flows through `.checkov.yaml`, which CI's `security` job already
reads via the pinned `bridgecrewio/checkov-action`, so this needs no
`.github/workflows/ci.yml` change.

Closes #123


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_