### PR TITLE
fix(dev): check-commit-authors.sh fails loud on its own git-log failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`check-commit-authors.sh` could read its own `git log` failure as "no
+  commit is authored by a tool" (#132).** `set -e` does not propagate a
+  failure inside a process substitution (`< <(git log … )`) — a malformed
+  rev-range from a future CI edit would leave the `while read` loop with
+  nothing to read, zero iterations, and the script printed its success line
+  over a check that never ran. `git log` now writes to a file first and its
+  own exit status is checked before anything reads it. Not yet exercised by
+  CI's own wiring (the `commits` job always passes a valid range), so this
+  was latent, not live — reproduced and fixed anyway.
+
 - **Six gates were reporting green on something they had stopped checking.**
   Found by auditing what the pipeline actually constrains, and each one is
   reproduced in both directions — broken on purpose, watched go red, fixed,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -371,6 +371,10 @@ tasks:
       # this proves the effective-config reader (and check-cilium-parity.py's
       # missing-key guard) actually catch it, offline.
       - ./scripts/dev/test-cilium-effective-config.sh
+      # `set -e` does not see a process substitution's own git-log failure
+      # (#132) — proves a malformed rev-range fails loud instead of reading
+      # as zero commits, none of them tool-authored.
+      - ./scripts/dev/test-commit-authors.sh
 
   test:
     desc: Run OpenTofu tests (cluster root)

--- a/scripts/dev/check-commit-authors.sh
+++ b/scripts/dev/check-commit-authors.sh
@@ -16,14 +16,27 @@ set -euo pipefail
 range="${1:?usage: check-commit-authors.sh <rev-range>}"
 tools='claude|copilot|chatgpt|gpt-[0-9]|gemini|cursor|codex|devin|aider|noreply@anthropic\.com|users\.noreply\.github\.com/copilot'
 
+# `git log` written to a file first, not read from a process substitution: a
+# failure inside `< <(...)` (a malformed rev-range, say) does not propagate
+# through `set -e` — the pipeline it fails in is not a simple command `set -e`
+# tracks — so the `while read` loop would just see EOF, run zero iterations,
+# and this script would print its own success line over a check that never
+# ran (#132). A file's exit status is the ordinary kind.
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+if ! git log --format='%H%x09%an <%ae>%x09%cn <%ce>' "$range" > "$tmp"; then
+  echo "✗ git log $range failed — commit authors could not be checked" >&2
+  exit 1
+fi
+
 bad=0
-while IFS=$'\t' read -r sha ident; do
+while IFS=$'\t' read -r sha ident _committer; do
   [ -n "$sha" ] || continue
   if grep -qiE "$tools" <<<"$ident"; then
     echo "✗ $sha is authored by a tool: $ident" >&2
     bad=1
   fi
-done < <(git log --format='%H%x09%an <%ae>%x09%cn <%ce>' "$range" | cut -f1,2)
+done < "$tmp"
 
 if [ "$bad" -eq 1 ]; then
   cat >&2 <<'EOT'

--- a/scripts/dev/test-commit-authors.sh
+++ b/scripts/dev/test-commit-authors.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Unit tests for #132: check-commit-authors.sh must fail loud when `git log`
+# itself fails, not read a bogus rev-range as "zero commits, all clean".
+#
+# Against an isolated throwaway git repo, not this one — a bad rev-range
+# against THIS repo's own history is one accident away from actually being
+# a valid (if unintended) range once this repo has enough commits.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT/scripts/dev/check-commit-authors.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+repo="$TMP/repo"
+rm -rf "$repo"
+mkdir -p "$repo"
+git -C "$repo" init -q
+git -C "$repo" config user.email human@example.invalid
+git -C "$repo" config user.name "A Human"
+echo one > "$repo/f"
+git -C "$repo" add f
+git -C "$repo" commit -q -m "first"
+echo two > "$repo/f"
+git -C "$repo" add f
+git -C "$repo" commit -q -m "second"
+
+echo "=== a bogus rev-range fails loud, not silently clean ==="
+
+out="$(cd "$repo" && "$CHECKER" "not-a-real-ref..HEAD" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "a malformed rev-range is a hard failure (rc=${rc})" ||
+  bad "a malformed rev-range exited 0 — the #132 regression"
+grep -qi "could not be checked\|failed" <<<"$out" && ok "the failure says the check did not run" ||
+  bad "no failure explanation in output: ${out}"
+grep -qi "no commit.*is authored by a tool" <<<"$out" &&
+  bad "printed the SUCCESS line despite git log failing — exactly #132" ||
+  ok "the success line is not printed on a failed git log"
+
+echo
+echo "=== a valid range with a human-authored commit passes ==="
+
+out="$(cd "$repo" && "$CHECKER" "HEAD~1..HEAD" 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "a human-authored commit passes (rc=0)" ||
+  bad "a clean range failed: ${out}"
+
+echo
+echo "=== a tool-authored commit is caught ==="
+
+git -C "$repo" config user.email "noreply@anthropic.com"
+git -C "$repo" config user.name "Claude"
+echo three > "$repo/f"
+git -C "$repo" add f
+git -C "$repo" commit -q -m "third"
+git -C "$repo" config user.email human@example.invalid
+git -C "$repo" config user.name "A Human"
+
+out="$(cd "$repo" && "$CHECKER" "HEAD~1..HEAD" 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "a tool-authored commit fails the check (rc=${rc})" ||
+  bad "a tool-authored commit passed"
+grep -qi "authored by a tool" <<<"$out" && ok "it says which commit and why" ||
+  bad "no explanation: ${out}"
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

`set -e` does not propagate a failure inside a process substitution
(`< <(git log …)`) — the pipeline it fails in is not a simple command
`set -e` tracks. So a malformed rev-range (a future CI edit, say) would
leave the `while read` loop with nothing to read, run zero iterations, and
`check-commit-authors.sh` printed its own "✓ no commit is authored by a
tool" success line over a check that never ran (#132).

`git log` now writes to a file first and its own exit status is checked
explicitly before anything reads it — a file's exit status is the ordinary
kind. Not exercised by CI's current wiring (the `commits` job always
passes a valid range), so this was latent rather than live; reproduced
with a bogus rev-range and fixed anyway.

## Test plan

- [x] Reproduced directly: `./scripts/dev/check-commit-authors.sh
  "not-a-real-ref..HEAD"` now fails loud (`git log … failed`) instead of
  printing the success line
- [x] `test-commit-authors.sh`, new — against an isolated throwaway git
  repo, not this one (a bad range against this repo's own history is one
  accident away from becoming a valid range as it grows): confirms the
  exact #132 shape, plus the two behaviors the script already had (a
  human-authored commit passes; a tool-authored one is caught and named)
- [x] Reverted the fix and re-ran the test: it goes red on exactly the
  #132 shape (`the success line despite git log failing`), confirming the
  test actually exercises the regression rather than passing by
  construction — restored afterward
- [x] `task lint`, `task test-scripts` — green
- [x] `task validate` (cluster root), `task render-check` — green
- [x] `checkov` (16/16) and `gitleaks` (`no leaks found`) — green
- [ ] `trivy` — not installed in this sandbox (pre-existing gap,
  unrelated to this change)

Mocked rung, offline, as the issue asks for.

Closes #132


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_