### PR TITLE
fix(scripts): refuse a talos-image build that would delete another cluster's pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **Building a Talos image for one cluster could silently delete the image
+  another cluster's tfvars still pinned (#93).** talos-image's root tracks
+  exactly one image per provider (`backend.tf`: `key=talos-image.tfstate`, not
+  per-version) — retargeting `talos_version` replaced the sole tracked image
+  instead of adding a second, and nothing failed until that OTHER cluster's
+  next plan/apply, with no visible sign on the account before then.
+  `scripts/bootstrap/talos-image.sh` now scans every real
+  `cluster/envs/*-<provider>.tfvars` for the version being built (same
+  resolution path as `scripts/internal/talos-version.sh`) and refuses, naming
+  the conflicting file and both versions, right after the provider is
+  resolved — before any credential resolution, bucket creation or
+  `tofu init`. New coverage in `scripts/dev/test-talos-image.sh` (a throwaway
+  fixture tfvars under the real, gitignored `envs/` dir, removed via
+  `trap EXIT`) proves the refusal fires with zero `tofu`/`aws` calls recorded,
+  names both versions and the file, and does not fire when the pin matches.
+
 - **Four places where `ci.yml`/`task lint` claimed or should have verified
   something and did not — same shape each time, closed or narrowed together.**
   - **Three tool installs in `ci.yml` carried no version pin** (#113) —

--- a/scripts/bootstrap/talos-image.sh
+++ b/scripts/bootstrap/talos-image.sh
@@ -37,6 +37,34 @@ case "$P" in
   *) echo "✗ unknown provider: $RAW (expected scaleway|ovh|outscale|proxmox)"; exit 1 ;;
 esac
 
+# ──────────────────────────────────────────────────────────────────────────────
+# talos-image's root tracks exactly one image PER PROVIDER (backend.tf:
+# key=talos-image.tfstate, not per-version) — retargeting talos_version does not
+# add a second image, it REPLACES the sole one tracked, destroying whatever
+# version another cluster's tfvars still pins. Nothing breaks that cluster until
+# its NEXT plan (Talos boots from local disk, it does not re-fetch the image at
+# runtime) — and by then the account has no visible sign of what happened (#93).
+# Refuse before the spend: same resolution path as everywhere else that reads a
+# cluster's pin (scripts/internal/talos-version.sh), scanned across every real
+# tfvars for THIS provider before a single credential is resolved.
+# ──────────────────────────────────────────────────────────────────────────────
+ENVS_DIR="$(dirname "${BASH_SOURCE[0]}")/../../infrastructure/opentofu/cluster/envs"
+INTERNAL="$(dirname "${BASH_SOURCE[0]}")/../internal"
+if [ -d "$ENVS_DIR" ]; then
+  conflict=0
+  for f in "$ENVS_DIR"/*-"$P".tfvars; do
+    [ -e "$f" ] || continue
+    PINNED="$("$INTERNAL/talos-version.sh" "$(basename "$f")" 2>/dev/null || true)"
+    [ -n "$PINNED" ] && [ "$PINNED" != "$VERSION" ] || continue
+    echo "✗ $(basename "$f") pins talos_version = ${PINNED}, but this build targets ${VERSION}." >&2
+    echo "  talos-image tracks ONE image per provider — building ${VERSION} would replace" >&2
+    echo "  the ${PINNED} image that cluster still pins, and it would not notice until its" >&2
+    echo "  next plan/apply. Build ${PINNED} instead, or update $(basename "$f") first." >&2
+    conflict=1
+  done
+  [ "$conflict" -eq 0 ] || exit 1
+fi
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../infrastructure/opentofu/talos-image" && pwd)"
 command -v tofu >/dev/null 2>&1 || { echo "✗ tofu required"; exit 1; }
 command -v aws  >/dev/null 2>&1 || { echo "✗ aws CLI required"; exit 1; }

--- a/scripts/dev/test-talos-image.sh
+++ b/scripts/dev/test-talos-image.sh
@@ -26,7 +26,10 @@ SCRIPT=scripts/bootstrap/talos-image.sh
 TFROOT=infrastructure/opentofu/talos-image
 SB="$(mktemp -d)"
 LOG="$SB/tofu.log"
-trap 'rm -rf "$SB"; rm -f "$TFROOT"/talos-image-scaleway.tfplan' EXIT
+# #93's guard scans the REAL (gitignored) envs dir, so its fixture has to live
+# there too — synthetic role prefix, removed on exit like every other fixture.
+FIXTURE93=infrastructure/opentofu/cluster/envs/oa93-scaleway.tfvars
+trap 'rm -rf "$SB"; rm -f "$TFROOT"/talos-image-scaleway.tfplan "$FIXTURE93"' EXIT
 
 # The schematic gate calls the Image Factory before anything else and refuses a
 # build when the live id differs from the cluster pin. Offline, the stub answers
@@ -54,7 +57,14 @@ case "$1" in
 esac
 exit 0
 STUB
-printf '#!/usr/bin/env bash\nexit 0\n' >"$SB/aws"
+# Logged (prefixed, so it never collides with a tofu subcommand match below) —
+# #93's zero-spend assertion needs to see whether aws was ever invoked, not
+# just tofu.
+cat >"$SB/aws" <<'STUB'
+#!/usr/bin/env bash
+printf 'aws:%s\n' "$*" >>"$OA_STUB_LOG"
+exit 0
+STUB
 printf '#!/usr/bin/env bash\nprintf %s "{\\"id\\":\\"%s\\"}"\n' '%s' "${PIN:-deadbeef}" >"$SB/curl"
 chmod +x "$SB/tofu" "$SB/aws" "$SB/curl"
 
@@ -190,6 +200,32 @@ env PATH="$SB:$PATH" OA_STUB_LOG="$LOG" OA_STUB_PLAN_EXIT=2 OA_STUB_APPLY_EXIT=1
 [ ! -e "$TFROOT/talos-image-scaleway.tfplan" ] \
   && ok "and the plan file is still cleaned up on that path" \
   || bad "a plan naming real buckets outlived a failed apply, in a public working tree"
+
+echo "--- #93: refuses when another cluster's tfvars still pins a different talos_version ---"
+printf 'talos_version = "v1.13.9"\n' >"$FIXTURE93"
+OUT="$(run 2 --ensure)"; RC=$?
+[ "$RC" -ne 0 ] \
+  && ok "a conflicting pin in another cluster's tfvars refuses the build (rc=$RC)" \
+  || bad "the build proceeded despite ${FIXTURE93##*/} pinning a different talos_version"
+grep -q "${FIXTURE93##*/}" <<<"$OUT" \
+  && ok "the message names the conflicting tfvars file" \
+  || bad "the refusal does not name ${FIXTURE93##*/}"
+grep -q 'v1.13.9' <<<"$OUT" && grep -q 'v1.13.4' <<<"$OUT" \
+  && ok "the message names both the pinned version and the one being built" \
+  || bad "the refusal does not name both versions"
+[ ! -s "$LOG" ] \
+  && ok "zero tofu/aws calls recorded — refusal happened before any spend" \
+  || bad "tofu/aws were invoked despite the conflicting pin: $(cat "$LOG")"
+
+echo "--- #93: a matching pin is not a false positive ---"
+printf 'talos_version = "v1.13.4"\n' >"$FIXTURE93"
+OUT="$(run 2 --ensure)"; RC=$?
+is "the script completes when the fixture's pin matches the build" 0 "$RC"
+grep -qi 'pins talos_version' <<<"$OUT" \
+  && bad "a matching pin was refused as though it conflicted" \
+  || ok "no conflict refusal when the tfvars pin matches the version being built"
+is "the run proceeded past the guard (plan+apply as normal)" 1 "$(calls apply)"
+rm -f "$FIXTURE93"
 
 echo "--- floors: the stubs really ran (all of the above is vacuous otherwise) ---"
 OUT="$(run 2 --ensure)"


