### PR TITLE
feat(ci): skip feint/validate/talos/security on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,46 @@ permissions:
   contents: read
 
 jobs:
+  # A docs-only PR cannot break Terraform, Talos, or a real HTTP API — feint,
+  # OpenTofu validate/test, and the Talos/IaC scans exist to catch mistakes IN
+  # infrastructure code, and there is none in the diff to catch a mistake in.
+  # Gates the JOB, never the trigger: a `paths-ignore` on `pull_request:`
+  # would stop these jobs from running at all on a docs-only PR, and a
+  # required check that never reports stays pending forever — the PR could
+  # never merge. A job that runs and is skipped by its own `if:` still
+  # reports "skipped", which satisfies a required check exactly like success.
+  #
+  # Errs toward "code": classifies by exclusion (docs/**, *.md, README*,
+  # CHANGELOG.md, CONTRIBUTING.md, LICENSE), so any path this doesn't
+  # recognise as documentation — a new top-level file type, say — runs the
+  # full suite until someone deliberately adds it to the docs list below.
+  # Push to main (not a PR) always runs everything: this job only exists for
+  # `pull_request`, and every gated job's own `if:` treats "not a PR" as code.
+  changes:
+    name: Detect change scope
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.classify.outputs.code }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Classify the diff
+        id: classify
+        run: |
+          set -uo pipefail
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" > "$RUNNER_TEMP/changed.txt"
+          docs_pattern='^(docs/|README|CHANGELOG\.md$|CONTRIBUTING\.md$|LICENSE$|.*\.md$)'
+          if grep -vEq "$docs_pattern" "$RUNNER_TEMP/changed.txt"; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # The commit-msg hooks that enforce this live in .git/hooks/, which no clone
   # carries — so the same checks run here on every subject a PR adds.
   commits:
@@ -171,6 +211,8 @@ jobs:
     name: Generated Manifests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
@@ -199,6 +241,8 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     strategy:
       matrix:
         # Validate every OpenTofu root, not just the cluster. talos-image is a
@@ -230,7 +274,8 @@ jobs:
     name: OpenTofu Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: validate
+    needs: [validate, changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
@@ -263,7 +308,8 @@ jobs:
     name: Emulated Cloud (${{ matrix.provider }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: validate
+    needs: [validate, changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     # The real provider binaries against a real HTTP API, with no account: one
     # step past `tofu test`, which mocks the provider and never leaves the
     # process. See docs/emulated-cloud.md for what it does and does not prove.
@@ -309,6 +355,8 @@ jobs:
     name: Talos Config Validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
@@ -349,6 +397,8 @@ jobs:
     name: IaC Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,20 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Changed
 
+- **CI no longer runs feint, `task validate`/`test`, Talos config validation
+  and the IaC security scan on a docs-only PR.** A new `changes` job diffs the
+  PR against its base and classifies it by exclusion (anything outside
+  `docs/`, `README*`, `CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE`, `*.md` is
+  "code"); the six heavy jobs gate on `needs.changes.outputs.code == 'true'`.
+  Gates the job, never the trigger: a `paths-ignore` on the workflow itself
+  would stop those jobs from running at all, and a required check that never
+  reports stays pending forever — the PR could never merge. A job that runs
+  and is skipped by its own `if:` still reports "skipped", which satisfies a
+  required check exactly like success. `commits`, `leaks` and `lint` (the job
+  that actually validates docs) stay unconditional; `security.yml`'s
+  `secret-scan` and `pipeline-audit` are untouched — both are already cheap
+  and repo-wide, not infra-specific.
+
 - **`helm/helm` 4.2.3 → 4.2.4**, probed green by Cléa ([#104](https://github.com/dis-bzh/OpenAether-infra/issues/104)) on both anchors (`ci.yml`, `setup.sh`). Left out this cycle: `getplumber/plumber` (still not probed — its job keeps failing before it can push a verdict branch), `kubernetes/kubernetes` v1.37.0 and `fluxcd/flux2` v2.9.4 (both `❌ probe failed` — the former on `cluster/versions-guard.tf`, the latter on `task render-check` drift against the upstream Flux manifest), `stephrobert/feint` v0.12.0 (`❌ probe failed`, same doc-drift gate as before — a fix is already up in PR #137, unmerged as of this cycle). `task lint`, `task render-check`, `task test-scripts`, `task validate` (`cluster` and `talos-image`), `task test`, checkov and gitleaks all green on the bumped tree (`trivy` unreachable from this sandbox).
 
 - **Six dependencies Cléa's first report ([#91](https://github.com/dis-bzh/OpenAether-infra/issues/91)) found behind upstream and probed green, bumped for real**:


### PR DESCRIPTION
## Why

Every PR re-ran the full CI suite regardless of what it touched — feint's emulated-cloud matrix, `task validate`/`test`, Talos config validation and the IaC security scan all fired for a docs-only PR that could not possibly break any of them.

## What changed

A new `changes` job in `ci.yml`, running only on `pull_request`, diffs the PR against its base branch and classifies it by exclusion: anything outside `docs/`, `README*`, `CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE`, `*.md` counts as "code". Six jobs now gate on `needs.changes.outputs.code == 'true'`:

- `manifests` (Generated Manifests / `task render-check`)
- `validate` (OpenTofu validate, matrix cluster/talos-image)
- `test` (`task test`)
- `emulated` (feint, matrix scaleway/outscale)
- `talos` (Talos Config Validation)
- `security` (trivy + checkov)

**Design choice — gates the job, never the trigger.** A `paths-ignore` on the workflow's own `on:` block would stop these jobs from running at all on a docs-only PR — but a required status check that never reports stays "pending" forever, and the PR could never merge. A job that runs and is skipped by its own `if:` still reports "skipped", which satisfies a required check exactly like "success". So every gated job keeps `needs: changes` (or is added to an existing `needs:` list) plus `if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'` — a push to `main` (not a PR) always runs everything.

**Errs toward "code".** The classifier only recognizes a fixed doc-path allowlist; anything it doesn't recognize — a new top-level file type, say — runs the full suite until someone deliberately adds it to the list.

**Left unconditional:** `commits` (commit-message hooks), `leaks` (env-data rules on new commits), and `lint` — `lint` stays on because it's the job that actually validates docs (`check-language.sh`, `check-dead-references.sh`, `check-doc-inputs.sh`).

**`security.yml` deliberately untouched.** `secret-scan` and `pipeline-audit` are already cheap and repo-wide rather than infra-specific, so they keep running on every PR regardless of what changed — flagging this explicitly in case that call should go the other way.

## Proof

- `actionlint .github/workflows/ci.yml` — clean.
- Dry-ran the classification grep against docs-only, mixed, infra-only, root `README.md`, `CHANGELOG.md`-only, an unrecognized file type, and the workflow file itself — all classified as expected (workflow-file-only changes correctly count as "code").
- `task lint`, `task test-scripts`, `task validate`, `task render-check` — all green.
- `checkov -d infrastructure/opentofu --config-file .checkov.yaml` — 32 passed, 0 failed.
- `./scripts/dev/test-checkov-custom-checks.sh` — 6 passed, 0 failed.
- `gitleaks dir` (git-tracked files only) — no leaks.
- `./scripts/dev/check-gitleaks-rules.sh` — 6 caught, 8 ignored, as specified.

Barreau: `task test`/mocked rungs only — no cloud account was exercised (this change touches CI wiring, not provider modules).

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_