### PR TITLE
fix(taskfile): cluster-up now verifies the cluster it just built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`cluster-up` said "complete" without ever asking the cluster**
+  ([#84](https://github.com/dis-bzh/OpenAether-infra/issues/84), partial —
+  mocked rung only). Its closing banner read "the plan is the verdict, not
+  this line" while nodes-Ready, control-plane count, Cilium, CoreDNS, the
+  schematic and the state-backup replica all went unchecked, and the task
+  always exited 0 regardless. `cluster-up` now runs `cluster-verify`
+  (ROLE/PROVIDER forwarded) right after `converge-versions.sh` and before the
+  closing echo — go-task 3.52.0 propagates a failing step's exit code up
+  through the parent task, so a red verify halts `cluster-up` there instead
+  of past it. The banner no longer disclaims itself. New `test-unattended.sh`
+  section statically confirms the call graph reaches `cluster-verify` and
+  that the edge is neither `ignore_error: true` nor trailed by `|| true`
+  (checked negative: both defects made it fail, VERIFIED offline), wired
+  into `task test-scripts`. Real-cloud rung — the failure actually seen red
+  on a cluster that does not match its config — is still open: feint only
+  emulates the provisioning API, no kubelet/apiserver/Cilium/CoreDNS ever
+  exists under it.
+
 - **Four places where `ci.yml`/`task lint` claimed or should have verified
   something and did not — same shape each time, closed or narrowed together.**
   - **Three tool installs in `ci.yml` carried no version pin** (#113) —

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -657,6 +657,14 @@ tasks:
       # has to reach it. APPROVE=auto inside is not a bypass: the one checkpoint
       # above already asked, and --check had told it what this would roll.
       - ./scripts/internal/converge-versions.sh {{.PROVIDER}} {{.ROLE}} {{.KEY}}
+      # The verdict, asked of the cluster rather than assumed from the steps
+      # above having run. go-task propagates this task's non-zero exit up
+      # through cluster-up, so a failing verify halts here — the closing
+      # echo below is only ever reached once it has passed.
+      - task: cluster-verify
+        vars:
+          ROLE: "{{.ROLE}}"
+          PROVIDER: "{{.PROVIDER}}"
       # Do NOT end on "every step above is idempotent": that line came out
       # identical on the first run, which applied 43 changes in phase 1 and 17 in
       # phase 2, and on the second, which applied none. Idempotence is a property
@@ -664,10 +672,7 @@ tasks:
       # own plan. A YAML comment, not a shell one: go-task echoes the block it
       # runs, so a `#` inside would be printed as the last thing the operator reads.
       - |
-        echo "✓ cluster-up complete."
-        echo "  Two verdicts, and neither of them is this line: OpenTofu's plan for"
-        echo "  the infrastructure, and the version check above for the fleet — asked"
-        echo "  separately because ignore_changes keeps a roll out of the plan."
+        echo "✓ cluster-up complete: cluster-verify passed."
         echo "  Run this exact command again to converge again."
 
   # ===========================================================================

--- a/scripts/dev/test-unattended.sh
+++ b/scripts/dev/test-unattended.sh
@@ -632,7 +632,53 @@ for f in sorted(claimed):
     else:
         ok(f'{f} claims the interactive exemption and no workflow runs it')
 
-# --- G. floors: a check that measured nothing is not a green run -------------
+# --- G. cluster-up must ask the cluster it just built (#84) ------------------
+# `cluster-up` used to print "complete" right after converge-versions.sh, with
+# nothing asking the cluster itself: nodes Ready, control-plane count, Cilium,
+# CoreDNS, the schematic, the state-backup replica all unchecked. The fix is a
+# `- task: cluster-verify` edge relying on go-task's own exit-code propagation
+# (VERIFIED offline: Task 3.52.0 halts a parent task on a failing `- task:`
+# step), so this proves the edge exists AND that nothing on it swallows a
+# failure before it can halt cluster-up.
+hdr('cluster-up reaches cluster-verify, and the edge is not defused (#84)')
+VERIFY = 'cluster-verify'
+
+def reaches_task(name, target, seen=None):
+    """True when task `name` calls `target`, directly or through any Taskfile
+    edge (task:/deps/shell) — same graph EDGES was built from, walked instead
+    of scanned."""
+    seen = seen if seen is not None else set()
+    if name == target:
+        return True
+    if name in seen:
+        return False
+    seen.add(name)
+    return any(reaches_task(callee, target, seen)
+               for caller, callee, _, _ in EDGES if caller == name)
+
+if reaches_task(ENTRY, VERIFY):
+    ok(f'{ENTRY} → … → {VERIFY}: the call graph reaches the verifier')
+else:
+    bad(f'{ENTRY} never reaches {VERIFY} — it can still report success without asking the cluster')
+
+# A defused edge would make the propagation above worthless: `ignore_error:
+# true` on a `- task:` entry, or a shell `task cluster-verify …` trailed by a
+# `|| true`, both let go-task swallow a red verify and keep going regardless.
+defused = []
+for c in (TASKS.get(ENTRY) or {}).get('cmds') or []:
+    if isinstance(c, dict) and ALIAS.get(c.get('task'), c.get('task')) == VERIFY and c.get('ignore_error'):
+        defused.append('ignore_error: true on the `- task:` entry')
+for _, line, mask in logical_lines(BODY[ENTRY]):
+    for seg in segments(line, mask):
+        c = task_call(seg)
+        if c and c[0] == VERIFY and re.search(r'\|\|\s*true\s*$', seg):
+            defused.append(f'`{seg.strip()}` trails a `|| true`')
+if defused:
+    bad(f'{ENTRY} → {VERIFY} is defused: {"; ".join(defused)} — a failing verify would not stop {ENTRY}')
+else:
+    ok(f'{ENTRY} → {VERIFY} is not defused — go-task propagates a failing verify up through {ENTRY}')
+
+# --- H. floors: a check that measured nothing is not a green run -------------
 # This is the fix for the defect that started this: the harness read Taskfile.yml
 # and nothing else, so a tree containing only that file still printed a green
 # summary. Zero of anything below means the parser went blind, not that the


### PR DESCRIPTION
## What

`cluster-up` printed "complete" right after `converge-versions.sh` checked the fleet's versions, with nothing asking the cluster itself whether it's actually healthy — nodes Ready, control-plane count, Cilium, CoreDNS, the schematic, the state-backup replica were all unchecked, and the task always exited 0. Its own closing banner admitted as much ("the plan is the verdict, not this line"), sending the operator elsewhere to find out — the opposite of a one-command tool the operator can rely on.

## Fix

`cluster-up` now runs the existing `cluster-verify` task (`ROLE`/`PROVIDER` forwarded) right after `converge-versions.sh` and before the closing echo. No bespoke error handling needed: go-task 3.52.0 (pinned in this repo, confirmed offline) propagates a failing `- task: X` step's non-zero exit up through the parent, so a red verify halts `cluster-up` before the banner — which no longer disclaims itself.

`test-unattended.sh` gains a static assertion, using its existing Taskfile call-graph parser (EDGES/BODY/task_call), that the call graph from `cluster-up` reaches `cluster-verify` and that the edge isn't defused (no `ignore_error: true`, no trailing `|| true`). Checked negative on both defect shapes offline before restoring the fix. Wired into `task test-scripts`.

## Proof

- `task lint`, `task test-scripts` (includes the new assertions), `task validate`, `task render-check`, checkov (32/0), checkov custom checks, gitleaks + rules check — all green.
- The new assertions verified to actually catch both defect shapes (edge missing, edge defused) before being restored to pass.

## Not closed by this PR

**Partial close of #84**: this proves the mocked rung. The issue's other half — the failure actually seen red on a real cluster that doesn't match its config — needs real cloud; Feint only emulates the provisioning API, so no kubelet/apiserver/Cilium/CoreDNS ever exists under it for `cluster-verify` to fail against. Issue stays open for that half.

Refs #84 (partial — mocked rung only)

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_