### PR TITLE
fix(bastion): make SSH-CA hooks real instead of hardcoded-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **The bastion's SSH-CA hooks shipped inert since they were written** ([#81](https://github.com/dis-bzh/OpenAether-infra/issues/81)).
+  `_shared/bastion-cloud-init.yaml.tftpl` hardcoded `TrustedUserCAKeys` and
+  `AuthorizedPrincipalsFile` to an always-empty file and directory, so no
+  caller could ever turn SSH-CA on — every bastion stayed on a static key
+  only a `tofu apply` can revoke. Both are now real template variables
+  (`ssh_ca_public_key`, `ssh_ca_principals`), default `""`, threaded through
+  all four providers' `bastion.tf` and the Feint fixture — identical
+  rendered bytes when unset. New `scripts/dev/ssh-ca-check.sh`
+  (`task ssh-ca-check`) proves it on a real sshd in Docker: a CA-signed
+  certificate authenticates, the same bare key without it is refused, and
+  `ssh -o ExitOnForwardFailure=yes -L` carries traffic through `PermitOpen`.
+  Rung: emulated.
 - **`docs/emulated-cloud.md`/`.fr.md` documented three Feint gaps as
   permanent** — Outscale load balancers ("this one will not move"), Scaleway
   IPAM reservations, Scaleway LB and public gateway ("genuinely absent") —

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1472,6 +1472,14 @@ tasks:
         vars: {PROVIDER: "{{.ITEM}}"}
       - task: feint-down
 
+  ssh-ca-check:
+    desc: >-
+      Bastion SSH-CA, rung "emulated" (#81): renders the shared cloud-init template and proves
+      TrustedUserCAKeys/AuthorizedPrincipalsFile actually work on a real sshd in Docker. No cloud
+      account. Needs Docker; skips (exit 0) if it is unavailable.
+    cmds:
+      - ./scripts/dev/ssh-ca-check.sh
+
   feint-evidence:
     desc: >-
       Capture Feint's evidence record under a machine runtime (Incus) and print what a baseline would

--- a/infrastructure/opentofu-feint/main.tf
+++ b/infrastructure/opentofu-feint/main.tf
@@ -29,6 +29,8 @@ locals {
     extra_packages    = []
     extra_write_files = []
     extra_runcmd      = []
+    ssh_ca_public_key = ""
+    ssh_ca_principals = ""
   })
 }
 

--- a/infrastructure/opentofu/modules/providers/_shared/bastion-cloud-init.yaml.tftpl
+++ b/infrastructure/opentofu/modules/providers/_shared/bastion-cloud-init.yaml.tftpl
@@ -10,7 +10,9 @@
 #
 # Vars: ssh_keys, bastion_user, private_cidr (required);
 #       extra_packages, extra_write_files, extra_runcmd (optional, runcmd runs
-#       BEFORE nftables is enabled).
+#       BEFORE nftables is enabled);
+#       ssh_ca_public_key, ssh_ca_principals (optional, default "" = SSH-CA
+#       off — see the "SSH-CA" write_files block below).
 
 groups:
   - bastion-admins
@@ -83,7 +85,8 @@ write_files:
       ClientAliveInterval 300
       ClientAliveCountMax 2
 
-      # SSH-CA forward-compat (empty files = no-op until CA is activated)
+      # SSH-CA: off by default (ssh_ca_public_key = "" -> empty trust file, no
+      # cert can verify). Set both ssh_ca_* vars to activate.
       TrustedUserCAKeys /etc/ssh/trusted_user_ca.pub
       AuthorizedPrincipalsFile /etc/ssh/auth_principals/%u
 
@@ -132,12 +135,22 @@ write_files:
       }
 
   # --------------------------------------------------------------------------
-  # SSH-CA forward-compat — empty placeholder files (no-op today)
-  # When SSH CA is activated via OpenBao, populate these files and reload sshd.
+  # SSH-CA — ssh_ca_public_key defaults to "" (empty trust file = today's
+  # inert behaviour, byte for byte). Populate it (typically from OpenBao) to
+  # activate cert-based auth.
   # --------------------------------------------------------------------------
   - path: /etc/ssh/trusted_user_ca.pub
     permissions: '0644'
