### PR TITLE
fix(test): version-pair guard proven against every step of the climb, not just endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,17 @@ in git. 0.1.0 is the first entry describing something proven.
   `scripts/dev/check-commit-authors.sh`, run in CI on the PR range, which is the
   only place it can still be refused.
 
+- **The version-pair guard was only tested on its start and end points, never
+  the path between them (#50).** A valid pair joined to another valid pair by
+  a step that is neither still passes if nothing evaluates the step. Seven
+  new `tofu test` run blocks in `version-pair.tftest.hcl` walk every
+  intermediate pair of the documented climb from (v1.12.7, v1.31.0) to
+  (v1.13.9, v1.36.3) — Talos moving first, then Kubernetes one minor at a
+  time — plus one trap pair (v1.13.9, v1.30.0: Talos ahead of Kubernetes
+  catching up) that the guard must refuse. Mutation-verified: narrowing
+  `k8s_min` in `version-support.json` turned one of the new intermediate runs
+  red before the revert.
+
 ### Added
 
 - **The Scaleway feint lane resolves its image by name instead of skipping

--- a/infrastructure/opentofu/cluster/tests/version-pair.tftest.hcl
+++ b/infrastructure/opentofu/cluster/tests/version-pair.tftest.hcl
@@ -146,3 +146,69 @@ run "unknown_talos_minor_is_refused" {
   }
   expect_failures = [terraform_data.version_pair_guard]
 }
+
+# A valid start and a valid end can be joined by a step that is neither, since
+# the two move one minor at a time. Each of these is one step of the climb
+# from (v1.12.7, v1.31.0) to the final pair above (v1.13.9, v1.36.3): Talos
+# first, then Kubernetes one minor at a time — every step must clear the guard
+# on its own, not just the endpoints.
+
+run "climb_step_v1_12_7_v1_31_0_passes" {
+  command = plan
+  variables {
+    talos_version      = "v1.12.7"
+    kubernetes_version = "v1.31.0"
+  }
+}
+
+run "climb_step_v1_13_9_v1_31_0_passes" {
+  command = plan
+  variables {
+    talos_version      = "v1.13.9" # Talos moves first, Kubernetes unchanged
+    kubernetes_version = "v1.31.0"
+  }
+}
+
+run "climb_step_v1_13_9_v1_32_0_passes" {
+  command = plan
+  variables {
+    talos_version      = "v1.13.9"
+    kubernetes_version = "v1.32.0"
+  }
+}
+
+run "climb_step_v1_13_9_v1_33_0_passes" {
+  command = plan
+  variables {
+    talos_version      = "v1.13.9"
+    kubernetes_version = "v1.33.0"
+  }
+}
+
+run "climb_step_v1_13_9_v1_34_0_passes" {
+  command = plan
+  variables {
+    talos_version      = "v1.13.9"
+    kubernetes_version = "v1.34.0"
+  }
+}
+
+run "climb_step_v1_13_9_v1_35_0_passes" {
+  command = plan
+  variables {
+    talos_version      = "v1.13.9"
+    kubernetes_version = "v1.35.0"
+  }
+}
+
+run "climb_trap_v1_13_9_v1_30_0_is_refused" {
+  command = plan
+  variables {
+    # Talos moved ahead of Kubernetes catching up: a valid pair on its own
+    # (1.30 is in range for Talos 1.12) but not one this climb ever visits
+    # once Talos is at 1.13, whose floor is 1.31.
+    talos_version      = "v1.13.9"
+    kubernetes_version = "v1.30.0"
+  }
+  expect_failures = [terraform_data.version_pair_guard]
+}


### PR DESCRIPTION
## What

`versions-guard.tf`'s Terraform-level precondition had only ever been exercised against a start pair and an end pair (`version-pair.tftest.hcl`'s 3 run blocks) — nothing proved it accepts every *intermediate* pair of a real multi-step upgrade climb, or rejects the specific wrong-order trap the code's own comments name: Talos moving ahead of Kubernetes lands on `(1.13, 1.30)`, which isn't a supported pair. `cluster-upgrade.sh`'s own `version_path`/`pair_ok` logic already walks that path in bash+jq — the OpenTofu guard itself was untested against it.

## Fix

7 new `tofu test` run blocks in `infrastructure/opentofu/cluster/tests/version-pair.tftest.hcl`:
- 6 `plan`-only runs walking every intermediate pair from `(v1.12.7, v1.31.0)` to `(v1.13.9, v1.35.0)` — the final step `(v1.13.9, v1.36.3)` is already covered by the existing `supported_pair_passes`.
- 1 trap-pair run for `(v1.13.9, v1.30.0)` with `expect_failures = [terraform_data.version_pair_guard]`.

Test-only — no production code touched.

## Proof

- Suite: 53 → 60 passed, 0 failed.
- Mutation-tested: temporarily narrowed `1.13`'s `k8s_min` from 31 to 33 in `version-support.json`, confirmed the new `(v1.13.9, v1.31.0)` run block went red while the pre-existing baseline runs stayed green, then reverted (`git diff` on `version-support.json` clean before commit).
- `task lint`, `task test-scripts`, `task validate`, `task render-check`, checkov (32/0), checkov custom checks, gitleaks — all green.

Mocked rung, matches the issue's own ask.

Closes #50

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_