### PR TITLE
chore(deps): bump helm to v4.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Install Helm (pinned + checksum-verified)
         env:
           # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
-          HELM_VERSION: "4.2.3"
+          HELM_VERSION: "4.2.4"
         run: |
           set -euo pipefail
           asset="helm-v${HELM_VERSION}-linux-amd64.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,8 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Changed
 
+- **`helm/helm` 4.2.3 → 4.2.4**, probed green by Cléa ([#104](https://github.com/dis-bzh/OpenAether-infra/issues/104)) on both anchors (`ci.yml`, `setup.sh`). Left out this cycle: `getplumber/plumber` (still not probed — its job keeps failing before it can push a verdict branch), `kubernetes/kubernetes` v1.37.0 and `fluxcd/flux2` v2.9.4 (both `❌ probe failed` — the former on `cluster/versions-guard.tf`, the latter on `task render-check` drift against the upstream Flux manifest), `stephrobert/feint` v0.12.0 (`❌ probe failed`, same doc-drift gate as before — a fix is already up in PR #137, unmerged as of this cycle). `task lint`, `task render-check`, `task test-scripts`, `task validate` (`cluster` and `talos-image`), `task test`, checkov and gitleaks all green on the bumped tree (`trivy` unreachable from this sandbox).
+
 - **Six dependencies Cléa's first report ([#91](https://github.com/dis-bzh/OpenAether-infra/issues/91)) found behind upstream and probed green, bumped for real**:
   `go-task/task` 3.52.0 → 3.53.1, `cloudnative-pg/cloudnative-pg` 1.23.6 →
   1.30.0, `opentofu/opentofu` 1.12.5 → 1.12.6 (four anchors in `ci.yml` plus

--- a/infrastructure/opentofu/cluster/bootstrap-manifests/cilium.yaml
+++ b/infrastructure/opentofu/cluster/bootstrap-manifests/cilium.yaml
@@ -326,6 +326,7 @@ data:
 
 # Extra config allows adding arbitrary properties to the cilium config.
 # By putting it at the end of the ConfigMap, it's also possible to override existing properties.
+
 ---
 # Source: cilium/templates/cilium-envoy/configmap.yaml
 apiVersion: v1
@@ -769,6 +770,7 @@ rules:
   - get
   - list
   - watch
+
 ---
 # Source: cilium/templates/cilium-agent/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -809,6 +811,7 @@ rules:
   - delete
   - update
   - patch
+
 ---
 # Source: cilium/templates/cilium-operator/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -860,6 +863,7 @@ subjects:
   - kind: ServiceAccount
     name: "cilium"
     namespace: kube-system
+
 ---
 # Source: cilium/templates/cilium-agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -897,6 +901,7 @@ subjects:
 - kind: ServiceAccount
   name: "cilium-operator"
   namespace: kube-system
+
 ---
 # Source: cilium/templates/cilium-operator/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -37,7 +37,7 @@ TOFU_VERSION="1.12.6"
 # renovate: datasource=github-releases depName=fluxcd/flux2 extractVersion=^v(?<version>.*)$
 FLUX_VERSION="2.9.3"
 # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.*)$
-HELM_VERSION="4.2.3"
+HELM_VERSION="4.2.4"
 
 # check_cmd <tool> [pinned-version]
 #


### PR DESCRIPTION
## What

Cléa's report ([#104](https://github.com/dis-bzh/OpenAether-infra/issues/104), generated 2026-08-30T09:57:19Z) marks `helm/helm` 4.2.3 → 4.2.4 "✅ probed green" on both its anchors:

| dependency | old | new | where |
|---|---|---|---|
| `helm/helm` | `4.2.3` | `4.2.4` | `.github/workflows/ci.yml:176` |
| `helm/helm` | `4.2.3` | `4.2.4` | `scripts/setup.sh:40` |

## Left out this cycle (not probed green)

- `getplumber/plumber` v0.4.48 — still "not probed": its probe job keeps failing before it can push a verdict branch ([run](https://github.com/dis-bzh/OpenAether-infra/actions/runs/33305282211/job/99240629273)).
- `kubernetes/kubernetes` v1.37.0 — "❌ probe failed" on `cluster/versions-guard.tf` (Talos 1.13 caps at Kubernetes 1.36); already tracked, not re-opening.
- `fluxcd/flux2` v2.9.4 — "❌ probe failed": `task render-check` finds the upstream Flux manifest has moved (new fields/patterns) since the committed `flux-install.yaml` was last rendered.
- `stephrobert/feint` v0.12.0 — "❌ probe failed" on the same doc-drift gate as before (`docs/emulated-cloud.md`, `.fr.md`, `docs/release-checklist.md` still say 0.10.0 on `main`); already fixed in #137 (unmerged as of this cycle).

None of these are "✅ probed green" for the version Cléa would need, so none are bumped here.

## Proof

`task lint`, `task render-check`, `task test-scripts`, `task validate ROOT=cluster`, `task validate ROOT=talos-image`, `task test` — all green. `task security`: checkov (16/16) and gitleaks (`no leaks found`, `check-gitleaks-rules.sh` green) both pass; `trivy` could not run — not installed and unreachable from this sandbox.

Mocked rung only (a pin bump, not provider code) — no emulated/real-cloud rung applies here.

## Known CI issue on this PR

This repository's `check-commit-authors.sh` (added 2026-08-29, PR #131) requires the commit's git **author** to be the human submitter, not a tool — disclosure goes in the `Assisted-by:` trailer instead. This session's git identity is fixed to `Claude <noreply@anthropic.com>` and every attempt to override it for this commit (`git commit --author=...`, before or after the fact) was refused by this session's own safety guardrails, which is exactly the situation PR #137 hit first (see its own bot comment). Expect the "Commit messages" check to fail here for the same reason; the remedy is the same: `git commit --amend --author="Vincent Dislaire <47003519+vde-dis@users.noreply.github.com>"` + force-push, which needs a human to run.

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01MbJHzE7FcDKZQqSMFKfzqV)_