### PR TITLE
feat(feint): resolve Scaleway images by name, first Incus evidence lane

### DIFF
--- a/.feint-evidence-outscale.json
+++ b/.feint-evidence-outscale.json
@@ -1,0 +1,202 @@
+{
+  "format": "feint-evidence-baseline",
+  "version": 1,
+  "machines": [
+    "incus"
+  ],
+  "generated_from": {
+    "contracts": "absent",
+    "shapes": "absent",
+    "suites": "absent"
+  },
+  "operations": {
+    "osc/Client.CreateInternetService": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateKeypair": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateNatService": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateNet": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreatePublicIp": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateRoute": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateRouteTable": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateSecurityGroup": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateSecurityGroupRule": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateSubnet": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateTags": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateVms": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.CreateVolume": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteInternetService": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteKeypair": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteNatService": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteNet": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeletePublicIp": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteRoute": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteRouteTable": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteSecurityGroup": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteSecurityGroupRule": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteSubnet": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteVms": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.DeleteVolume": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.LinkInternetService": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.LinkPublicIp": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.LinkRouteTable": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.LinkVolume": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadInternetServices": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadKeypairs": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadLoadBalancers": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadNatServices": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadNets": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadNics": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadPublicIps": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadRouteTables": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadSecurityGroups": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadSubnets": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadVms": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadVmsState": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.ReadVolumes": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.StopVms": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.UnlinkInternetService": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.UnlinkPublicIp": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.UnlinkRouteTable": {
+      "dataplane": true,
+      "driven": true
+    },
+    "osc/Client.UnlinkVolume": {
+      "dataplane": true,
+      "driven": true
+    }
+  }
+}

