### PR TITLE
docs(emulated-cloud): three Feint gaps this doc called permanent are closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`docs/emulated-cloud.md`/`.fr.md` documented three Feint gaps as
+  permanent** — Outscale load balancers ("this one will not move"), Scaleway
+  IPAM reservations, Scaleway LB and public gateway ("genuinely absent") —
+  and Feint 0.12.0 closed all three. Re-measured 2026-08-31 with
+  `task feint-record` on both providers: *"every operation the client called
+  is served by a pack"*, zero unserved calls where the 0.7.3 recording listed
+  three. `feint-record`'s own apply is a real `tofu apply
+  -target=module.<provider>` on the cluster root itself, so this is also
+  proof that root's provider module can now be applied against the emulator,
+  not only planned — `feint-plan`'s "plan only" framing was stale for the
+  same reason. Docs updated in both languages; the closed gaps moved from
+  the table to the "left this list" history alongside the ones 0.6.0/0.7.0
+  already closed.
+
 - **`check-commit-authors.sh` could read its own `git log` failure as "no
   commit is authored by a tool" (#132).** `set -e` does not propagate a
   failure inside a process substitution (`< <(git log … )`) — a malformed

--- a/docs/emulated-cloud.fr.md
+++ b/docs/emulated-cloud.fr.md
@@ -31,19 +31,10 @@ task feint-down
 ## Trois voies, parce qu'une seule ne peut pas faire les trois
 
 **`feint-plan` — le vrai root `cluster`, plan seulement.** Vrais modules, vrai
-provider, `envs/feint-<provider>.tfvars.example`. Impossible d'aller plus loin
-que le `plan`, et ce qui l'en empêche tient désormais en une liste courte :
-
-- **Scaleway** : le module crée toujours une public gateway et des réservations
-  IPAM. La gateway n'est pas servie ; la réservation IPAM est déclinée
-  volontairement. Inchangé depuis **Feint** 0.5.0 — aucune version jusqu'à
-  l'enregistrement 0.7.3 ci-dessous n'a fait bouger le pack Scaleway.
-- **Outscale** : les load balancers, et rien d'autre — et c'est une décision, pas
-  un manque. La 0.6.0 a fait passer le pack de 31 à 72 routes : security groups,
-  IP publiques, internet service, NAT service, route tables et NICs fonctionnent
-  tous ; la 0.7.0 n'y ajoute aucune route mais a fait cesser le segfault de
-  `data.outscale_images`, ce qui permet à cette voie de résoudre son image par
-  la data source.
+provider, `envs/feint-<provider>.tfvars.example`. Le script lui-même ne fait
+toujours que planifier, mais les raisons qui l'arrêtaient là ont disparu depuis
+Feint 0.12.0 — voir `feint-record` ci-dessous, qui applique désormais le
+module provider de ce même root de bout en bout.
 
 Le root déclarant un backend S3 partiel, la voie y dépose un `*_override.tf` de
 backend local et le retire en sortant.
@@ -58,25 +49,19 @@ depuis l'API et non depuis le state. Voir son
 **`feint-record` — mesurer le mur au lieu d'en discuter.** `feint proxy`
 s'intercale entre le provider et l'émulateur et écrit un objet JSON caviardé par
 échange ; `feint transcript` classe ensuite les opérations qu'aucun pack ne sert,
-les plus appelées d'abord. L'apply derrière est *censé* échouer, au premier appel
-non servi — tout ce qui précède est justement ce qui est enregistré. Résultat
-actuel, reproductible avec les commandes ci-dessus :
+les plus appelées d'abord. En dessous, ceci exécute un vrai `tofu apply
+-target=module.<provider>` sur le root cluster lui-même — le même root que
+`feint-plan` se contente de planifier — à travers le proxy, et cet apply était
+*censé* échouer au premier appel non servi.
 
-| Provider | Appelé, servi par personne | Appels | Manquant, ou décliné ? |
-|---|---|---|---|
-| Scaleway | `POST /ipam/v1/regions/fr-par/ips` (501) | 2 | Décliné — le `GET` sur le même chemin répond 200 |
-| Scaleway | `/lb/v1/zones/fr-par-1/ips` (501) | 2 | Manquant |
-| Scaleway | `/vpc-gw/v2/zones/fr-par-1/ips` (501) | 1 | Manquant |
-| Outscale | `/api/v1/CreateLoadBalancer` (404) | 2 | Décliné |
-
-Les mêmes trois opérations en 0.6.0, 0.7.0 et 0.7.3 : aucune version n'a bougé
-quoi que ce soit qu'appellent nos modules. Ce qui a bougé, c'est la *forme* du
-refus — les deux manques Scaleway répondaient un `404` en texte brut jusqu'à la
-0.7.3, que le SDK jetait pour son content type, si bien que l'appelant voyait
-`404 Not Found` et pas de corps. Ils répondent maintenant `501` dans le dialecte
-de Scaleway (notre issue #74). La distinction de la dernière colonne est tout
-l'intérêt de rejouer la mesure — une route manquante est un trou que quelqu'un
-peut combler, un decline est une réponse.
+**Fermé depuis Feint 0.12.0** (re-mesuré le 2026-08-31, les deux providers) :
+*« every operation the client called is served by a pack »* — zéro appel non
+servi, là où l'enregistrement 0.7.3 ci-dessous en listait trois. L'apply que
+ceci mesure va maintenant jusqu'au bout sur les modules des deux providers, ce
+qui prouve que le module provider du vrai root cluster peut être appliqué
+contre l'émulateur, pas seulement planifié (voir `feint-plan` ci-dessus). Ce
+qui échouait avant et où c'est parti est conservé dans « Manques connus »
+ci-dessous, puisque c'est de l'histoire désormais, plus une limite actuelle.
 
 L'amont est ici l'émulateur, pas le cloud. Un client qui signe l'hôte pour lequel
 il a été configuré — le provider Terraform le fait — ne peut pas être enregistré
@@ -121,13 +106,10 @@ toujours pas porter, tout consigné dans [les issues ouvertes](https://github.co
 
 | Non exercé | Pourquoi |
 |---|---|
-| Load balancers Outscale | `CreateLoadBalancer` est **décliné volontairement**, pas manquant : un load balancer est un plan de données que l'émulateur n'a pas, en créer un rendrait un nom DNS ne résolvant nulle part. `ReadLoadBalancers` répond une liste vide. Celui-là ne bougera pas. |
-| Réservations IPAM Scaleway | Décliné aussi, avec une raison : les adresses viennent du plan de sous-réseau où le NIC est placé, donc `BookIP` distribuerait une adresse qu'aucun runtime ne configure. `scaleway_ipam_ip` est donc hors de portée ici. |
-| LB et public gateway Scaleway | Réellement absents. Les deux vrais manques que nos modules rencontrent. Depuis la 0.7.3 ils refusent au moins lisiblement — `501` dans le dialecte du SDK au lieu du `404` en texte brut de net/http, que le SDK Scaleway jetait pour son content type (notre issue #74). |
-| Type de volume racine Scaleway | Aucun `root_volume { volume_type }` n'est écrivable : le provider 2.79+ refuse `b_ssd`, et `sbs_volume` planifie éternellement car l'émulateur l'écrase. L'honorer enverrait le provider sur `block/v1`, non monté. Mesuré ici, c'est devenu la limite documentée en amont et son issue #8. |
+| Type de volume racine Scaleway | Aucun `root_volume { volume_type }` n'est écrivable : le provider 2.79+ refuse `b_ssd`, et `sbs_volume` planifie éternellement car l'émulateur l'écrase. L'honorer enverrait le provider sur `block/v1`, non monté. Mesuré ici, c'est devenu la limite documentée en amont et son issue #8. Non re-vérifié sous 0.12.0. |
 | Résolution d'image par nom | Le catalogue est fixe, et la 0.7.0 applique le filtre `image_names` : un nom publié par un pipeline de build ne correspond à rien — des deux côtés. Les tfvars Scaleway épinglent `image_id` ; ceux d'Outscale pointent `image_name` sur une entrée du catalogue, ce qui exerce la recherche sans prétendre résoudre notre propre image. |
 
-Trois choses ont quitté cette liste. `outscale_volume_link` en 0.6.0, qui a monté
+Six choses ont quitté cette liste. `outscale_volume_link` en 0.6.0, qui a monté
 le filtre `LinkVolumeVmIds` dont dépend son attente. `data.outscale_images` en
 0.7.0, qui ne fait plus segfaulter le provider — la voie Outscale résout donc son
 image par la data source plutôt que par un id épinglé, ce qui exerce la forme
@@ -138,3 +120,17 @@ contre seize que le pack frappait, si bien que taguer un `igw-` ou un `rtb-`
 maintenant six types plutôt que de remettre les trois qu'elle avait retirés — une
 table qui a pris du retard une fois mérite d'être exercée sur plus que la ligne
 qui l'a attrapée.
+
+Trois de plus l'ont quittée en 0.12.0, mesuré le 2026-08-31, et cette table les
+avait pourtant appelées permanents. **Load balancers Outscale** :
+`CreateLoadBalancer` et `UpdateLoadBalancer` répondent maintenant 200 —
+étiquetés ici « décliné volontairement... celui-là ne bougera pas » jusqu'à la
+version qui l'a fait bouger. **Réservations IPAM Scaleway** :
+`ipam/v1/API.BookIP` répond maintenant 200, pas le `501` que cette table
+appelait un decline permanent. **LB et public gateway Scaleway** : chaque
+route `lb/v1/ZonedAPI.*` que le module appelle (`CreateLB`, `CreateFrontend`,
+`CreateBackend`, `AttachPrivateNetwork`…) répond maintenant 200 — les deux
+manques que cette table appelait « réellement absents ». C'est l'apply propre
+à `feint-record` (ci-dessus) qui a attrapé les trois : un apply du module
+provider du vrai root cluster, les deux providers, allant jusqu'au bout avec
+zéro appel non servi, là où la 0.7.3 s'arrêtait net au premier.

--- a/docs/emulated-cloud.md
+++ b/docs/emulated-cloud.md
@@ -30,19 +30,10 @@ task feint-down
 ## Three lanes, because one cannot do all three jobs
 
 **`feint-plan` — the real `cluster` root, plan only.** Real modules, real
-provider, `envs/feint-<provider>.tfvars.example`. It cannot go further than
-`plan`, and what stops it is now a short list rather than a long one:
-
-- **Scaleway**: the module always builds a public gateway and IPAM reservations.
-  The gateway is unserved; IPAM booking is declined on purpose. Unchanged since
-  **Feint** 0.5.0 — no release up to the 0.7.3 recording below moved the
-  Scaleway pack.
-- **Outscale**: only the load balancers, and that is a decision rather than a
-  gap. Feint 0.6.0 took the pack from 31 routes to 72, so security groups,
-  public IPs, the internet service, the NAT service, route tables and NICs all
-  work; 0.7.0 added no route here but stopped `data.outscale_images` from
-  segfaulting the provider, which is what lets this lane resolve its image
-  through the data source.
+provider, `envs/feint-<provider>.tfvars.example`. The script itself still only
+plans, but the reasons it used to stop there are gone as of Feint 0.12.0 — see
+`feint-record` below, which now applies the same root's provider module end to
+end.
 
 The root declares a partial S3 backend, so the lane drops a local-backend
 `*_override.tf` in and removes it on exit.
@@ -57,24 +48,19 @@ from the API rather than from the state. See its
 **`feint-record` — measure the wall instead of arguing about it.** `feint proxy`
 sits between the provider and the emulator and writes one redacted JSON object
 per exchange; `feint transcript` then ranks the operations no pack serves,
-most-called first. The apply behind it is *expected* to fail, on the first
-unserved call — everything up to that point is what gets recorded. Current
-output, reproducible with the commands above:
+most-called first. Underneath, this runs a real `tofu apply
+-target=module.<provider>` on the cluster root itself — the same root
+`feint-plan` only plans — through the proxy, and the apply used to be
+*expected* to fail on the first unserved call.
 
-| Provider | Called, served by nobody | Calls | Missing, or declined? |
-|---|---|---|---|
-| Scaleway | `POST /ipam/v1/regions/fr-par/ips` (501) | 2 | Declined — `GET` on the same path answers 200 |
-| Scaleway | `/lb/v1/zones/fr-par-1/ips` (501) | 2 | Missing |
-| Scaleway | `/vpc-gw/v2/zones/fr-par-1/ips` (501) | 1 | Missing |
-| Outscale | `/api/v1/CreateLoadBalancer` (404) | 2 | Declined |
-
-The same three operations on 0.6.0, 0.7.0 and 0.7.3: no release has moved
-anything our modules call. What did move is the *shape* of the refusal — the two
-Scaleway gaps answered a plain-text `404` until 0.7.3, which the SDK discarded
-for its content type, so the caller saw `404 Not Found` and no body. They answer
-`501` in Scaleway's own dialect now (our issue #74). The distinction in the last
-column is the whole value of re-running this — a missing route is a gap someone
-may fill, a decline is an answer.
+**Closed as of Feint 0.12.0** (re-measured 2026-08-31, both providers):
+*"every operation the client called is served by a pack"* — zero unserved
+calls, where the 0.7.3 recording below listed three. The apply this measures
+now completes end to end on both providers' modules, which is proof the real
+cluster root's provider module can be applied against the emulator, not only
+planned (see `feint-plan` above). What used to fail and what it moved to is
+kept in "Known gaps" below, since it is history now rather than a current
+limit.
 
 Upstream here is the emulator, not the cloud. A client that signs the host it
 was configured with — the Terraform provider does — cannot be recorded against a
@@ -117,13 +103,10 @@ carry, all recorded in [the open issues](https://github.com/dis-bzh/OpenAether-i
 
 | Not exercised | Why |
 |---|---|
-| Outscale load balancers | `CreateLoadBalancer` is **declined on purpose**, not missing: a load balancer is a data plane the emulator does not have, so creating one would return a DNS name resolving nowhere. `ReadLoadBalancers` answers an empty list. This one will not move. |
-| Scaleway IPAM reservations | Also a decline with a reason: addresses come from the subnet plan a NIC is placed in, so `BookIP` would hand out an address no runtime configures. `scaleway_ipam_ip` is therefore out of reach here. |
-| Scaleway LB and public gateway | Genuinely absent. The two remaining gaps our modules hit. Since 0.7.3 they at least refuse legibly — `501` in the SDK's own dialect instead of net/http's plain-text `404`, which the Scaleway SDK dropped on the floor for having the wrong content type (our issue #74). |
-| Scaleway root volume type | No `root_volume { volume_type }` is writable: provider 2.79+ refuses `b_ssd`, and `sbs_volume` plans for ever because the emulator overrides it. Honouring it would send the provider to `block/v1`, unmounted. Measured here, now upstream's stated limit and its issue #8. |
+| Scaleway root volume type | No `root_volume { volume_type }` is writable: provider 2.79+ refuses `b_ssd`, and `sbs_volume` plans for ever because the emulator overrides it. Honouring it would send the provider to `block/v1`, unmounted. Measured here, now upstream's stated limit and its issue #8. Not re-verified against 0.12.0. |
 | Image name resolution | The catalogue is fixed, and 0.7.0 applies the `image_names` filter, so a name a build pipeline published matches nothing — on either provider. The Scaleway tfvars pin `image_id`; the Outscale ones point `image_name` at a catalogue entry instead, which exercises the lookup without pretending to resolve our own image. |
 
-Three things left this list. `outscale_volume_link` in 0.6.0, which mounted the
+Six things left this list. `outscale_volume_link` in 0.6.0, which mounted the
 `LinkVolumeVmIds` filter its wait depends on. `data.outscale_images` in 0.7.0,
 which stopped segfaulting the provider — so the Outscale lane now resolves its
 image through the data source rather than a pinned id, exercising the
@@ -133,3 +116,16 @@ sixteen the pack minted, so tagging an `igw-` or an `rtb-` was refused on a
 resource the emulator had just created. The fixture tags six kinds now rather
 than putting back the three it had removed — a table that fell behind once
 should be exercised on more than the row that caught it.
+
+Three more left it at 0.12.0, measured 2026-08-31, and this table had called
+all three permanent. **Outscale load balancers**: `CreateLoadBalancer` and
+`UpdateLoadBalancer` now answer 200 — labelled here as "declined on purpose...
+this one will not move" right up to the release that moved it.
+**Scaleway IPAM reservations**: `ipam/v1/API.BookIP` now answers 200, not the
+`501` this table called a permanent decline. **Scaleway LB and public
+gateway**: every `lb/v1/ZonedAPI.*` route the module calls (`CreateLB`,
+`CreateFrontend`, `CreateBackend`, `AttachPrivateNetwork`…) now answers 200 —
+the two gaps this table called "genuinely absent". `feint-record`'s own apply
+(above) is what caught all three: an apply of the real cluster root's
+provider module, both providers, completing with zero unserved calls where
+0.7.3 stopped hard on the first one.


### PR DESCRIPTION
## What

Re-tested `feint` 0.12.0 on `main` (merged via #137) at the maintainer's request: `task feint-test` still green end to end on both providers, and a fresh `task feint-record` on both found **zero unserved calls**, where the 0.7.3 recording this doc quoted listed three.

`feint-record`'s own apply is a real `tofu apply -target=module.<provider>` on the cluster root itself (confirmed by reading `feint.sh`'s `record_root`), so this is also proof that root's provider module can now be applied against the emulator, not only planned — `feint-plan`'s "plan only" framing was stale for the same reason.

## Closed, all three previously documented here as permanent

| Gap | Old verdict in this doc | Now |
|---|---|---|
| Outscale load balancers | "declined on purpose... this one will not move" | `CreateLoadBalancer`/`UpdateLoadBalancer` answer 200 |
| Scaleway IPAM reservations | permanent decline | `BookIP` answers 200 |
| Scaleway LB and public gateway | "genuinely absent" | every `lb/v1/ZonedAPI.*` route the module calls answers 200 |

Moved from the "Known gaps" table to the "left this list" history in both `docs/emulated-cloud.md` and `.fr.md`, alongside the gaps 0.6.0/0.7.0 already closed there.

## Not touched

The Scaleway root volume type gap (`sbs_volume` plans forever) is an attribute-acceptance quirk, not a route — invisible to `feint-record`, so not re-verified here. Left in the table, noted as such.

## Proof

- `task feint-test`: full create → verify → empty re-plan → destroy, both providers, green.
- `task feint-record PROVIDER=scaleway` and `PROVIDER=outscale`: both report "every operation the client called is served by a pack".
- `task lint` green on the doc changes.

Docs only — mocked rung, no code touched.

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01MbJHzE7FcDKZQqSMFKfzqV)_