### PR TITLE
fix(cluster): correct stale deprecation comment on outscale region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **A comment beside the Outscale provider block claimed the top-level
+  `region` argument was deprecated and warned on every real command**
+  (#77). Stale: `outscale/terraform-provider-outscale` reverted that
+  deprecation in its own PR #817, shipped in 1.8.0 — the version this repo
+  already pins. Real commands no longer warn, so there is nothing left to
+  avoid by building the API URL ourselves (which would mean hardcoding
+  Outscale's DNS). Comment now records the decision instead of a stale
+  premise; no behavior change.
+
 - **`docs/emulated-cloud.md`/`.fr.md` documented three Feint gaps as
   permanent** — Outscale load balancers ("this one will not move"), Scaleway
   IPAM reservations, Scaleway LB and public gateway ("genuinely absent") —

--- a/infrastructure/opentofu/cluster/main.tf
+++ b/infrastructure/opentofu/cluster/main.tf
@@ -43,8 +43,12 @@ provider "outscale" {
   access_key_id = local.emulated ? local.emulator_creds.osc_access_key : (var.outscale_access_key_id != "" ? var.outscale_access_key_id : null)
   secret_key_id = local.emulated ? local.emulator_creds.osc_secret_key : (var.outscale_secret_key_id != "" ? var.outscale_secret_key_id : null)
 
-  # region and the api{} block are mutually exclusive: the top-level argument is
-  # deprecated in favour of the block, and setting both warns on every command.
+  # region and the api{} block are mutually exclusive — only one may be set.
+  # #77 asked whether to move real runs onto api{} too, which would mean
+  # hardcoding Outscale's DNS ourselves. Decided: no. outscale/terraform-provider-outscale
+  # reverted the top-level `region` deprecation in its own PR #817 (shipped in
+  # 1.8.0, pinned here) — real commands no longer warn, so there is nothing left
+  # to build the URL to avoid.
   region = local.emulated ? null : (local.active_provider == "outscale" ? local.osc_dist.region : null)
 
   # `endpoint` carries the whole API path, version segment included. Without it


### PR DESCRIPTION
## What

`outscale/terraform-provider-outscale` reverted the top-level `region` deprecation in its own PR #817, shipped in 1.8.0 — the version this repo already pins (confirmed against `infrastructure/opentofu/modules/providers/outscale/.terraform.lock.hcl`: `version = "1.8.0"`). Real Outscale commands no longer warn, so the "build the URL ourselves vs. keep the warning" decision the issue asked for is moot — there's no warning left to avoid.

The comment beside the provider block claimed the opposite (deprecated, warns on every command) — stale, now corrected to record the actual decision instead.

No behavior change — comment only.

## Proof

- `tofu validate` — Success.
- `task lint` — green.
- Public-repo-safety IP check on the diff — clean.

Mocked rung — doc/comment-only change, no provider code touched.

Closes #77

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_