### PR DESCRIPTION
## What

`talos-image`'s root tracks exactly one image per provider (`backend.tf`: `key=talos-image.tfstate`, not per-version) — retargeting `talos_version` to build a different image replaces the sole tracked image instead of adding a second, destroying whatever version another cluster's tfvars still pins. Nothing fails until that OTHER cluster's next plan/apply, with no visible sign on the account before then. Reported live: an unrelated throwaway build on Scaleway deleted the image a running, healthy cluster was pinned to.

## Fix

Implements option (a) from the issue — the smaller of the two it names (refuse the build, naming the pinning cluster), over (b) (multi-version state, which would need real state-migration testing to trust).

`scripts/bootstrap/talos-image.sh` now scans every real `cluster/envs/*-<provider>.tfvars` for the version being built (same resolution path as `scripts/internal/talos-version.sh`) and refuses — naming the conflicting file and both versions — right after the provider is resolved, before any credential resolution, bucket creation, or `tofu init`.

New coverage in `scripts/dev/test-talos-image.sh`: a throwaway fixture tfvars under the real, gitignored `envs/` dir (removed via `trap EXIT`) proves the refusal fires with zero `tofu`/`aws` calls recorded (refusal happens before any spend), names both versions and the file, and does not false-positive when the pin matches.

## Proof

`task lint`, `task test-scripts`, `task validate`, `task render-check`, checkov (32/0), checkov custom checks, gitleaks + rules check — all green.

The issue's own `rung:real-cloud` label describes where the *bug* was discovered (a second, concurrent build against shared provider state) — the *fix* is a pure local file comparison and its proof is fully offline, matching the issue's own framing of option (a) as buildable now.

Closes #93

Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_