-    content: ""
+    content: "${ssh_ca_public_key}"
+%{ if ssh_ca_principals != "" ~}
+
+  # AuthorizedPrincipalsFile target for ${bastion_user} — only written when
+  # ssh_ca_principals is set, so the "" default renders no extra file at all.
+  - path: /etc/ssh/auth_principals/${bastion_user}
+    permissions: '0644'
+    content: |
+      ${indent(6, trimspace(ssh_ca_principals))}
+%{ endif ~}
 
   # --------------------------------------------------------------------------
   # No bash history to disk
@@ -173,7 +186,9 @@ mounts:
   - [tmpfs, /tmp, tmpfs, "size=64m,mode=1777,nosuid,nodev,noexec", "0", "0"]
 
 runcmd:
-  # SSH-CA principals directory (no-op placeholder)
+  # SSH-CA principals directory — created even when ssh_ca_principals is ""
+  # (cloud-init only creates parents for files it writes) so the directory
+  # always exists for AuthorizedPrincipalsFile to point at.
   - mkdir -p /etc/ssh/auth_principals && chmod 755 /etc/ssh/auth_principals
   # Ensure authorized_keys.d has correct ownership
   - chown root:root /etc/ssh/authorized_keys.d && chmod 755 /etc/ssh/authorized_keys.d

--- a/infrastructure/opentofu/modules/providers/outscale/bastion.tf
+++ b/infrastructure/opentofu/modules/providers/outscale/bastion.tf
@@ -87,6 +87,8 @@ resource "outscale_vm" "bastion" {
     extra_packages    = []
     extra_write_files = []
     extra_runcmd      = []
+    ssh_ca_public_key = var.bastion_ssh_ca_public_key
+    ssh_ca_principals = var.bastion_ssh_ca_principals
   }))
 
   tags {

--- a/infrastructure/opentofu/modules/providers/outscale/variables.tf
+++ b/infrastructure/opentofu/modules/providers/outscale/variables.tf
@@ -92,6 +92,20 @@ variable "bastion_ssh_keys" {
   default     = []
 }
 
+# SSH-CA — both "" (default) keeps the bastion on static-key auth only, byte
+# for byte the same cloud-init as before these variables existed.
+variable "bastion_ssh_ca_public_key" {
+  description = "SSH CA public key trusted for certificate auth on the bastion (empty = SSH-CA off)"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_ssh_ca_principals" {
+  description = "Principals (one per line) authorized via AuthorizedPrincipalsFile for bastion_user (empty = SSH-CA off)"
+  type        = string
+  default     = ""
+}
+
 variable "bastion_image_id" {
   description = "Image ID for the bastion host"
   type        = string

--- a/infrastructure/opentofu/modules/providers/ovh/bastion.tf
+++ b/infrastructure/opentofu/modules/providers/ovh/bastion.tf
@@ -117,6 +117,8 @@ resource "openstack_compute_instance_v2" "bastion" {
     extra_packages    = []
     extra_write_files = []
     extra_runcmd      = []
+    ssh_ca_public_key = var.bastion_ssh_ca_public_key
+    ssh_ca_principals = var.bastion_ssh_ca_principals
   })
 
   tags = ["bastion", var.cluster_name]

--- a/infrastructure/opentofu/modules/providers/ovh/variables.tf
+++ b/infrastructure/opentofu/modules/providers/ovh/variables.tf
@@ -96,6 +96,20 @@ variable "bastion_ssh_keys" {
   default     = []
 }
 
+# SSH-CA — both "" (default) keeps the bastion on static-key auth only, byte
+# for byte the same cloud-init as before these variables existed.
+variable "bastion_ssh_ca_public_key" {
+  description = "SSH CA public key trusted for certificate auth on the bastion (empty = SSH-CA off)"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_ssh_ca_principals" {
+  description = "Principals (one per line) authorized via AuthorizedPrincipalsFile for bastion_user (empty = SSH-CA off)"
+  type        = string
+  default     = ""
+}
+
 variable "bastion_image_id" {
   description = "Image ID or name for the bastion host"
   type        = string

--- a/infrastructure/opentofu/modules/providers/proxmox/bastion.tf
+++ b/infrastructure/opentofu/modules/providers/proxmox/bastion.tf
@@ -75,6 +75,8 @@ resource "proxmox_virtual_environment_file" "bastion_cloud_init" {
       extra_packages    = []
       extra_write_files = []
       extra_runcmd      = []
+      ssh_ca_public_key = var.bastion_ssh_ca_public_key
+      ssh_ca_principals = var.bastion_ssh_ca_principals
     })
   }
 }

