### PR TITLE
chore(deps): bump yamllint to 1.38.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Install yamllint
         # renovate: datasource=pypi depName=yamllint
-        run: pip install yamllint==1.35.1
+        run: pip install yamllint==1.38.0
 
       # `task lint` gates on shellcheck. The GitHub runner image is DOCUMENTED to
       # carry it, but "the image happens to ship it" is not a dependency — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -513,6 +513,19 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Changed
 
+- **`yamllint` 1.35.1 → 1.38.0** in `.github/workflows/ci.yml`, probed green
+  by Cléa (issue #91). `task lint`, `task test-scripts`, `task validate`
+  (both roots), `task test`, checkov (32/0) + custom checks, and a default-rules
+  gitleaks dir scan all green on the bump. `task security`'s `trivy` step
+  could not run in this sandbox (no network) — relies on CI. Left out of this
+  batch, all `❌ probe failed` or `not probed` in the same report: `flux2`
+  2.9.3 → 2.9.5 (three anchors), `plumber` v0.4.48 → v0.4.50 (two anchors —
+  `clea bump` now refuses the `security.yml` one outright: an `action-sha`
+  anchor whose SHA it cannot also move, so rewriting only the comment would
+  claim a version the pinned commit does not carry), and `kubernetes/kubernetes`
+  v1.36.3 → v1.37.0 (still refused by `cluster/versions-guard.tf`, tracked in
+  draft PR #149).
+
 - **`gitleaks/gitleaks` 8.22.1 → 8.30.1**, probed by Cléa. `install-gitleaks.sh`
   (the binary CI and `task security` actually run) and
   `.pre-commit-config.yaml`'s `gitleaks-system` hook rev now agree — the probe


### PR DESCRIPTION
## What moved

| dependency | old → new | where | probe |
|---|---|---|---|
| `yamllint` | `1.35.1` → `1.38.0` | `.github/workflows/ci.yml:200` | ✅ probed green — `clea/probe/yamllint` |

Source: Cléa's dependency report, issue #91 (rewritten 2026-09-01T09:25 UTC — the first live run confirming #157's report-issue picker fix actually works: #91 got updated, the human-authored #104 stayed untouched).

## Left out of this batch, and why

| dependency | where | probe | why not bumped |
|---|---|---|---|
| `fluxcd/flux2` 2.9.3 → 2.9.5 | 3 anchors | not probed | Cléa hasn't probed it yet this cycle |
| `getplumber/plumber` v0.4.48 → v0.4.50 | `security.yml:97` | not probed (refused before push) | `clea bump` now correctly **refuses** this one: it's an `action-sha` anchor (`uses: owner/repo@<sha> # vX.Y.Z`), and rewriting only the comment to `v0.4.50` while the pinned commit still resolves to `v0.4.48` would desync the label from what actually runs. This needs the SHA re-resolved too — Renovate's own `pinDigests`/`pinGitHubActionDigests` helpers do this, or a manual bump. Not something this routine does per its own hard limits (`.github/workflows/**` is hand-edit-only via `clea bump` itself). |
| `getplumber/plumber` 0.4.48 → 0.4.50 | `install-plumber.sh:20` | not probed | Same dependency, different (safe, non-SHA) anchor — left alongside its sibling rather than bumped alone, to avoid the two anchors disagreeing (`check-version-drift.sh` would catch it, but there's no reason to create the drift in the first place). |
| `kubernetes/kubernetes` v1.36.3 → v1.37.0 | 2 anchors | ❌ probe failed | `cluster/versions-guard.tf`: Talos 1.13 only supports Kubernetes 1.31–1.36. Already tracked in draft PR #149, deliberately left in draft until Talos extends its own support matrix — not this routine's to force. |

## Gates run (this sandbox has no network for `trivy`/Actions — relies on CI for that one)

- `task lint` — green (includes `check-version-drift.sh`, `check-tool-pins.sh`, `check-flux-schema.sh`, `check-upstream-artifacts-lock.sh`)
- `task render-check` — green
- `task test-scripts` — green
- `task validate ROOT=cluster` / `ROOT=talos-image` — green
- `task test` — 61/61 passed
- `checkov -d infrastructure/opentofu` — 32/0
- `./scripts/dev/test-checkov-custom-checks.sh` — 6/0
- `gitleaks dir` (default rules, matching `task security`'s own invocation) — no leaks
- `./scripts/dev/check-gitleaks-rules.sh` — green
- `plumber analyze` — 0 real findings (branch-protection data incomplete without `GH_TOKEN`, same as every prior run)
- `trivy` — **not run**, no network access in this sandbox; CI's own Trivy step is what verifies this

Mocked rung — a CI tool-version pin bump, no provider/cloud surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbJHzE7FcDKZQqSMFKfzqV)_