### PR TITLE
fix(scw): scope security group perimeter to the module's own subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,26 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **The Scaleway security group's documented perimeter and its enforced one
+  had drifted apart** (#79). `security.tf`'s own comment said "Talos API —
+  From Bastion ONLY" and admitted `:50000` from the bastion's **public** IP —
+  a rule that never fires, since the bastion reaches nodes over its private
+  NIC. What actually admitted that traffic (and everything else) was a
+  `port = 0`/`protocol = "ANY"` rule matching `172.16.0.0/12` — Scaleway's
+  whole IPAM range, not this cluster's own subnet — plus a redundant
+  `10.0.0.0/8` rule nothing in this module ever gets an address in. Fixed by
+  pinning the private network's own `/22` (`network.tf`, matching OVH's and
+  Outscale's existing self-declared-CIDR pattern instead of trusting IPAM
+  auto-assignment), scoping the mesh rule to that `/22`, dropping the dead
+  bastion-public-IP rule and the `10.0.0.0/8` rule, and dropping `port = 0`
+  from every remaining `protocol = "ANY"` rule (meaningless there, and
+  already the pattern `bastion.tf`'s own `outbound_rule` used). New
+  `tofu test` run asserts no SCW `inbound_rule` carries `port == 0`. Rung:
+  mocked + `task feint-plan`/`feint-apply` against the emulator; the
+  real-cloud confirmation (does pinning the subnet force a disruptive
+  replacement on an already-provisioned network, do LB health checks and
+  Talos API access still work after narrowing) is still open.
+
 - **Four places where `ci.yml`/`task lint` claimed or should have verified
   something and did not — same shape each time, closed or narrowed together.**
   - **Three tool installs in `ci.yml` carried no version pin** (#113) —

--- a/infrastructure/opentofu/cluster/tests/scaleway.tftest.hcl
+++ b/infrastructure/opentofu/cluster/tests/scaleway.tftest.hcl
@@ -234,6 +234,19 @@ run "verify_bastion_config" {
 }
 
 # ==============================================================================
+# Test 4b: Security Groups — no inbound rule left wildcard-port (#79)
+# ==============================================================================
+
+run "verify_no_wildcard_inbound_port" {
+  command = plan
+
+  assert {
+    condition     = alltrue([for p in module.scw[0].inbound_rule_ports : p != 0])
+    error_message = "No SCW inbound_rule may carry port == 0 (#79)."
+  }
+}
+
+# ==============================================================================
 # Test 5: Provider Contract — SCW outputs conform to provider-contract.md
 # ==============================================================================
 

--- a/infrastructure/opentofu/modules/providers/scw/network.tf
+++ b/infrastructure/opentofu/modules/providers/scw/network.tf
@@ -1,7 +1,18 @@
+# Pin the subnet ourselves instead of trusting Scaleway's IPAM auto-assignment —
+# OVH and Outscale already self-declare their CIDR (network.tf in each module);
+# Scaleway was the outlier, which let security.tf's mesh rule drift from it (#79).
+locals {
+  scw_cluster_subnet = "172.16.0.0/22"
+}
+
 # Private Network for secure internal communication
 resource "scaleway_vpc_private_network" "this" {
   name   = "${var.cluster_name}-private-network"
   region = var.region
+
+  ipv4_subnet {
+    subnet = local.scw_cluster_subnet
+  }
 }
 
 # Reserve IPs for control plane nodes via IPAM (VPC v2)

--- a/infrastructure/opentofu/modules/providers/scw/outputs.tf
+++ b/infrastructure/opentofu/modules/providers/scw/outputs.tf
@@ -31,3 +31,15 @@ output "nat_gateway_ip" {
   description = "Public IP of the NAT gateway (for LB ACL whitelisting)"
   value       = scaleway_vpc_public_gateway_ip.this.address
 }
+
+# Test-only: security group internals aren't visible to test assertions
+# outside a module's own outputs — this lets scaleway.tftest.hcl check the
+# generated inbound rules directly (#79).
+output "inbound_rule_ports" {
+  description = "Flattened port of every security group inbound_rule, for tests"
+  value = flatten([
+    for sg in scaleway_instance_security_group.this : [
+      for r in sg.inbound_rule : r.port
+    ]
+  ])
+}

--- a/infrastructure/opentofu/modules/providers/scw/security.tf
+++ b/infrastructure/opentofu/modules/providers/scw/security.tf
@@ -2,10 +2,11 @@
 #
 # Network access strategy:
 #   - 6443/TCP: Kubernetes API via K8s LB (permanent)
-#   - 50000/TCP: Talos API via bastion ONLY. Accessible via SSH tunnels established
-#                through the bastion host. Never exposed via Load Balancers.
+#   - 50000/TCP: Talos API — the bastion reaches nodes over its PRIVATE NIC, so
+#                this is admitted by the private-subnet mesh rule below, not a
+#                dedicated bastion rule. Never exposed via Load Balancers.
 #   - NodePorts 30080/30443: application traffic from the App LB (deploy_app_lb only)
-#   - Inter-node: full mesh on private subnets
+#   - Inter-node: full mesh on the module's own private subnet
 # ==============================================================================
 
 resource "scaleway_instance_security_group" "this" {
@@ -41,33 +42,18 @@ resource "scaleway_instance_security_group" "this" {
     }
   }
 
-  # Talos API — From Bastion ONLY (50000/TCP, never from LB)
+  # Inter-node mesh, scoped to this module's own pinned subnet (network.tf) —
+  # also what admits 50000/TCP (Talos API) from the bastion's private NIC now.
   inbound_rule {
     action   = "accept"
-    port     = 50000
-    ip_range = "${scaleway_instance_ip.bastion.address}/32"
-    protocol = "TCP"
-  }
-
-  # Inter-node communication (private subnets) + LB health checks
-  inbound_rule {
-    action   = "accept"
-    port     = 0
-    ip_range = "172.16.0.0/12"
+    ip_range = local.scw_cluster_subnet
     protocol = "ANY"
   }
 
+  # Scaleway internal / LB health checks — not this module's subnet, left as-is.
   inbound_rule {
     action   = "accept"
-    port     = 0
-    ip_range = "10.0.0.0/8"
-    protocol = "ANY"
-  }
-
-  inbound_rule {
-    action   = "accept"
-    port     = 0
-    ip_range = "100.64.0.0/10" # Scaleway internal / LB health checks
+    ip_range = "100.64.0.0/10"
     protocol = "ANY"
   }
 


### PR DESCRIPTION
## What

`security.tf`'s comment claimed 50000/TCP (Talos API) was admitted "From Bastion ONLY" — but that rule matched the bastion's **public** IP, while the bastion actually reaches nodes over its **private** NIC. The rule never fired. What actually admitted traffic (all of it, any port) was a mesh rule matching Scaleway's whole `172.16.0.0/12` IPAM range plus a redundant `10.0.0.0/8` rule nothing in this module ever gets an address in — so the documented and enforced perimeters had drifted apart, and nothing at any rung noticed (the test suite never touched `inbound_rule` contents at all).

## Fix

- `network.tf`: pin the private network's own `/22` (`172.16.0.0/22`) instead of trusting Scaleway's IPAM auto-assignment — matches OVH's and Outscale's existing self-declared-CIDR pattern (Scaleway was the outlier).
- `security.tf`: scope the mesh rule to that `/22` (which now also legitimately admits 50000/TCP from the bastion's private NIC), drop the dead bastion-public-IP rule and the unused `10.0.0.0/8` rule, drop `port = 0` from the remaining `protocol = "ANY"` rules (meaningless there — already the pattern `bastion.tf`'s own `outbound_rule` used), leave the `100.64.0.0/10` Scaleway-health-check rule untouched.
- `outputs.tf`: new test-only `inbound_rule_ports` output — Terraform/OpenTofu test assertions can't reach into a child module's internal resources directly (confirmed empirically: "This value does not have any attributes"), so this is how `scaleway.tftest.hcl` can assert on the generated rules at all.
- `scaleway.tftest.hcl`: new run block asserting no inbound rule carries `port == 0`. Verified non-vacuous by temporarily reintroducing `port = 0` and watching it fail.

## Proof

- `task test` — 61/61 passed (mocked rung).
- `task feint-plan PROVIDER=scaleway` / `task feint-apply PROVIDER=scaleway` against Feint 0.12.0: clean plan (narrowed `/22` mesh rule + unchanged health-check rule, no `port=0`, no dead bastion rule), apply 8 added / empty re-plan / destroy 8 — no drift.
- `task lint`, `task validate`, `task render-check`, checkov (32/0), checkov custom checks, gitleaks + rules check — all green.

## Not closed by this PR

The issue's own real-cloud confirmation half is still open: whether pinning the subnet forces a disruptive replacement on an already-provisioned real private network, and whether Scaleway's LB health checks / Talos API access still work end-to-end after narrowing the perimeter. Neither is observable without a real account — **issue #79 stays open** until that rung runs. Flagged to the maintainer before implementing given the potential for a disruptive replacement on a live network; they asked to proceed with implementing and opening this PR regardless.

Refs #79 (partial — mocked/feint rung only)

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_