--- a/infrastructure/opentofu/modules/providers/proxmox/variables.tf
+++ b/infrastructure/opentofu/modules/providers/proxmox/variables.tf
@@ -208,6 +208,20 @@ variable "bastion_ssh_keys" {
   default     = []
 }
 
+# SSH-CA — both "" (default) keeps the bastion on static-key auth only, byte
+# for byte the same cloud-init as before these variables existed.
+variable "bastion_ssh_ca_public_key" {
+  description = "SSH CA public key trusted for certificate auth on the bastion (empty = SSH-CA off)"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_ssh_ca_principals" {
+  description = "Principals (one per line) authorized via AuthorizedPrincipalsFile for bastion_user (empty = SSH-CA off)"
+  type        = string
+  default     = ""
+}
+
 # --- Worker storage (contract parity; consumed here to create data disks) -----
 
 variable "worker_storage" {

--- a/infrastructure/opentofu/modules/providers/scw/bastion.tf
+++ b/infrastructure/opentofu/modules/providers/scw/bastion.tf
@@ -135,6 +135,8 @@ resource "scaleway_instance_server" "bastion" {
       extra_packages    = ["netplan.io"]
       extra_write_files = local.scw_bastion_extra_write_files
       extra_runcmd      = local.scw_bastion_extra_runcmd
+      ssh_ca_public_key = var.bastion_ssh_ca_public_key
+      ssh_ca_principals = var.bastion_ssh_ca_principals
     })
   }
 

--- a/infrastructure/opentofu/modules/providers/scw/variables.tf
+++ b/infrastructure/opentofu/modules/providers/scw/variables.tf
@@ -90,6 +90,20 @@ variable "bastion_ssh_keys" {
   default     = []
 }
 