--- a/.feint-evidence-scaleway.json
+++ b/.feint-evidence-scaleway.json
@@ -1,0 +1,138 @@
+{
+  "format": "feint-evidence-baseline",
+  "version": 1,
+  "machines": [
+    "incus"
+  ],
+  "generated_from": {
+    "contracts": "absent",
+    "shapes": "absent",
+    "suites": "absent"
+  },
+  "operations": {
+    "block/v1/API.DeleteVolume": {
+      "dataplane": true,
+      "driven": true
+    },
+    "block/v1/API.GetVolume": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.CreateIP": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.CreateSecurityGroup": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.CreateServer": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.CreateVolume": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.DeleteIP": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.DeleteSecurityGroup": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.DeleteVolume": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.GetIP": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.GetSecurityGroup": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.GetServer": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.GetServerUserData": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.GetVolume": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.ListSecurityGroupRules": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.ListServerUserData": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.ListServersTypes": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.ServerAction": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.SetSecurityGroupRules": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.SetServerUserData": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.UpdateIP": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v1/API.UpdateSecurityGroup": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v2alpha1/API.CreatePrivateNetworkInterface": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v2alpha1/API.DeletePrivateNetworkInterface": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v2alpha1/API.GetPrivateNetworkInterface": {
+      "dataplane": true,
+      "driven": true
+    },
+    "instance/v2alpha1/API.ListPrivateNetworkInterfaces": {
+      "dataplane": true,
+      "driven": true
+    },
+    "ipam/v1/API.ListIPs": {
+      "dataplane": true,
+      "driven": true
+    },
+    "marketplace/v2/API.ListLocalImages": {
+      "dataplane": true,
+      "driven": true
+    },
+    "vpc/v2/API.CreatePrivateNetwork": {
+      "dataplane": true,
+      "driven": true
+    },
+    "vpc/v2/API.DeletePrivateNetwork": {
+      "dataplane": true,
+      "driven": true
+    },
+    "vpc/v2/API.GetPrivateNetwork": {
+      "dataplane": true,
+      "driven": true
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,9 +479,27 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         run: task feint-evidence PROVIDER=${{ matrix.provider }}
 
+      # `evidence baseline` only reads the file `feint evidence` already wrote,
+      # so this needs no live emulator — safe to run after `feint-down`. A
+      # log line is not a build artifact: exact bytes, not a hand transcription
+      # of terminal output, are what a baseline this repo commits is built from.
+      - name: Capture the baseline as a build artifact
+        if: needs.changes.outputs.code == 'true'
+        run: |
+          ./scripts/dev/feint.sh evidence-baseline ${{ matrix.provider }} \
+            > "/tmp/feint-evidence-${{ matrix.provider }}.json"
+
       - name: task feint-down
         if: always() && needs.changes.outputs.code == 'true'
         run: task feint-down
+
+      - name: Upload the baseline
+        if: needs.changes.outputs.code == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: feint-evidence-${{ matrix.provider }}
+          path: /tmp/feint-evidence-${{ matrix.provider }}.json
+          retention-days: 7
 
   talos:
     name: Talos Config Validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,14 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         run: task feint-evidence PROVIDER=${{ matrix.provider }}
 
+      # Has what `.feint-evidence-<provider>.json` pins stopped being true?
+      # `continue-on-error` on the job (above) is what keeps this from blocking
+      # unrelated PRs on the startup race measured on this job's first runs
+      # (#151) — not a signal this check may be ignored.
+      - name: task feint-evidence-verify
+        if: needs.changes.outputs.code == 'true'
+        run: task feint-evidence-verify PROVIDER=${{ matrix.provider }}
+
       # `evidence baseline` only reads the file `feint evidence` already wrote,
       # so this needs no live emulator — safe to run after `feint-down`. A
       # log line is not a build artifact: exact bytes, not a hand transcription

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,100 @@ jobs:
         if: always() && needs.changes.outputs.code == 'true'
         run: task feint-down
 
+  # First trial of a machine runtime in this repo's CI (#151): `feint evidence
+  # baseline` refuses to pin anything captured under metadata-only machines
+  # (every `dataplane` verdict would be a hardcoded `false`), and this is the
+  # only way to earn a real one. Kept off the required path with
+  # continue-on-error while this is unproven here — not a signal it may be
+  # ignored, just that a still-flaky Incus recipe should not block unrelated
+  # work the first few times.
+  #
+  # No job-level `if:` either, same reason as `validate`/`emulated` above: a
+  # matrix job skipped by its own `if:` collapses every combination into one
+  # unexpanded check name. Steps are gated per matrix entry instead.
+  feint-evidence:
+    name: Feint Evidence (${{ matrix.provider }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: [validate, changes]
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [scaleway, outscale]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup OpenTofu
+        if: needs.changes.outputs.code == 'true'
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4  # v2
+        with:
+          # renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.*)$
+          tofu_version: "1.12.6"
+
+      - name: Setup Task
+        if: needs.changes.outputs.code == 'true'
+        run: ./scripts/internal/install-task.sh
+
+      - name: Install Feint (pinned + checksum-verified)
+        if: needs.changes.outputs.code == 'true'
+        run: |
+          ./scripts/dev/feint.sh install
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # The Zabbly stable channel, not the distro package: Ubuntu 24.04 ships
+      # Incus 6.0.0, below the 6.0.4 floor where NIC ACLs start being
+      # accepted. Mirrors stephrobert/feint's own runtime-proof.yml, the only
+      # place this recipe has actually been proven on a GitHub-hosted runner.
+      - name: Install Incus (Zabbly stable, key fingerprint pinned)
+        if: needs.changes.outputs.code == 'true'
+        env:
+          ZABBLY_FPR: "4EFC590696CB15B87C73A3AD82CC8797C838DCFD"
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          curl --retry 3 --retry-connrefused -fsSL https://pkgs.zabbly.com/key.asc -o "${workdir}/zabbly.asc"
+          fpr="$(gpg --show-keys --with-colons "${workdir}/zabbly.asc" | awk -F: '/^fpr/ {print $10; exit}')"
+          if [ "${fpr}" != "${ZABBLY_FPR}" ]; then
+            echo "unexpected Zabbly key fingerprint: ${fpr}" >&2
+            exit 1
+          fi
+          sudo install -D -m 0644 "${workdir}/zabbly.asc" /etc/apt/keyrings/zabbly.asc
+          # shellcheck disable=SC1091
+          codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+          arch="$(dpkg --print-architecture)"
+          sudo tee /etc/apt/sources.list.d/zabbly-incus.sources >/dev/null <<EOF
+          Enabled: yes
+          Types: deb
+          URIs: https://pkgs.zabbly.com/incus/stable
+          Suites: ${codename}
+          Components: main
+          Architectures: ${arch}
+          Signed-By: /etc/apt/keyrings/zabbly.asc
+          EOF
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends incus incus-client
+          sudo incus admin init --minimal
+          sudo incus --version
+
+      # The runner image ships Docker, which sets the host's iptables FORWARD
+      # policy to DROP — every packet an Incus machine sends or receives would
+      # die on a policy Incus never wrote. Same fix stephrobert/feint's own CI
+      # applies for the same reason.
+      - name: Keep the runner's Docker firewall out of the verdict
+        if: needs.changes.outputs.code == 'true'
+        run: sudo iptables -P FORWARD ACCEPT
+
+      - name: task feint-evidence
+        if: needs.changes.outputs.code == 'true'
+        run: task feint-evidence PROVIDER=${{ matrix.provider }}
+
+      - name: task feint-down
+        if: always() && needs.changes.outputs.code == 'true'
+        run: task feint-down
+
   talos:
     name: Talos Config Validation
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,10 @@ infrastructure/opentofu/cluster/bootstrap-manifests/cilium-local.yaml
 # a trap — if you ever see it in a working tree, a run died hard: delete it.
 infrastructure/opentofu-feint/terraform.tfstate*
 infrastructure/opentofu/cluster/zz-feint-backend_override.tf
+# `feint evidence`'s own output: regenerated per run, timestamped, never the
+# thing to commit. `.feint-evidence-<provider>.json` (the pinned baseline) is
+# the committed artifact, deliberately outside this directory.
+coverage/
 
 # Editor/IDE
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,25 +156,36 @@ in git. 0.1.0 is the first entry describing something proven.
   the module calling `instance/v1/API.ListImages` and `GetImage`, which a
   pinned `image_id` never triggered.
 
-- **`feint evidence baseline`/`evidence verify` wiring, gated on a machine
-  runtime this repo's CI does not have yet (#151).** Feint 0.12.0 lets a
-  downstream project pin the level of proof — seven independent axes per
-  operation — it actually relies on, and fail its own CI the day Feint
-  stops delivering one, instead of finding out from the outside after the
-  fact. `feint evidence baseline` refuses unconditionally, before any
-  `--axes` filtering, when the record it is pinning was earned with no
-  machine runtime (`internal/cli/evidence_baseline.go`'s `reachesARuntime`)
-  — every `dataplane` verdict would be a hardcoded `false`, and pinning
-  that would report nothing on the day it regressed for real. New
-  `scripts/dev/feint.sh evidence|evidence-baseline|evidence-verify` and
-  `task feint-evidence`/`feint-evidence-verify`, plus a `feint-evidence` CI
-  job that installs Incus (the same Zabbly-stable recipe
-  `stephrobert/feint`'s own CI proves on GitHub-hosted runners) and runs
-  the fixture's full apply/destroy cycle under it. Left `continue-on-error`
-  and without a committed `.feint-evidence-<provider>.json` yet: this is
-  the first run of that Incus recipe in this repository's CI, unverifiable
-  locally (this environment's egress policy blocks the Zabbly package
-  host), so the baseline itself is deferred to once the job is seen green.
+- **`feint evidence baseline`/`evidence verify` wired in, with a real,
+  committed baseline (#151).** Feint 0.12.0 lets a downstream project pin
+  the level of proof — seven independent axes per operation — it actually
+  relies on, and fail its own CI the day Feint stops delivering one,
+  instead of finding out from the outside after the fact. `feint evidence
+  baseline` refuses unconditionally, before any `--axes` filtering, when
+  the record it is pinning was earned with no machine runtime
+  (`internal/cli/evidence_baseline.go`'s `reachesARuntime`) — every
+  `dataplane` verdict would be a hardcoded `false`, and pinning that would
+  report nothing on the day it regressed for real. New `scripts/dev/feint.sh
+  evidence|evidence-baseline|evidence-verify`, `task
+  feint-evidence`/`feint-evidence-verify`, and a `feint-evidence` CI job
+  that installs Incus (the same Zabbly-stable recipe `stephrobert/feint`'s
+  own CI proves on GitHub-hosted runners) and runs the fixture's full
+  apply/destroy cycle under it — unverifiable locally, this environment's
+  egress policy blocks the Zabbly package host outright.
+
+  `.feint-evidence-scaleway.json` / `.feint-evidence-outscale.json` are the
+  real committed artefacts: pulled from two independent green CI runs of
+  that job (not hand-transcribed — a log line is not a build artifact, so
+  the job also uploads the baseline it captured, and this is that upload,
+  downloaded back), byte-identical between them, and `feint evidence
+  verify` now runs against them on every push. One of those two runs also
+  measured the only rough edge so far: `Feint Evidence (outscale)` failed
+  once with the emulator gone entirely between `feint start` confirming
+  "running" and the next command's own check — passed clean on the
+  immediate re-run and on scaleway throughout, so this reads as a
+  startup race under Incus rather than a real defect. The job stays
+  `continue-on-error` until that is either reproduced and fixed or seen
+  stable across enough runs to trust as a hard gate.
 
 - **Two Checkov custom checks close the gap for the three providers Checkov
   ships no policy family for (#123).** `.checkov.yaml` is a hard gate, but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,43 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Added
 
+- **The Scaleway feint lane resolves its image by name instead of skipping
+  the lookup (#150).** `data.scaleway_instance_image.talos` in
+  `modules/providers/scw/main.tf` — the real, production `image_name`
+  lookup — had a `count` of 0 on every feint run because
+  `envs/feint-scaleway.tfvars.example` pinned `image_id` instead, dating
+  back to when Feint declined `instance/v1 ListImages` outright. As of
+  0.12.0 that route is served, along with `CreateSnapshot` and
+  `CreateImage` (the latter enforces a real dependency: a made-up snapshot
+  id gets a genuine 404, not a rubber stamp). `scripts/dev/feint.sh` now
+  registers a throwaway image under the name the tfvars ask for — volume →
+  snapshot → image — before planning or applying, so the data source
+  resolves it for real. Verified on both lanes: `feint-plan` completes with
+  the data source resolved (a failed lookup errors `tofu plan` outright,
+  it does not silently degrade), and `feint-record`'s transcript now shows
+  the module calling `instance/v1/API.ListImages` and `GetImage`, which a
+  pinned `image_id` never triggered.
+
+- **`feint evidence baseline`/`evidence verify` wiring, gated on a machine
+  runtime this repo's CI does not have yet (#151).** Feint 0.12.0 lets a
+  downstream project pin the level of proof — seven independent axes per
+  operation — it actually relies on, and fail its own CI the day Feint
+  stops delivering one, instead of finding out from the outside after the
+  fact. `feint evidence baseline` refuses unconditionally, before any
+  `--axes` filtering, when the record it is pinning was earned with no
+  machine runtime (`internal/cli/evidence_baseline.go`'s `reachesARuntime`)
+  — every `dataplane` verdict would be a hardcoded `false`, and pinning
+  that would report nothing on the day it regressed for real. New
+  `scripts/dev/feint.sh evidence|evidence-baseline|evidence-verify` and
+  `task feint-evidence`/`feint-evidence-verify`, plus a `feint-evidence` CI
+  job that installs Incus (the same Zabbly-stable recipe
+  `stephrobert/feint`'s own CI proves on GitHub-hosted runners) and runs
+  the fixture's full apply/destroy cycle under it. Left `continue-on-error`
+  and without a committed `.feint-evidence-<provider>.json` yet: this is
+  the first run of that Incus recipe in this repository's CI, unverifiable
+  locally (this environment's egress policy blocks the Zabbly package
+  host), so the baseline itself is deferred to once the job is seen green.
+
 - **Two Checkov custom checks close the gap for the three providers Checkov
   ships no policy family for (#123).** `.checkov.yaml` is a hard gate, but
   measured on this tree Checkov's built-in rules land on OpenStack (OVH)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1472,6 +1472,35 @@ tasks:
         vars: {PROVIDER: "{{.ITEM}}"}
       - task: feint-down
 
+  feint-evidence:
+    desc: >-
+      Capture Feint's evidence record under a machine runtime (Incus) and print what a baseline would
+      pin. Needs Incus; see docs/emulated-cloud.md. Usage: task feint-evidence PROVIDER=scaleway|outscale
+    vars:
+      PROVIDER: '{{.PROVIDER | default "scaleway"}}'
+    # Task vars are NOT environment variables: without this,
+    # `task feint-plan FEINT_ENDPOINT=https://api.scaleway.com` set a var the
+    # script never read, the loopback guard never saw it, and the negative
+    # test in docs/release-checklist.md passed without testing anything.
+    env:
+      FEINT_ENDPOINT: '{{.FEINT_ENDPOINT | default "http://127.0.0.1:4599"}}'
+      FEINT_VM: incus
+    cmds:
+      - ./scripts/dev/feint.sh start
+      - ./scripts/dev/feint.sh apply {{.PROVIDER}}
+      - ./scripts/dev/feint.sh evidence {{.PROVIDER}}
+      - ./scripts/dev/feint.sh evidence-baseline {{.PROVIDER}}
+      - ./scripts/dev/feint.sh stop
+
+  feint-evidence-verify:
+    desc: >-
+      Check a freshly captured evidence record against the pinned baseline (.feint-evidence-<provider>.json).
+      Usage: task feint-evidence-verify PROVIDER=scaleway|outscale
+    vars:
+      PROVIDER: '{{.PROVIDER | default "scaleway"}}'
+    cmds:
+      - ./scripts/dev/feint.sh evidence-verify {{.PROVIDER}}
+
   # ===========================================================================
   # Local Testing (Docker / WSL2)
   # ===========================================================================

--- a/docs/emulated-cloud.fr.md
+++ b/docs/emulated-cloud.fr.md
@@ -26,6 +26,10 @@ task feint-apply  PROVIDER=outscale    # cycle apply/destroy sur la fixture réd
 task feint-record PROVIDER=scaleway    # classe ce que notre module appelle et qu'aucun pack ne sert
 task feint-test                        # les deux providers, plan + apply
 task feint-down
+
+task feint-evidence PROVIDER=scaleway  # besoin d'Incus : apply sous un vrai runtime machine, puis
+                                        # affiche ce qu'un baseline de la preuve de feint épinglerait (#151)
+task feint-evidence-verify PROVIDER=scaleway  # vérifie une capture fraîche contre le baseline épinglé
 ```
 
 ## Trois voies, parce qu'une seule ne peut pas faire les trois
@@ -107,7 +111,7 @@ toujours pas porter, tout consigné dans [les issues ouvertes](https://github.co
 | Non exercé | Pourquoi |
 |---|---|
 | Type de volume racine Scaleway | Aucun `root_volume { volume_type }` n'est écrivable : le provider 2.79+ refuse `b_ssd`, et `sbs_volume` planifie éternellement car l'émulateur l'écrase. L'honorer enverrait le provider sur `block/v1`, non monté. Mesuré ici, c'est devenu la limite documentée en amont et son issue #8. Non re-vérifié sous 0.12.0. |
-| Résolution d'image par nom | Le catalogue est fixe, et la 0.7.0 applique le filtre `image_names` : un nom publié par un pipeline de build ne correspond à rien — des deux côtés. Les tfvars Scaleway épinglent `image_id` ; ceux d'Outscale pointent `image_name` sur une entrée du catalogue, ce qui exerce la recherche sans prétendre résoudre notre propre image. |
+| Résolution d'image par nom, Outscale | Les tfvars Outscale pointent `image_name` sur une entrée fixe du catalogue, ce qui exerce le mécanisme de recherche sans résoudre un nom publié par notre propre pipeline — voir #150 pour ce qu'il faudrait. |
 
 Six choses ont quitté cette liste. `outscale_volume_link` en 0.6.0, qui a monté
 le filtre `LinkVolumeVmIds` dont dépend son attente. `data.outscale_images` en
@@ -134,3 +138,14 @@ manques que cette table appelait « réellement absents ». C'est l'apply propre
 à `feint-record` (ci-dessus) qui a attrapé les trois : un apply du module
 provider du vrai root cluster, les deux providers, allant jusqu'au bout avec
 zéro appel non servi, là où la 0.7.3 s'arrêtait net au premier.
+
+La moitié Scaleway de la résolution d'image par nom a fermé le même jour, pas
+via une version de feint mais parce que `scripts/dev/feint.sh` enregistre
+désormais une image sous le nom que demande
+`envs/feint-scaleway.tfvars.example`, avant de planifier ou d'appliquer :
+`data.scaleway_instance_image.talos`, code mort derrière un `image_id`
+épinglé jusque-là, tourne maintenant pour de vrai, et `feint-plan` comme
+`feint-record` le résolvent — le transcript de ce dernier montre le module
+appelant `instance/v1/API.ListImages` et `GetImage` pour la première fois
+(#150). Outscale non : ses tfvars pointent toujours `image_name` sur une
+entrée du catalogue plutôt que sur quelque chose que cette voie a créé.

--- a/docs/emulated-cloud.md
+++ b/docs/emulated-cloud.md
@@ -25,6 +25,10 @@ task feint-apply  PROVIDER=outscale    # apply/destroy cycle on the reduced fixt
 task feint-record PROVIDER=scaleway    # rank what our module calls and no pack serves
 task feint-test                        # both providers, plan + apply
 task feint-down
+
+task feint-evidence PROVIDER=scaleway  # needs Incus: apply under a real machine runtime, then
+                                        # print what a baseline of feint's own proof would pin (#151)
+task feint-evidence-verify PROVIDER=scaleway  # check a fresh capture against the pinned baseline
 ```
 
 ## Three lanes, because one cannot do all three jobs
@@ -104,7 +108,7 @@ carry, all recorded in [the open issues](https://github.com/dis-bzh/OpenAether-i
 | Not exercised | Why |
 |---|---|
 | Scaleway root volume type | No `root_volume { volume_type }` is writable: provider 2.79+ refuses `b_ssd`, and `sbs_volume` plans for ever because the emulator overrides it. Honouring it would send the provider to `block/v1`, unmounted. Measured here, now upstream's stated limit and its issue #8. Not re-verified against 0.12.0. |
-| Image name resolution | The catalogue is fixed, and 0.7.0 applies the `image_names` filter, so a name a build pipeline published matches nothing — on either provider. The Scaleway tfvars pin `image_id`; the Outscale ones point `image_name` at a catalogue entry instead, which exercises the lookup without pretending to resolve our own image. |
+| Outscale image name resolution | The Outscale tfvars point `image_name` at a fixed catalogue entry, which exercises the lookup mechanism without resolving a name our own pipeline published — see #150 for what it would take. |
 
 Six things left this list. `outscale_volume_link` in 0.6.0, which mounted the
 `LinkVolumeVmIds` filter its wait depends on. `data.outscale_images` in 0.7.0,
@@ -129,3 +133,13 @@ the two gaps this table called "genuinely absent". `feint-record`'s own apply
 (above) is what caught all three: an apply of the real cluster root's
 provider module, both providers, completing with zero unserved calls where
 0.7.3 stopped hard on the first one.
+
+Scaleway's half of image name resolution closed the same day, not from a
+feint version but from `scripts/dev/feint.sh` registering an image under the
+name `envs/feint-scaleway.tfvars.example` asks for, before planning or
+applying: `data.scaleway_instance_image.talos`, dead code behind a pinned
+`image_id` until then, now runs for real, and both `feint-plan` and
+`feint-record` resolve it — the latter's transcript shows the module calling
+`instance/v1/API.ListImages` and `GetImage` for the first time (#150).
+Outscale is not: its tfvars still point `image_name` at a catalogue entry
+rather than something this lane created.

--- a/infrastructure/opentofu/cluster/envs/feint-scaleway.tfvars.example
+++ b/infrastructure/opentofu/cluster/envs/feint-scaleway.tfvars.example
@@ -8,9 +8,11 @@
 # Every value here is fake by construction — this file is public, and nothing in
 # it may ever name a real environment. admin_ip is RFC 5737 TEST-NET-3.
 #
-# image_id is pinned because Feint serves no image search: `instance/v1
-# ListImages` answers 501, so a lookup by name cannot resolve. This id is the
-# single image the emulator publishes.
+# image_name, not image_id: as of Feint 0.12.0 `instance/v1 ListImages`,
+# CreateSnapshot and CreateImage are all served, so `scripts/dev/feint.sh`
+# registers a throwaway image under this exact name before planning or
+# applying — the same `data.scaleway_instance_image` name lookup a real
+# deploy uses actually runs, instead of being skipped by a pinned id (#150).
 # ==============================================================================
 
 cluster_name    = "feint-scaleway"
@@ -26,7 +28,7 @@ node_distribution = {
     zone           = "fr-par-1"
     zones          = ["fr-par-1"]
     instance_type  = "DEV1-S"
-    image_id       = "22222222-2222-4222-8222-222222222222"
+    image_name     = "talos-openaether-feint"
   }
 }
 

--- a/scripts/dev/feint.sh
+++ b/scripts/dev/feint.sh
@@ -5,6 +5,7 @@
 #
 # Usage: feint.sh install|start|stop|status|guard [endpoint]
 #        feint.sh plan|apply|record scaleway|outscale
+#        feint.sh evidence|evidence-baseline|evidence-verify scaleway|outscale
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -13,6 +14,23 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FEINT_VERSION="0.12.0"
 FEINT_ENDPOINT="${FEINT_ENDPOINT:-http://127.0.0.1:4599}"
 BIN_DIR="${FEINT_BIN_DIR:-$HOME/.local/bin}"
+# Off (metadata-only machines) unless a caller asks for a real one — the
+# evidence lane sets this to "incus", nothing else needs to.
+FEINT_VM="${FEINT_VM:-}"
+
+# feint_cli runs the emulator's own lifecycle commands (start/stop/status): a
+# machine runtime means Incus, whose socket belongs to root:incus-admin, and a
+# group granted mid-job never reaches the runner's already-running session —
+# so root is how feint's own CI runs it too. Resolved to an absolute path
+# first: sudo's secure_path does not carry $BIN_DIR when that is a user
+# install (~/.local/bin).
+feint_cli() {
+  if [ -n "$FEINT_VM" ]; then
+    sudo "$(command -v feint)" "$@"
+  else
+    feint "$@"
+  fi
+}
 
 # --- The guard --------------------------------------------------------------
 # Refuse anything that is not this machine. Every official cloud client falls
@@ -32,7 +50,7 @@ addr_of() { printf '%s' "${1#http://}"; }
 
 # running answers whether the emulator is actually listening. `feint status`
 # exits 0 whether or not it is, so the output is the only signal.
-running() { feint status 2>/dev/null | grep -q '^running on'; }
+running() { feint_cli status 2>/dev/null | grep -q '^running on'; }
 
 # require_emulator fails a lane that has nothing to talk to.
 #
@@ -65,8 +83,10 @@ require_emulator() {
 # a lane inherits the previous one's resources and dies on 409 at the first
 # create, long before reaching the operations it was meant to measure.
 reset_emulator() {
-  feint stop >/dev/null 2>&1 || true
-  feint start --addr "$(addr_of "$FEINT_ENDPOINT")" >/dev/null
+  local vm_args=()
+  [ -n "$FEINT_VM" ] && vm_args=(--vm "$FEINT_VM")
+  feint_cli stop >/dev/null 2>&1 || true
+  feint_cli start --addr "$(addr_of "$FEINT_ENDPOINT")" "${vm_args[@]}" >/dev/null
   running || { echo "✗ the emulator did not come back on $FEINT_ENDPOINT" >&2; exit 1; }
 }
 
@@ -111,6 +131,49 @@ install_feint() {
   echo "installed feint v${FEINT_VERSION} → $BIN_DIR/feint"
 }
 
+# The Terraform provider resolves `image_name` through a real name lookup —
+# `data.scaleway_instance_image.talos` in modules/providers/scw/main.tf, whose
+# `count` is 0 whenever `image_id` is set. Every feint tfvars used to pin
+# `image_id` instead, so that data source never actually ran. Feint 0.7.0
+# declined `instance/v1 ListImages` outright (501); 0.12.0 serves it, along with
+# CreateSnapshot and CreateImage — none declined, and CreateImage enforces a
+# real dependency (a made-up snapshot id gets a genuine 404, not a rubber
+# stamp). So a name can now be made to resolve to something real: create a
+# throwaway volume, snapshot it, and register an image under the name
+# `envs/feint-scaleway.tfvars.example` asks for. See issue #150.
+SCW_FEINT_IMAGE_NAME="talos-openaether-feint"
+# The fixed project the emulated `scaleway` provider block pins
+# (infrastructure/opentofu/cluster/main.tf, local.emulator_creds.scw_project_id).
+SCW_FEINT_PROJECT_ID="11111111-1111-1111-1111-111111111111"
+
+register_scaleway_image() {
+  local endpoint="$1" zone="fr-par-1" images_url vol_id snap_id
+  images_url="$endpoint/instance/v1/zones/$zone/images"
+
+  # Idempotent: a second call against an emulator that already served the
+  # first one must not mint a duplicate image under the same name.
+  if curl -sf "$images_url?name=$SCW_FEINT_IMAGE_NAME" \
+    | grep -q "\"name\":\"$SCW_FEINT_IMAGE_NAME\""; then
+    return 0
+  fi
+
+  vol_id="$(curl -sf -X POST "$endpoint/instance/v1/zones/$zone/volumes" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"${SCW_FEINT_IMAGE_NAME}-src\",\"volume_type\":\"l_ssd\",\"size\":10000000000,\"project_id\":\"$SCW_FEINT_PROJECT_ID\"}" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["volume"]["id"])')"
+
+  snap_id="$(curl -sf -X POST "$endpoint/instance/v1/zones/$zone/snapshots" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"${SCW_FEINT_IMAGE_NAME}-snap\",\"volume_id\":\"$vol_id\",\"project_id\":\"$SCW_FEINT_PROJECT_ID\"}" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["snapshot"]["id"])')"
+
+  curl -sf -X POST "$images_url" -H 'Content-Type: application/json' \
+    -d "{\"name\":\"$SCW_FEINT_IMAGE_NAME\",\"root_volume\":\"$snap_id\",\"arch\":\"x86_64\",\"project_id\":\"$SCW_FEINT_PROJECT_ID\"}" \
+    >/dev/null
+
+  echo "  registered image '$SCW_FEINT_IMAGE_NAME' — image_name now resolves to something the emulator actually created"
+}
+
 # plan_root runs `tofu plan` on the REAL cluster root against the emulator.
 #
 # That root declares a partial S3 backend, and `init -backend=false` then leaves
@@ -141,6 +204,8 @@ terraform {
 }
 EOT
   cp "$example" "$work/feint.tfvars"
+
+  [ "$provider" = scaleway ] && register_scaleway_image "$FEINT_ENDPOINT"
 
   emulated_env
   export TF_VAR_encryption_passphrase="feint-emulated-lane-passphrase-not-a-secret"
@@ -181,6 +246,10 @@ record_root() {
 
   work="$(mktemp -d)"
   reset_emulator
+  # Straight to the emulator, never through the proxy about to start: this is
+  # our own setup, not a call the module makes, and the transcript below must
+  # rank only the latter.
+  [ "$provider" = scaleway ] && register_scaleway_image "$FEINT_ENDPOINT"
   feint proxy --provider "$provider" --upstream "$FEINT_ENDPOINT" \
     --addr "$proxy_addr" --record "$work/$provider.jsonl" >"$work/proxy.log" 2>&1 &
   proxy_pid=$!
@@ -314,21 +383,23 @@ case "${1:-}" in
     # honoured on a fresh machine and decorative on every machine that had already
     # run the lane. Bumping the pin to 0.10.0 on 2026-08-21 kept running 0.9.0.
     install_feint
+    vm_args=()
+    [ -n "$FEINT_VM" ] && vm_args=(--vm "$FEINT_VM")
     # Idempotent: `feint start` refuses when one is already listening, and a
     # target you cannot run twice is a target nobody re-runs after a failure.
     # Matched on the output, not the exit code: `feint status` exits 0 either
     # way, so keying off it silently skipped the start and left every later
     # step running against nothing.
-    running || feint start --addr "$(addr_of "$FEINT_ENDPOINT")"
+    running || feint_cli start --addr "$(addr_of "$FEINT_ENDPOINT")" "${vm_args[@]}"
     running || { echo "✗ the emulator did not come up on $FEINT_ENDPOINT" >&2; exit 1; }
-    feint status
+    feint_cli status
     ;;
   stop)
     # Stopping is enough to discard the store: it lives in memory, nothing is
     # persisted (no --state). Resetting between lanes is `reset_emulator`.
-    feint stop || true
+    feint_cli stop || true
     ;;
-  status) feint status ;;
+  status) feint_cli status ;;
   guard) guard_local "${2:-$FEINT_ENDPOINT}" ;;
   plan)
     guard_local "$FEINT_ENDPOINT"
@@ -345,9 +416,34 @@ case "${1:-}" in
     require_emulator
     record_root "${2:?usage: feint.sh record scaleway|outscale}"
     ;;
+  evidence)
+    # Reads whatever the emulator's own /_feint/conformance already knows, so
+    # it must run right after a real cycle (e.g. `feint.sh apply`) and before
+    # any reset — a reset is what a fresh `feint start` always is (#151).
+    guard_local "$FEINT_ENDPOINT"
+    require_emulator
+    provider="${2:?usage: feint.sh evidence scaleway|outscale}"
+    mkdir -p "$REPO_ROOT/coverage"
+    feint evidence --endpoint "$FEINT_ENDPOINT" --out "$REPO_ROOT/coverage/evidence-${provider}.json"
+    ;;
+  evidence-baseline)
+    # Refuses at capture if the record behind it reached no machine runtime
+    # (`FEINT_VM` unset) — see feint's own `evidence baseline` help. No `--out`:
+    # printed for a human to review before it becomes a committed file, not
+    # written as a side effect of a script.
+    provider="${2:?usage: feint.sh evidence-baseline scaleway|outscale}"
+    feint evidence baseline --evidence "$REPO_ROOT/coverage/evidence-${provider}.json"
+    ;;
+  evidence-verify)
+    provider="${2:?usage: feint.sh evidence-verify scaleway|outscale}"
+    feint evidence verify \
+      --baseline "$REPO_ROOT/.feint-evidence-${provider}.json" \
+      --evidence "$REPO_ROOT/coverage/evidence-${provider}.json"
+    ;;
   *)
     echo "Usage: $(basename "$0") install|start|stop|status|guard [endpoint]" >&2
     echo "       $(basename "$0") plan|apply|record scaleway|outscale" >&2
+    echo "       $(basename "$0") evidence|evidence-baseline|evidence-verify scaleway|outscale" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- **Closes #150** — `data.scaleway_instance_image.talos` in
  `modules/providers/scw/main.tf` (the real, production `image_name` lookup)
  had `count = 0` on every feint run because the tfvars pinned `image_id`
  instead, dating back to when Feint declined `instance/v1 ListImages`
  outright. As of Feint 0.12.0 that route is served, along with
  `CreateSnapshot` and `CreateImage` (the latter enforces a real dependency —
  a made-up snapshot id gets a genuine 404, not a rubber stamp).
  `scripts/dev/feint.sh` now registers a throwaway image under the name the
  tfvars ask for — volume → snapshot → image — before planning or applying.
  Verified locally: `feint-plan` completes with the data source resolved (a
  failed lookup errors `tofu plan` outright), and `feint-record`'s transcript
  now shows the module calling `instance/v1/API.ListImages` and `GetImage`,
  which a pinned `image_id` never triggered.

- **Closes #151** — `feint evidence`/`evidence-baseline`/`evidence-verify`
  wiring (`scripts/dev/feint.sh`, `task feint-evidence(-verify)`) and a
  `feint-evidence` CI job that installs Incus (the same Zabbly-stable recipe
  `stephrobert/feint`'s own CI proves on GitHub-hosted runners), so
  `feint evidence baseline` earns a real machine runtime instead of refusing
  outright. `.feint-evidence-scaleway.json` / `.feint-evidence-outscale.json`
  are now committed — pulled from two independent green CI runs of that job
  (the job uploads what it captured as a build artifact; these are that
  artifact downloaded back, not a hand transcription), byte-identical
  between them. `feint evidence verify` runs against them on every push.
  One of those two runs surfaced a startup race under Incus (the emulator
  gone entirely between `feint start` confirming "running" and the very
  next command's check) — clean on an immediate re-run and on scaleway
  throughout, so the job stays `continue-on-error` until that is reproduced
  and fixed, or seen stable across enough runs to trust as a hard gate.

## Test plan

- [x] `task lint` — clean (shellcheck, actionlint, yamllint, tflint,
      check-version-drift, check-language, check-dead-references, …)
- [x] `task feint-test` (both providers, plan + apply) — green, no regression
- [x] `task feint-plan PROVIDER=scaleway` — real image registered, data
      source resolves it by name
- [x] `task feint-record PROVIDER=scaleway` — real apply through the proxy,
      zero unserved calls, transcript shows `ListImages`/`GetImage` for the
      first time
- [x] `task feint-plan/apply PROVIDER=outscale` — unaffected, still green
- [x] `plumber analyze` locally — 0 findings on pinning, permissions,
      dangerous triggers, checkout credentials
- [x] `feint-evidence` CI job (Incus install + `task feint-evidence`) — green
      on both providers across two runs (one re-run needed for a startup
      race on outscale); `.feint-evidence-*.json` pulled from those runs and
      committed; `feint evidence verify` green against them