+# SSH-CA — both "" (default) keeps the bastion on static-key auth only, byte
+# for byte the same cloud-init as before these variables existed.
+variable "bastion_ssh_ca_public_key" {
+  description = "SSH CA public key trusted for certificate auth on the bastion (empty = SSH-CA off)"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_ssh_ca_principals" {
+  description = "Principals (one per line) authorized via AuthorizedPrincipalsFile for bastion_user (empty = SSH-CA off)"
+  type        = string
+  default     = ""
+}
+
 variable "bastion_image_id" {
   description = "Image ID for the bastion host"
   type        = string

--- a/scripts/dev/ssh-ca-check.sh
+++ b/scripts/dev/ssh-ca-check.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# ssh-ca-check.sh — proves the bastion cloud-init template actually enables
+# SSH-CA once ssh_ca_public_key / ssh_ca_principals are set (#81: both were
+# hardcoded to an empty file/dir, so no caller could ever turn it on).
+#
+# Mocked/local proof, rung "emulated": renders the real .tftpl with `tofu`
+# (the same technique used to investigate #81 — read what the template
+# actually emits, not what the .tftpl source implies) and drops the exact
+# write_files bytes onto a real sshd in Docker. No cloud account, no VM boot.
+#
+# Asserts the issue's own closing bar:
+#   0. Defaults ("") still render an EMPTY trust file and NO principals file
+#      at all — today's inert behaviour, byte for byte.
+#   1. A CA-signed certificate authenticates.
+#   2. The SAME bare key, presented without its certificate, is REFUSED.
+#   3. `ssh -o ExitOnForwardFailure=yes -L` through PermitOpen actually
+#      carries traffic.
+#
+# ⚠️ Signs with `-O permit-port-forwarding` explicitly: ssh-keygen's default
+# extension set already includes it, but a narrowed one that forgets it still
+# authenticates and then refuses every `-L` — the exact 2026-08-18 failure
+# this issue cites (talos-tunnels.sh reporting 0/6 against a healthy bastion).
+#
+# Usage: ./scripts/dev/ssh-ca-check.sh
+# Requires: docker, tofu, ssh, ssh-keygen, python3+pyyaml. Skips (exit 0) if
+# docker is unavailable — same fail-open shape as check-docker-talos-capability.sh.
+# ==============================================================================
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$ROOT/infrastructure/opentofu/modules/providers/_shared/bastion-cloud-init.yaml.tftpl"
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+command -v docker >/dev/null 2>&1 || { echo "SKIP — docker not available, cannot run the local sshd proof"; exit 0; }
+for c in tofu ssh ssh-keygen python3; do
+  command -v "$c" >/dev/null 2>&1 || { echo "✗ $c not found — required for this proof" >&2; exit 1; }
+done
+python3 -c 'import yaml' 2>/dev/null || { echo "✗ python3 pyyaml module not found — required for this proof" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+CONTAINER="ssh-ca-check-$$"
+IMAGE="ubuntu:24.04"
+BASTION_USER="bastion"
+PRINCIPAL="ssh-ca-check-admin"
+
+cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+echo "=== 0. Rendering the template — both the default (\"\") and SSH-CA-on ==="
+
+# CA + a user key signed for $PRINCIPAL, WITH permit-port-forwarding explicit
+# (see the ⚠️ above — the default extension set covers it, but don't rely on
+# an implicit default for the one thing #81's own regression was about).
+ssh-keygen -q -t ed25519 -N '' -f "$WORK/ca" -C ca
+ssh-keygen -q -t ed25519 -N '' -f "$WORK/user" -C "$PRINCIPAL"
+ssh-keygen -q -s "$WORK/ca" -I ssh-ca-check -n "$PRINCIPAL" -O permit-port-forwarding \
+  -V always:forever "$WORK/user.pub"
+CA_PUBKEY="$(cat "$WORK/ca.pub")"
+
+render() { # <ssh_ca_public_key> <ssh_ca_principals> <out-file>
+  cat >"$WORK/render.tf" <<EOF
+output "rendered" {
+  value = templatefile("$TEMPLATE", {
+    bastion_user      = "$BASTION_USER"
+    ssh_keys          = []
+    private_cidr      = "10.0.0.0/24"
+    extra_packages    = []
+    extra_write_files = []
+    extra_runcmd      = []
+    ssh_ca_public_key = "$1"
+    ssh_ca_principals = "$2"
+  })
+}
+EOF
+  tofu -chdir="$WORK" init -input=false >/dev/null 2>&1 &&
+    tofu -chdir="$WORK" apply -auto-approve -input=false >/dev/null 2>&1 &&
+    tofu -chdir="$WORK" output -raw rendered >"$3"
+}
+
+render "" "" "$WORK/off.yaml" ||
+  { echo "✗ could not render the template with default vars" >&2; exit 1; }
+render "$CA_PUBKEY" "$PRINCIPAL" "$WORK/on.yaml" ||
+  { echo "✗ could not render the template with SSH-CA vars set" >&2; exit 1; }
+
+# Pull out exactly what a provider's bastion.tf would ship to disk — no
+# cloud-init interpreter involved, the proof is the literal template bytes —
+# and stage the "on" render's files for the container step below.
+CHECKS="$(python3 - "$WORK" "$BASTION_USER" <<'PY'
+import sys, yaml
+
+work, user = sys.argv[1], sys.argv[2]
+
+def write_files(name):
+    with open(f"{work}/{name}.yaml") as f:
+        doc = yaml.safe_load(f)
+    return {wf["path"]: wf["content"] for wf in doc["write_files"]}
+
+off, on = write_files("off"), write_files("on")
+principals_path = f"/etc/ssh/auth_principals/{user}"
+
+def check(cond, msg):
+    print(("ok" if cond else "bad") + "|" + msg)
+
+check(off["/etc/ssh/trusted_user_ca.pub"] == "",
+      "default renders an empty trusted_user_ca.pub (unchanged)")
+check(principals_path not in off,
+      "default renders NO auth_principals file at all (unchanged)")
+check(on["/etc/ssh/trusted_user_ca.pub"].strip() != "",
+      "ssh_ca_public_key set -> trusted_user_ca.pub carries it")
+check(principals_path in on,
+      "ssh_ca_principals set -> auth_principals file is rendered")
+
+# .get(..., "") rather than a bare index: a regression that drops one of
+# these paths must fail on the checks above, not crash here before they are
+# even reported.
+with open(f"{work}/sshd-hardening.conf", "w") as f:
+    f.write(on.get("/etc/ssh/sshd_config.d/99-bastion-hardening.conf", ""))
+with open(f"{work}/trusted_user_ca.pub", "w") as f:
+    f.write(on.get("/etc/ssh/trusted_user_ca.pub", ""))
+with open(f"{work}/auth_principals", "w") as f:
+    f.write(on.get(principals_path, ""))
+PY
+)"
+[ -n "$CHECKS" ] || { echo "✗ template rendering/extraction produced nothing — parser broke silently" >&2; exit 1; }
+
+while IFS='|' read -r verdict msg; do
+  [ "$verdict" = "ok" ] && ok "$msg" || bad "$msg"
+done <<<"$CHECKS"
+
+echo
+echo "=== 1-3. Materializing the rendered files onto a real sshd (Docker) ==="
+
+docker run -d --name "$CONTAINER" -p 127.0.0.1::22 "$IMAGE" sleep infinity >/dev/null
+
+docker exec -e DEBIAN_FRONTEND=noninteractive "$CONTAINER" bash -c "
+  set -e
+  apt-get update -qq
+  apt-get install -y -qq openssh-server openssh-client netcat-openbsd
+  groupadd bastion-admins
+  useradd -m -s /bin/bash -G bastion-admins -c bastion $BASTION_USER
+  mkdir -p /etc/ssh/authorized_keys.d /etc/ssh/auth_principals /run/sshd
+  chmod 755 /etc/ssh/authorized_keys.d /etc/ssh/auth_principals
+  : > /etc/ssh/authorized_keys.d/$BASTION_USER
+  chmod 0600 /etc/ssh/authorized_keys.d/$BASTION_USER
+" >/dev/null
+SETUP_RC=$?
+
+if [ "$SETUP_RC" -ne 0 ]; then
+  bad "container setup (packages/user/dirs) failed — cannot run the live sshd checks"
+else
+  docker cp "$WORK/sshd-hardening.conf" "$CONTAINER:/etc/ssh/sshd_config.d/99-bastion-hardening.conf" >/dev/null
+  docker cp "$WORK/trusted_user_ca.pub" "$CONTAINER:/etc/ssh/trusted_user_ca.pub" >/dev/null
+  docker cp "$WORK/auth_principals" "$CONTAINER:/etc/ssh/auth_principals/$BASTION_USER" >/dev/null
+  docker exec "$CONTAINER" bash -c "
+    chmod 0600 /etc/ssh/sshd_config.d/99-bastion-hardening.conf
+    chmod 0644 /etc/ssh/trusted_user_ca.pub /etc/ssh/auth_principals/$BASTION_USER
+  "
+
+  if ! docker exec "$CONTAINER" sshd -t; then
+    bad "rendered sshd config is rejected by sshd -t"
+  else
+    ok "rendered sshd config is accepted by sshd -t"
+    docker exec "$CONTAINER" /usr/sbin/sshd
+    # Synthetic cluster-port listener: PermitOpen allows *:6443, so this
+    # stands in for what a real Talos/K8s endpoint would be at that port.
+    docker exec -d "$CONTAINER" bash -c 'nc -lk 127.0.0.1 6443 > /tmp/nc-received.txt'
+
+    HOST_PORT=""
+    for i in $(seq 1 20); do
+      HOST_PORT="$(docker port "$CONTAINER" 22/tcp 2>/dev/null | head -1 | cut -d: -f2)"
+      if [ -n "$HOST_PORT" ] && ssh -i "$WORK/user" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+           -o BatchMode=yes -o ConnectTimeout=2 -p "$HOST_PORT" "$BASTION_USER@127.0.0.1" true 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+
+    SSH="ssh -i $WORK/user -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=5 -p $HOST_PORT ${BASTION_USER}@127.0.0.1"
+
+    # --- 1. Cert authenticates ---
+    if $SSH echo cert-ok 2>/dev/null | grep -q cert-ok; then
+      ok "CA-signed certificate authenticates"
+    else
+      bad "CA-signed certificate did NOT authenticate"
+    fi
+
+    # --- 2. Same key, no cert -> refused ---
+    mv "$WORK/user-cert.pub" "$WORK/user-cert.pub.hidden"
+    if $SSH echo should-not-print 2>/dev/null | grep -q should-not-print; then
+      bad "the bare key (no certificate) was accepted — should be refused"
+    else
+      ok "the same key WITHOUT its certificate is refused"
+    fi
+    mv "$WORK/user-cert.pub.hidden" "$WORK/user-cert.pub"
+
+    # --- 3. -L with ExitOnForwardFailure carries real traffic ---
+    if $SSH -o ExitOnForwardFailure=yes -N -f -L 16443:127.0.0.1:6443 2>/dev/null; then
+      MARKER="ssh-ca-check-$$"
+      printf '%s\n' "$MARKER" | timeout 3 bash -c "exec 3<>/dev/tcp/127.0.0.1/16443; cat >&3" 2>/dev/null
+      sleep 1
+      if docker exec "$CONTAINER" grep -q "$MARKER" /tmp/nc-received.txt 2>/dev/null; then
+        ok "ssh -o ExitOnForwardFailure=yes -L succeeds and carries traffic through PermitOpen"
+      else
+        bad "the tunnel came up but no traffic reached the far side"
+      fi
+      pkill -f "16443:127.0.0.1:6443" >/dev/null 2>&1 || true
+    else
+      bad "ssh -o ExitOnForwardFailure=yes -L failed to set up"
+    fi
+  fi
+fi
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$PASS" -gt 0 ] && [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

`_shared/bastion-cloud-init.yaml.tftpl` hardcoded `TrustedUserCAKeys`/`AuthorizedPrincipalsFile` to an always-empty file and directory, so SSH-CA could never actually be turned on no matter what a caller configured — every bastion has been running on a static key only a `tofu apply` can revoke, since these hooks were written.

## Fix

`ssh_ca_public_key` and `ssh_ca_principals` are now real `templatefile()` variables, default `""` (today's behavior, byte-for-byte unchanged when unset), threaded through all four provider `bastion.tf` files (scw, ovh, outscale, proxmox) and the Feint fixture (`infrastructure/opentofu-feint/main.tf`).

New `scripts/dev/ssh-ca-check.sh` (`task ssh-ca-check`): a local Docker+openssh proof, no cloud account needed. Renders the real template with `tofu`, materializes the exact `write_files` bytes onto a real `sshd` in an `ubuntu:24.04` container, and proves the issue's own closing bar — a CA-signed cert (signed with `-O permit-port-forwarding` explicit, guarding the 2026-08-18 failure mode the issue cites where a cert missing that extension authenticates and then refuses every `-L`) authenticates, the same bare key without its cert is refused, and an actual `-L` port-forward carries traffic through `PermitOpen`.

Checked `.claude/skills/provider-module/SKILL.md` and `provider-contract.md` — neither documents the bastion cloud-init contract or the new (optional, defaulted) variables, so neither needed updating.

## Proof

- `scripts/dev/ssh-ca-check.sh` run twice against the fixed template: 8/8 checks pass both times.
- Same script run once against the **pre-fix** template: 4/4 fail — confirms the proof is meaningful, not green by construction.
- `task feint-test` (scaleway + outscale) — both apply/destroy cleanly with the new default-empty vars in place.
- `task lint`, `task test-scripts`, `task validate`, `task render-check`, checkov (32/0), checkov custom checks, gitleaks + rules check — all green.

Feint + local-Docker rung — no cloud account touched.

Closes #81

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_