### PR TITLE
fix(ops): harness the data-loss scripts; clamp the etcd snapshot retention slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`etcd-snapshot.sh` retention deleted almost everything while a cluster had
+  the fewest snapshots to lose.** The prune slice `.[0:(length - KEEP)]` went
+  negative with fewer than `KEEP` objects, and jq counts a negative end from
+  the END: at `KEEP=30`, 29 snapshots became 1, 20 became 10, every run. The
+  end is now clamped at 0. Found by the first harness for the data-loss
+  scripts, `scripts/dev/test-state-backups.sh` (backup-state.sh,
+  etcd-snapshot.sh, resolve-s3-cred.sh — stub tofu/aws/talosctl recording
+  argv AND the credential each call ran with, real gpg round-trip on the
+  artifact) and `scripts/dev/test-seed-openbao.sh` (write-if-absent on a
+  re-run, which path but never what). Two more defects fell out of writing
+  them: an optional tfvars key (`s3_replica_endpoint`, `bucket_suffix`) made
+  `grep` exit 1 under `pipefail`, and `seed-openbao.sh`'s `tfvar()` — and
+  `lib/common.sh`'s `tfv()` behind six other scripts — killed the caller at
+  the assignment with no output at all; both read with `sed -n` now. And
+  `s3_cred` with `<kind>`/`<type>` swapped printed the SECRET where an
+  access-key id was expected; it refuses.
 - **Building a Talos image for one cluster could silently delete the image
   another cluster's tfvars still pinned (#93).** talos-image's root tracks
   exactly one image per provider (`backend.tf`: `key=talos-image.tfstate`, not

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -378,6 +378,12 @@ tasks:
       # with the first provider's. Only the ENDPOINTS can say a backup was meant
       # to be elsewhere, which is what these assert.
       - ./scripts/dev/test-backup-creds.sh
+      # The three scripts between a cluster and a lost tfstate or etcd, and the
+      # Day-1 seeder whose one rule is never to rotate what exists. Writing
+      # these found a retention slice that deleted 28 of 29 snapshots and two
+      # scripts that died silently on an absent optional key.
+      - ./scripts/dev/test-state-backups.sh
+      - ./scripts/dev/test-seed-openbao.sh
       # Nothing said "tainted", so re-running destroyed a load balancer the
       # provider was still building. This keeps that sentence on screen.
       - ./scripts/dev/test-explain-failure.sh

--- a/scripts/dev/test-seed-openbao.sh
+++ b/scripts/dev/test-seed-openbao.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# seed-openbao.sh writes the Day-1 secrets, and its one hard rule is WRITE-IF-
+# ABSENT: a re-run that rotated `backup/restic` would not fail, it would make
+# every existing backup undecryptable. Nothing measured that rule, or that the
+# script keeps its promise to print WHICH path it wrote and never WHAT.
+#
+# A stub `kubectl` answers the recovery Secret and plays `bao` behind
+# `kubectl exec`: which paths already exist, which writes are refused. Offline —
+# no cluster, no OpenBao, no credentials beyond the placeholders below.
+# ==============================================================================
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+is()  { # <label> <expected> <actual>
+  [ "$2" = "$3" ] && ok "$1" || bad "$1 — expected '$2', got '$3'"
+}
+
+SCRIPT=scripts/ops/seed-openbao.sh
+SB="$(mktemp -d)"; LOG="$SB/calls.log"
+# The script reads the REAL (gitignored) envs dir, so the fixture lives there
+# under a synthetic role and goes away with the sandbox.
+ROLE=oaseed
+FIXTURE="infrastructure/opentofu/cluster/envs/${ROLE}-scaleway.tfvars"
+trap 'rm -rf "$SB"; rm -f "$FIXTURE"' EXIT
+
+cat >"$FIXTURE" <<'EOF'
+cluster_name        = "example-mgmt"
+environment         = "test"
+s3_primary_endpoint = "https://s3.fr-par.scw.cloud"
+EOF
+printf 'apiVersion: v1\nkind: Config\n' >"$SB/kubeconfig"   # non-empty: no `task kubeconfig`
+
+cat >"$SB/kubectl" <<'STUB'
+#!/usr/bin/env bash
+printf 'kubectl:%s\n' "$*" >>"$OA_STUB_LOG"
+case "$*" in
+  "get secret openbao-recovery"*)
+    [ "${OA_STUB_NO_TOKEN:-0}" = 1 ] && exit 1
+    printf 'root-token-STUB' | base64 ;;
+  "get externalsecrets"*) printf 'observability alertmanager-slack\nbackup restic\n' ;;
+  "annotate externalsecret"*) ;;
+  "exec -i openbao-0 -n foundation-vault -- env "*)
+    set -- "${@:7}"   # drop: exec -i pod -n ns -- ; then env + 3 assignments
+    while [ "$1" != bao ]; do shift; done; shift
+    case "$1 $2" in
+      "status ") exit 0 ;;
+      "secrets list") printf 'secret/    kv\n' ;;
+      "kv get")  case ",${OA_STUB_EXISTING:-}," in *",${3#secret/},"*) exit 0 ;; *) exit 1 ;; esac ;;
+      "kv put")
+        p="${3#secret/}"; shift 3
+        printf 'put:%s|%s\n' "$p" "$*" >>"$OA_STUB_LOG"
+        case ",${OA_STUB_PUT_FAIL:-}," in *",$p,"*) echo "Error making API request: permission denied" >&2; exit 2 ;; esac ;;
+    esac ;;
+esac
+exit 0
+STUB
+chmod +x "$SB/kubectl"
+
+BASE="KUBECONFIG=$SB/kubeconfig OPENBAO_WAIT=0 SCW_AWS_ACCESS_KEY_ID=STUB-PRIMARY-AK SCW_AWS_SECRET_ACCESS_KEY=STUB-PRIMARY-SK"
+run() { # [env k=v ...] — the script's stdout+stderr; env is exactly $ENV_EXTRA
+  : >"$LOG"
+  # shellcheck disable=SC2086
+  env -i PATH="$SB:$PATH" HOME="$SB" OA_STUB_LOG="$LOG" $ENV_EXTRA "$SCRIPT" scaleway "$ROLE" </dev/null 2>&1
+}
+puts()   { grep '^put:' "$LOG"; }
+put_of() { grep "^put:$1|" "$LOG" | sed 's/^[^|]*|//'; }
+
+echo "--- a fresh cluster: every Day-1 path is written, with the resolved S3 keys ---"
+ENV_EXTRA="$BASE"
+OUT="$(run)"; RC=$?
+is "the script completes" 0 "$RC"
+is "nine paths written" 9 "$(puts | wc -l)"
+for p in backup/s3-primary backup/s3-replica backup/restic observability/loki-s3 \
+         observability/alertmanager-slack observability/alertmanager-deadmansswitch \
+         grafana/db zitadel/db longhorn/encryption; do
+  grep -q "^put:$p|" "$LOG" && ok "  + $p" || bad "  $p was not written"
+done
+P="$(put_of backup/s3-primary)"
+grep -q "endpoint=https://s3.fr-par.scw.cloud" <<<"$P" && ok "s3-primary carries the tfvars endpoint" || bad "$P"
+grep -q "bucket=s3-example-scaleway-backups-test" <<<"$P" && ok "…and the backups bucket built from cluster_name/environment" || bad "$P"
+grep -q "access_key=STUB-PRIMARY-AK secret_key=STUB-PRIMARY-SK" <<<"$P" && ok "…and the keys resolve-s3-cred.sh resolved" || bad "$P"
+R="$(put_of backup/s3-replica)"
+grep -q "endpoint=https://s3.fr-par.scw.cloud" <<<"$R" && ok "no s3_replica_endpoint in the tfvars: the replica falls back to the primary endpoint" || bad "$R"
+grep -q "bucket=s3-example-scaleway-backups-test-backup" <<<"$R" && ok "…in the -backup bucket" || bad "$R"
+[ "$(put_of backup/restic | sed -n 's/^password=//p' | wc -c)" -gt 30 ] && ok "restic gets a fresh random password" || bad "restic: $(put_of backup/restic)"
+grep -q "placeholders" <<<"$OUT" && ok "no alerting URLs in scope: it SAYS placeholders were seeded" || bad "silent placeholders: $OUT"
+grep -q "seed-openbao/synced-at=" "$LOG" && ok "ExternalSecrets are nudged to re-read" || bad "no annotate call recorded"
+
+echo "--- the promise: which path, never what ---"
+grep -q "STUB-PRIMARY-SK" <<<"$OUT" && bad "the S3 secret key was printed" || ok "the S3 secret key is not in the output"
+grep -q "STUB-PRIMARY-AK" <<<"$OUT" && bad "the S3 access key was printed" || ok "the S3 access key is not in the output"
+grep -q "root-token-STUB" <<<"$OUT" && bad "the root token was printed" || ok "the root token is not in the output"
+RESTIC_PW="$(put_of backup/restic | sed -n 's/^password=//p')"
+[ -n "$RESTIC_PW" ] && ! grep -q "$RESTIC_PW" <<<"$OUT" \
+  && ok "the generated restic password is not in the output" || bad "the restic password was printed (or never generated)"
+
+echo "--- a re-run: what exists is left ALONE (rotating restic loses every backup) ---"
+ENV_EXTRA="$BASE OA_STUB_EXISTING=backup/restic,zitadel/db"
+OUT="$(run)"; RC=$?
+is "the script completes" 0 "$RC"
+is "seven paths written" 7 "$(puts | wc -l)"
+grep -q "^put:backup/restic|" "$LOG" && bad "backup/restic was REWRITTEN on a re-run" || ok "backup/restic is not rewritten"
+grep -q "^put:zitadel/db|" "$LOG" && bad "zitadel/db was REWRITTEN on a re-run" || ok "zitadel/db is not rewritten"
+grep -q "= secret/backup/restic (already set, left alone)" <<<"$OUT" && ok "and the output says it was left alone" || bad "$OUT"
+
+echo "--- alerting URLs in scope: used, and no placeholder warning ---"
+ENV_EXTRA="$BASE OA_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0/B0/x OA_DEADMANSSWITCH_URL=https://hc-ping.com/1234"
+OUT="$(run)"; RC=$?
+is "the script completes" 0 "$RC"
+grep -q "webhook-url=https://hooks.slack.com/services/T0/B0/x" <<<"$(put_of observability/alertmanager-slack)" && ok "the Slack webhook is the one given" || bad "$(put_of observability/alertmanager-slack)"
+grep -q "placeholders" <<<"$OUT" && bad "warned about placeholders with both URLs set" || ok "no placeholder warning"
+
+echo "--- no S3 keys in scope: refused before any write ---"
+ENV_EXTRA="KUBECONFIG=$SB/kubeconfig OPENBAO_WAIT=0"
+OUT="$(run)"; RC=$?
+[ "$RC" -ne 0 ] && ok "refused (rc=$RC)" || bad "rc=0 with no credentials"
+grep -q "no S3 credentials in scope" <<<"$OUT" && ok "and says so" || bad "$OUT"
+is "zero writes" 0 "$(puts | wc -l)"
+
+echo "--- a write is refused: the reason is on screen, and the run fails ---"
+ENV_EXTRA="$BASE OA_STUB_PUT_FAIL=backup/s3-primary"
+OUT="$(run)"; RC=$?
+[ "$RC" -ne 0 ] && ok "fails (rc=$RC)" || bad "rc=0 after a refused write"
+grep -q "could not write secret/backup/s3-primary: .*permission denied" <<<"$OUT" \
+  && ok "the path AND bao's own reason are in the message" || bad "$OUT"
+
+echo "--- the recovery Secret never appears: fails naming it, writes nothing ---"
+ENV_EXTRA="$BASE OA_STUB_NO_TOKEN=1"
+OUT="$(run)"; RC=$?
+[ "$RC" -ne 0 ] && ok "fails (rc=$RC)" || bad "rc=0 with no root token"
+grep -q "Secret/openbao-recovery" <<<"$OUT" && ok "and names the Secret it waited for" || bad "$OUT"
+is "zero writes" 0 "$(puts | wc -l)"
+
+echo "--- no s3_primary_endpoint in the tfvars: refused, not seeded empty ---"
+sed -i '/s3_primary_endpoint/d' "$FIXTURE"
+ENV_EXTRA="$BASE"
+OUT="$(run)"; RC=$?
+[ "$RC" -ne 0 ] && ok "refused (rc=$RC)" || bad "seeded with an empty endpoint"
+grep -q "s3_primary_endpoint is not set" <<<"$OUT" && ok "and names the missing field" || bad "$OUT"
+is "zero writes" 0 "$(puts | wc -l)"
+
+echo "--- no tfvars for that role/provider: refused ---"
+rm -f "$FIXTURE"
+OUT="$(run)"; RC=$?
+[ "$RC" -ne 0 ] && ok "refused (rc=$RC)" || bad "ran without a tfvars"
+grep -q "no .*${ROLE}-scaleway.tfvars" <<<"$OUT" && ok "and names the file it wanted" || bad "$OUT"
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$PASS" -gt 0 ] && [ "$FAIL" -eq 0 ]

--- a/scripts/dev/test-state-backups.sh
+++ b/scripts/dev/test-state-backups.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# The three scripts that stand between a cluster and a lost state or etcd,
+# measured offline: backup-state.sh, etcd-snapshot.sh, resolve-s3-cred.sh.
+#
+# None of them had a harness. Each is a data-loss path that reports ✓ on the
+# strength of its own exit code, and two defects were found writing this file:
+# etcd-snapshot's retention slice went NEGATIVE with fewer than $KEEP snapshots
+# (jq counts a negative end from the END — 28 of 29 deleted at KEEP=30), and a
+# swapped <kind>/<type> to s3_cred printed the secret where an id was expected.
+#
+# Stub `tofu`, `aws`, `talosctl` on PATH record their argv AND the credential
+# they ran with; `gpg` and `jq` are real. No cloud, no account, no bill.
+# ==============================================================================
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+ROOT="$PWD"
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+is()  { # <label> <expected> <actual>
+  [ "$2" = "$3" ] && ok "$1" || bad "$1 — expected '$2', got '$3'"
+}
+
+SB="$(mktemp -d)"; LOG="$SB/calls.log"; CAP="$SB/captured"; mkdir -p "$CAP"
+trap 'rm -rf "$SB"' EXIT
+
+SCW_EP=https://s3.fr-par.scw.cloud
+OSC_EP=https://oos.eu-west-2.outscale.com
+
+# --- stubs --------------------------------------------------------------------
+# tofu: `output -json backup_targets` answers from a file, or fails the way the
+# real one does — a missing output and a broken backend are DIFFERENT failures.
+cat >"$SB/tofu" <<'STUB'
+#!/usr/bin/env bash
+printf 'tofu:%s\n' "$*" >>"$OA_STUB_LOG"
+case "$*" in
+  "output -json backup_targets")
+    case "${OA_STUB_TOFU_MODE:-ok}" in
+      ok)     cat "$OA_STUB_TARGETS" ;;
+      absent) echo 'Error: Output "backup_targets" not found' >&2; exit 1 ;;
+      broken) echo 'Error: Failed to load state: AccessDenied: Access Denied' >&2; exit 1 ;;
+    esac ;;
+  "output -json")
+    printf '{"control_plane_private_ips":{"value":%s}}\n' "${OA_STUB_CP_IPS:-[]}" ;;
+esac
+exit 0
+STUB
+# aws: logs the access key it was handed (that is the whole cross-provider
+# question), captures every upload, fabricates every download.
+cat >"$SB/aws" <<'STUB'
+#!/usr/bin/env bash
+printf 'aws:%s|%s\n' "${AWS_ACCESS_KEY_ID:-<unset>}" "$*" >>"$OA_STUB_LOG"
+case "$1 $2" in
+  "s3 cp")
+    if [ -f "$3" ]; then cp "$3" "$OA_STUB_CAP/$(basename "$4")"
+    else [ "${OA_STUB_DL_EXIT:-0}" = 0 ] || exit "$OA_STUB_DL_EXIT"; printf 'CIPHERTEXT-FROM-PRIMARY' >"$4"; fi ;;
+  "s3api list-objects-v2") printf '%s\n' "${OA_STUB_LIST:-null}" ;;
+esac
+exit 0
+STUB
+# talosctl: writes a snapshot unless the endpoint is one declared down.
+cat >"$SB/talosctl" <<'STUB'
+#!/usr/bin/env bash
+printf 'talosctl:%s\n' "$*" >>"$OA_STUB_LOG"
+out="${!#}"; ep=""
+while [ $# -gt 0 ]; do [ "$1" = -e ] && ep="$2"; shift; done
+case ",${OA_STUB_TALOS_DOWN:-}," in *",$ep,"*|*",all,"*) exit 1 ;; esac
+printf 'ETCD-PLAINTEXT-%s' "$ep" >"$out"
+exit 0
+STUB
+chmod +x "$SB/tofu" "$SB/aws" "$SB/talosctl"
+
+targets() { # <provider|""> <replica-endpoint> — writes the backup_targets JSON
+  cat >"$SB/targets.json" <<EOF
+{ $( [ -n "$1" ] && printf '"provider": "%s",' "$1" )
+  "state_bucket_primary": "s3-example-scaleway-tfstate-test",
+  "state_bucket_replica": "s3-example-scaleway-tfstate-test-backup",
+  "state_key": "cluster/terraform.tfstate",
+  "artifact_bucket_primary": "s3-example-scaleway-management-test",
+  "artifact_bucket_replica": "s3-example-scaleway-management-test-backup",
+  "primary_endpoint": "$SCW_EP", "primary_region": "fr-par",
+  "replica_endpoint": "$2", "replica_region": "eu-west-2" }
+EOF
+}
+# Every run: the env is EXACTLY what is listed — no key leaks in from the
+# developer's own shell, which is how a wrong-provider copy hid on 2026-08-19.
+run_raw() { # <script> [args...] — env from $ENV_EXTRA (space-separated k=v)
+  : >"$LOG"; rm -f "$CAP"/*
+  # shellcheck disable=SC2086
+  env -i PATH="$SB:$PATH" HOME="$SB" OA_STUB_LOG="$LOG" OA_STUB_CAP="$CAP" \
+      OA_STUB_TARGETS="$SB/targets.json" $ENV_EXTRA "$@" </dev/null
+}
+run()    { run_raw "$@" 2>&1; }          # everything the operator would see
+stdout() { run_raw "$@" 2>/dev/null; }   # what a Taskfile `env: sh:` would capture
+calls()  { grep -c "^$1" "$LOG"; }
+uploads() { grep -E '^aws:[^|]*\|s3 cp [^s]' "$LOG"; }   # local → s3://
+downloads() { grep -E '^aws:[^|]*\|s3 cp s3://' "$LOG"; }
+key_of() { sed -E 's/^aws:([^|]*)\|.*/\1/' <<<"$1"; }
+
+# =============================================================================
+echo "=== backup-state.sh ==="
+BS=scripts/ops/backup-state.sh
+
+echo "--- same provider: download from primary, upload to replica, SSE on, same key ---"
+targets scaleway "$SCW_EP"
+ENV_EXTRA="AWS_ACCESS_KEY_ID=AMBIENT-AK AWS_SECRET_ACCESS_KEY=AMBIENT-SK SCW_AWS_ACCESS_KEY_ID=PRIMARY-AK SCW_AWS_SECRET_ACCESS_KEY=PRIMARY-SK"
+OUT="$(run "$BS" "$ROOT")"; RC=$?
+is "the script completes" 0 "$RC"
+is "one download" 1 "$(downloads | wc -l)"
+is "one upload" 1 "$(uploads | wc -l)"
+DL="$(downloads)"; UP="$(uploads)"
+grep -q "s3://s3-example-scaleway-tfstate-test/cluster/terraform.tfstate" <<<"$DL" \
+  && ok "the download names the primary bucket and the state key" \
+  || bad "download: $DL"
+grep -q -- "--endpoint-url $SCW_EP" <<<"$DL" && ok "…against the primary endpoint" || bad "download endpoint: $DL"
+grep -q "s3://s3-example-scaleway-tfstate-test-backup/cluster/terraform.tfstate" <<<"$UP" \
+  && ok "the upload lands in the replica bucket under the SAME key" \
+  || bad "upload: $UP"
+grep -q -- "--sse AES256" <<<"$UP" && ok "server-side encryption is layered on the copy" || bad "no --sse on the upload: $UP"
+is "the download authenticates as the ambient (cluster) keys" AMBIENT-AK "$(key_of "$DL")"
+is "same provider, no backup keys: the upload falls back to the primary keys" PRIMARY-AK "$(key_of "$UP")"
+grep -q "SAME provider" <<<"$OUT" && ok "and the result says the copy is on the SAME provider" || bad "no SAME-provider warning: $OUT"
+
+echo "--- cross-provider: the copy signs with the keys of the cloud that HOLDS the bucket ---"
+targets scaleway "$OSC_EP"
+ENV_EXTRA="AWS_ACCESS_KEY_ID=AMBIENT-AK AWS_SECRET_ACCESS_KEY=AMBIENT-SK SCW_AWS_ACCESS_KEY_ID=PRIMARY-AK SCW_AWS_SECRET_ACCESS_KEY=PRIMARY-SK OUTSCALE_BACKUP_AWS_ACCESS_KEY_ID=OSC-BK-AK OUTSCALE_BACKUP_AWS_SECRET_ACCESS_KEY=OSC-BK-SK"
+OUT="$(run "$BS" "$ROOT")"; RC=$?
+is "the script completes" 0 "$RC"
+is "the upload authenticates with the Outscale backup keys, not the cluster's" OSC-BK-AK "$(key_of "$(uploads)")"
+grep -q -- "--endpoint-url $OSC_EP" <<<"$(uploads)" && ok "…against the replica endpoint" || bad "upload endpoint: $(uploads)"
+grep -q "on $OSC_EP" <<<"$OUT" && ok "and the result names where the copy went" || bad "result does not name the replica endpoint: $OUT"
+
+echo "--- provider missing from the output: derived from the bucket name ---"
+targets "" "$SCW_EP"
+ENV_EXTRA="AWS_ACCESS_KEY_ID=AMBIENT-AK SCW_AWS_ACCESS_KEY_ID=PRIMARY-AK SCW_AWS_SECRET_ACCESS_KEY=PRIMARY-SK"
+OUT="$(run "$BS" "$ROOT")"; RC=$?
+is "the script completes without a provider field" 0 "$RC"
+is "and still resolves the Scaleway keys for the upload" PRIMARY-AK "$(key_of "$(uploads)")"
+
+echo "--- no backup_targets output: 'nothing to replicate yet' is exit 0 and no aws call ---"
+targets scaleway "$SCW_EP"
+ENV_EXTRA="OA_STUB_TOFU_MODE=absent AWS_ACCESS_KEY_ID=AMBIENT-AK"
+OUT="$(run "$BS" "$ROOT")"; RC=$?
+is "exit 0" 0 "$RC"
+is "zero aws calls" 0 "$(calls aws:)"
+grep -q "Skipping state backup" <<<"$OUT" && ok "and it says it skipped" || bad "silent skip: $OUT"
+
+echo "--- the backend cannot be read: that is NOT 'no backup configured' ---"
+ENV_EXTRA="OA_STUB_TOFU_MODE=broken AWS_ACCESS_KEY_ID=AMBIENT-AK"
+OUT="$(run "$BS" "$ROOT")"; RC=$?
+is "exit 1" 1 "$RC"
+is "zero aws calls" 0 "$(calls aws:)"
+grep -q "AccessDenied" <<<"$OUT" && ok "tofu's own error is shown" || bad "the cause is hidden: $OUT"
+grep -q "not 'no backup configured'" <<<"$OUT" && ok "and the two answers are told apart" || bad "$OUT"
+
+echo "--- the download fails: no upload, no ✓ ---"
+ENV_EXTRA="OA_STUB_DL_EXIT=1 AWS_ACCESS_KEY_ID=AMBIENT-AK SCW_AWS_ACCESS_KEY_ID=PRIMARY-AK SCW_AWS_SECRET_ACCESS_KEY=PRIMARY-SK"
+OUT="$(run "$BS" "$ROOT")"; RC=$?
+[ "$RC" -ne 0 ] && ok "a failed download fails the script (rc=$RC)" || bad "rc=0 after a failed download"
+is "nothing was uploaded" 0 "$(uploads | wc -l)"
+grep -q "✓" <<<"$OUT" && bad "a ✓ was printed for a copy that never happened" || ok "no ✓ printed"
+
+# =============================================================================
+echo
+echo "=== etcd-snapshot.sh ==="
+ES="$ROOT/scripts/ops/etcd-snapshot.sh"
+WD="$SB/cluster"; mkdir -p "$WD"; printf 'context: stub\n' >"$WD/talosconfig"
+targets scaleway "$OSC_EP"
+CP_IPS='["10.0.1.10","10.0.1.11"]'
+BASE="TF_VAR_encryption_passphrase=correct-horse-battery-staple-32chars OA_STUB_CP_IPS=$CP_IPS SCW_AWS_ACCESS_KEY_ID=PRIMARY-AK SCW_AWS_SECRET_ACCESS_KEY=PRIMARY-SK OUTSCALE_BACKUP_AWS_ACCESS_KEY_ID=OSC-BK-AK OUTSCALE_BACKUP_AWS_SECRET_ACCESS_KEY=OSC-BK-SK"
+runes() { (cd "$WD" && run "$ES"); }   # the script wants ./talosconfig and cwd = cluster root
+
+echo "--- without the passphrase nothing is taken, nothing is uploaded ---"
+ENV_EXTRA="OA_STUB_CP_IPS=$CP_IPS SCW_AWS_ACCESS_KEY_ID=PRIMARY-AK SCW_AWS_SECRET_ACCESS_KEY=PRIMARY-SK"
+OUT="$(runes)"; RC=$?
+[ "$RC" -ne 0 ] && ok "refused (rc=$RC)" || bad "ran without a passphrase"
+grep -q "TF_VAR_encryption_passphrase" <<<"$OUT" && ok "and names the missing variable" || bad "$OUT"
+is "zero aws calls" 0 "$(calls aws:)"
+
+echo "--- without a talosconfig: refused before any call ---"
+mv "$WD/talosconfig" "$WD/talosconfig.away"
+ENV_EXTRA="$BASE"
+OUT="$(runes)"; RC=$?
+[ "$RC" -ne 0 ] && ok "refused (rc=$RC)" || bad "ran without a talosconfig"
+grep -q "talosconfig not found" <<<"$OUT" && ok "and says so" || bad "$OUT"
+mv "$WD/talosconfig.away" "$WD/talosconfig"
+
+echo "--- no control-plane IPs in the state: refused before a snapshot is tried ---"
+ENV_EXTRA="${BASE//$CP_IPS/[]}"
+OUT="$(runes)"; RC=$?
+[ "$RC" -ne 0 ] && ok "refused (rc=$RC)" || bad "ran with no CP"
+is "zero talosctl calls" 0 "$(calls talosctl:)"
+
+echo "--- the snapshot: first CP through its tunnel, encrypted, to both stores ---"
+ENV_EXTRA="$BASE"
+OUT="$(runes)"; RC=$?
+is "the script completes" 0 "$RC"
+grep -q "^talosctl:-e 127.0.0.1:50000 -n 10.0.1.10 etcd snapshot" "$LOG" \
+  && ok "cp-0 is asked through local port 50000 with its own node IP" \
+  || bad "talosctl call: $(grep '^talosctl:' "$LOG")"
+is "two uploads (primary + replica)" 2 "$(uploads | wc -l)"
+UP_P="$(uploads | grep 's3-example-scaleway-management-test/')"
+UP_R="$(uploads | grep 's3-example-scaleway-management-test-backup/')"
+[ -n "$UP_P" ] && [ -n "$UP_R" ] && ok "one to the primary artifact bucket, one to the replica" || bad "$(uploads)"
+grep -qE 'backups/etcd/etcd-[0-9]{8}T[0-9]{6}Z\.snap\.gpg' <<<"$UP_P" \
+  && ok "the key is timestamped so names sort chronologically" || bad "key: $UP_P"
+is "the primary upload signs with the primary keys" PRIMARY-AK "$(key_of "$UP_P")"
+is "the replica upload signs with the keys of the cloud holding it" OSC-BK-AK "$(key_of "$UP_R")"
+[ "$(grep -c -- '--sse AES256' <<<"$(uploads)")" = 2 ] && ok "both uploads carry --sse AES256" || bad "$(uploads)"
+grep -q "via cp-0 (10.0.1.10)" <<<"$OUT" && ok "the result says which CP answered" || bad "$OUT"
+
+echo "--- the artifact is ciphertext, and only the tfstate passphrase opens it ---"
+ART="$(ls "$CAP"/etcd-*.snap.gpg 2>/dev/null | head -1)"
+[ -n "$ART" ] && ok "the uploaded artifact was captured: $(basename "$ART")" || bad "no artifact captured"
+grep -q "ETCD-PLAINTEXT" "$ART" 2>/dev/null \
+  && bad "the snapshot went up in CLEAR" || ok "the plaintext marker is not in the artifact"
+G="$(mktemp -d)"
+DEC="$(GNUPGHOME="$G" gpg --batch --quiet --pinentry-mode loopback \
+        --passphrase correct-horse-battery-staple-32chars -d "$ART" 2>/dev/null)"
+is "it decrypts with the tfstate passphrase to the bytes talosctl wrote" "ETCD-PLAINTEXT-127.0.0.1:50000" "$DEC"
+GNUPGHOME="$G" gpg --batch --quiet --pinentry-mode loopback --passphrase wrong -d "$ART" >/dev/null 2>&1 \
+  && bad "a wrong passphrase decrypted it" || ok "a wrong passphrase does not"
+rm -rf "$G"
+
+echo "--- cp-0 is down: cp-1 through the next port, and the result says so ---"
+ENV_EXTRA="$BASE OA_STUB_TALOS_DOWN=127.0.0.1:50000"
+OUT="$(runes)"; RC=$?
+is "the script completes" 0 "$RC"
+grep -q "^talosctl:-e 127.0.0.1:50001 -n 10.0.1.11 " "$LOG" && ok "cp-1 was asked on port 50001" || bad "$(grep '^talosctl:' "$LOG")"
+grep -q "via cp-1 (10.0.1.11)" <<<"$OUT" && ok "and the result names cp-1" || bad "$OUT"
+
+echo "--- TALOS_TUNNEL_OFFSET shifts the port block ---"
+ENV_EXTRA="$BASE TALOS_TUNNEL_OFFSET=200"
+OUT="$(runes)"; RC=$?
+is "the script completes" 0 "$RC"
+grep -q "^talosctl:-e 127.0.0.1:50200 " "$LOG" && ok "cp-0 is asked on 50200" || bad "$(grep '^talosctl:' "$LOG")"
+
+echo "--- every CP is down: nothing uploaded, and the tunnels are named ---"
+ENV_EXTRA="$BASE OA_STUB_TALOS_DOWN=all"
+OUT="$(runes)"; RC=$?
+[ "$RC" -ne 0 ] && ok "fails (rc=$RC)" || bad "rc=0 with no snapshot"
+is "zero uploads" 0 "$(uploads | wc -l)"
+grep -q "tunnels open" <<<"$OUT" && ok "and the message points at the tunnels" || bad "$OUT"
+
+echo "--- retention: exactly the oldest beyond KEEP, never the newest ---"
+keys() { python3 -c "import json,sys;print(json.dumps(['backups/etcd/etcd-2026%04dT000000Z.snap.gpg'%i for i in range(int(sys.argv[1]))],separators=(',',':')))" "$1"; }
+rms() { grep -E '^aws:[^|]*\|s3 rm ' "$LOG"; }
+ENV_EXTRA="$BASE KEEP=30 OA_STUB_LIST=$(keys 33)"
+OUT="$(runes)"; RC=$?
+is "33 snapshots, KEEP=30: three removals per store" 6 "$(rms | wc -l)"
+for i in 0 1 2; do
+  grep -q "etcd-2026000${i}T" <<<"$(rms)" && ok "…the oldest: etcd-2026000${i}T" || bad "did not remove etcd-2026000${i}T"
+done
+grep -q "etcd-20260032T" <<<"$(rms)" && bad "the NEWEST snapshot was removed" || ok "…and the newest is kept"
+ENV_EXTRA="$BASE KEEP=30 OA_STUB_LIST=$(keys 29)"
+OUT="$(runes)"; RC=$?
+is "29 snapshots, KEEP=30: nothing removed (a negative slice end counts from the END in jq)" 0 "$(rms | wc -l)"
+ENV_EXTRA="$BASE KEEP=30 OA_STUB_LIST=$(keys 30)"
+OUT="$(runes)"; RC=$?
+is "exactly KEEP snapshots: nothing removed" 0 "$(rms | wc -l)"
+ENV_EXTRA="$BASE KEEP=3 OA_STUB_LIST=$(keys 5)"
+OUT="$(runes)"; RC=$?
+is "5 snapshots, KEEP=3: two removals per store" 4 "$(rms | wc -l)"
+ENV_EXTRA="$BASE KEEP=30 OA_STUB_LIST=null"
+OUT="$(runes)"; RC=$?
+is "an empty bucket (null listing) removes nothing and still succeeds" "0 0" "$(rms | wc -l) $RC"
+
+# =============================================================================
+echo
+echo "=== resolve-s3-cred.sh ==="
+RS=scripts/internal/resolve-s3-cred.sh
+# <provider> <ak|sk> [primary|backup] [endpoint] — the CLI order differs from
+# s3_cred's, and every Taskfile `env: sh:` line depends on this mapping.
+ENV_EXTRA="SCW_AWS_ACCESS_KEY_ID=P-AK SCW_AWS_SECRET_ACCESS_KEY=P-SK SCW_BACKUP_AWS_ACCESS_KEY_ID=SCW-BK-AK OUTSCALE_BACKUP_AWS_SECRET_ACCESS_KEY=OSC-BK-SK"
+is "<provider> <ak>: the primary access key"            P-AK      "$(stdout "$RS" scaleway ak)"
+is "<provider> <sk>: the primary secret"                P-SK      "$(stdout "$RS" scaleway sk)"
+is "… backup, no endpoint: the cluster-namespaced key"  SCW-BK-AK "$(stdout "$RS" scaleway ak backup)"
+is "… backup + Outscale endpoint: the endpoint decides"  OSC-BK-SK "$(stdout "$RS" scaleway sk backup "$OSC_EP")"
+OUT="$(stdout "$RS")"; RC=$?
+[ "$RC" -ne 0 ] && [ -z "$OUT" ] && ok "no arguments: non-zero and NOTHING on stdout" || bad "rc=$RC stdout='$OUT'"
+OUT="$(stdout "$RS" nimbus ak)"; RC=$?
+[ "$RC" -ne 0 ] && [ -z "$OUT" ] && ok "unknown provider: non-zero and nothing on stdout (seed-openbao relies on the empty answer)" || bad "rc=$RC stdout='$OUT'"
+OUT="$(stdout "$RS" scaleway primary ak)"; RC=$?
+[ "$RC" -ne 0 ] && [ -z "$OUT" ] \
+  && ok "swapped <kind>/<type>: refused rather than printing the SECRET as an access-key id" \
+  || bad "swapped arguments answered rc=$RC stdout='$OUT'"
+
+echo
+echo "--- floors: the stubs really ran (all of the above is vacuous otherwise) ---"
+ENV_EXTRA="$BASE"
+OUT="$(runes)"
+[ "$(calls tofu:)" -ge 2 ] && [ "$(calls aws:)" -ge 2 ] && [ "$(calls talosctl:)" -ge 1 ] \
+  && ok "tofu, aws and talosctl all went through the stubs ($(wc -l <"$LOG") calls)" \
+  || bad "a stub was never reached: $(cat "$LOG")"
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$PASS" -gt 0 ] && [ "$FAIL" -eq 0 ]

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -65,10 +65,13 @@ oa_aws_compat() {
 }
 
 # --- tfvars: read a top-level string assignment (key = "value"), ignore comments.
+# Empty and exit 0 when the key is absent: with grep in front, an optional key
+# (bucket_suffix, s3_replica_endpoint) returned 1 under pipefail, and a caller's
+# `v="$(tfv …)"` under set -e died at the assignment with no output.
 # Usage: tfv <tfvars-file> <key>
 tfv() {
-  grep -E "^[[:space:]]*$2[[:space:]]*=" "$1" 2>/dev/null | head -1 \
-    | sed -E 's/^[^=]*=[[:space:]]*"?([^"#]*)"?.*/\1/' | sed 's/[[:space:]]*$//'
+  sed -nE "s/^[[:space:]]*$2[[:space:]]*=[[:space:]]*\"?([^\"#]*)\"?.*/\1/p" "$1" 2>/dev/null \
+    | head -1 | sed 's/[[:space:]]*$//'
 }
 
 # --- Detect the active provider (scaleway|ovh|outscale|proxmox) from node_distribution.
@@ -115,6 +118,10 @@ provider_of_endpoint() {
 _s3_cred_pick() {
   local prov="$1" kind="$2" type="$3" ep="${4:-}" pu suffix alt v1 v2 g rprov rpu
   pu="$(provider_pu "$prov")" || { echo "s3_cred: unknown provider '$prov'" >&2; return 1; }
+  # Swapped <kind> and <type> used to answer anyway: `s3_cred scw ak primary`
+  # read as backup+sk and printed the SECRET where an access-key id was expected.
+  case "$kind" in primary | backup) ;; *) echo "s3_cred: kind must be primary|backup, got '$kind'" >&2; return 1 ;; esac
+  case "$type" in ak | sk) ;; *) echo "s3_cred: type must be ak|sk, got '$type'" >&2; return 1 ;; esac
   if [ "$type" = ak ]; then suffix=ACCESS_KEY_ID; alt=ACCESS_KEY
   else suffix=SECRET_ACCESS_KEY; alt=SECRET_KEY; fi
 

--- a/scripts/ops/etcd-snapshot.sh
+++ b/scripts/ops/etcd-snapshot.sh
@@ -77,13 +77,16 @@ put_and_prune() { # bucket endpoint region ak sk
     aws s3 cp "$OUT" "s3://${bucket}/backups/etcd/$(basename "$OUT")" \
       --endpoint-url "$ep" --region "$region" --sse AES256 >/dev/null
 
-  # Retention: timestamped names sort lexically == chronologically.
+  # Retention: timestamped names sort lexically == chronologically. The slice
+  # end is clamped at 0: a negative end counts from the END in jq, so with fewer
+  # than $KEEP snapshots `.[0:(length - KEEP)]` deleted all but the newest few —
+  # 28 of 29 at KEEP=30 — exactly while a young cluster had the fewest to lose.
   local old
   old="$(AWS_ACCESS_KEY_ID="$ak" AWS_SECRET_ACCESS_KEY="$sk" \
     aws s3api list-objects-v2 --bucket "$bucket" --prefix "backups/etcd/etcd-" \
       --endpoint-url "$ep" --region "$region" \
       --query 'Contents[].Key' --output json 2>/dev/null \
-    | jq -r '. // [] | sort | .[0:(length - '"$KEEP"')] | .[]?' )"
+    | jq -r --argjson keep "$KEEP" '. // [] | sort | .[0:([length - $keep, 0] | max)] | .[]?' )"
   local key
   while IFS= read -r key; do
     [ -n "$key" ] || continue

--- a/scripts/ops/seed-openbao.sh
+++ b/scripts/ops/seed-openbao.sh
@@ -37,9 +37,12 @@ fail() { echo "✗ $*" >&2; exit 1; }
 [ -f "$TFVARS" ] || fail "no $TFVARS"
 command -v kubectl >/dev/null || fail "kubectl is required"
 
-tfvar() { # <key> — read a top-level string from the env file
-  grep -E "^[[:space:]]*$1[[:space:]]*=" "$TFVARS" | head -1 |
-    sed -E 's/^[^=]*=[[:space:]]*"?([^"#]*)"?.*/\1/' | tr -d '[:space:]'
+tfvar() { # <key> — read a top-level string from the env file; empty when absent
+  # sed, not grep|sed: an absent key made grep exit 1, and under pipefail +
+  # set -e that killed the script at the assignment with no output at all —
+  # the "vanish" this file's own comments below refuse for the root token.
+  sed -nE "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*\"?([^\"#]*)\"?.*/\1/p" "$TFVARS" |
+    head -1 | tr -d '[:space:]'
 }
 
 # --- Where the secrets go -----------------------------------------------------


### PR DESCRIPTION
⚠ This PR modifies the repository's own gates/scripts — read the diff before running anything on this branch.

Supersedes #165: that branch's first commit carried fixture bucket names (`s3-oa-…-tfstate-…`) the env-data scan rightly flags, and since the scan reads every commit in the range a follow-up commit would not clear it. Rebuilt as one clean commit rather than force-pushing (the routine never rewrites a pushed ref). Fixtures now use the `example` placeholder form the rule allowlists.

## Why

Requested by the owner after the test-coverage inventory of 2026-09-01: of the ops/internal scripts nothing exercised, four sit on the data-loss path — `backup-state.sh`, `etcd-snapshot.sh`, `resolve-s3-cred.sh`, `seed-openbao.sh`. Each reported ✓ on the strength of its own exit code. This adds the first offline harness for them, and writing it found three defects.

## Defects found and fixed

| where | defect | fix |
|---|---|---|
| `scripts/ops/etcd-snapshot.sh` retention | `.[0:(length - KEEP)]` goes negative with fewer than `KEEP` snapshots, and jq counts a negative end from the **end**. At `KEEP=30`: 29 snapshots → 1 kept, 20 → 10 kept, on every run — worst exactly while a young cluster has the fewest to lose. | slice end clamped at 0 (`[length - $keep, 0] \| max`, `--argjson`) |
| `scripts/ops/seed-openbao.sh` `tfvar()`, `scripts/lib/common.sh` `tfv()` | an absent **optional** key (`s3_replica_endpoint`, `bucket_suffix`) made the leading `grep` exit 1 under `pipefail`; a caller's `v="$(…)"` under `set -e` then died at the assignment with **no output at all** — the "vanish" the seed script's own comments refuse for the root token, reproduced two functions below. `tfv` sits behind six other scripts (`tf-backend.sh`, `ensure-buckets.sh`, `restore-artifacts.sh`, …). | both read with `sed -n`, which exits 0 on no match |
| `scripts/lib/common.sh` `_s3_cred_pick` | `<kind>` and `<type>` swapped (`s3_cred scw ak primary`) answered anyway: read as backup+sk, it printed the **secret** where an access-key id was expected — a value that ends up in logs and error messages | refused with a message naming the valid values |

## Harness

- `scripts/dev/test-state-backups.sh` (71 assertions): stub `tofu`/`aws`/`talosctl` on PATH record argv **and the access key each call ran with**; `gpg` and `jq` are real; every run under `env -i` so no key leaks in from the developer's shell (how a wrong-provider copy hid on 2026-08-19).
  - `backup-state.sh`: download from primary / upload to replica under the same key with `--sse`; cross-provider copy signs with the keys of the cloud **holding** the bucket; provider derived from the bucket name when absent; "no output yet" is exit 0 with zero aws calls, a broken backend is exit 1 and shows tofu's error; a failed download uploads nothing and prints no ✓.
  - `etcd-snapshot.sh`: refuses without passphrase / talosconfig / CP IPs before any call; cp-0 through port 50000 with its node IP, cp-1 on 50001 when cp-0 is down, `TALOS_TUNNEL_OFFSET` shifts the block; two uploads with `--sse`, primary keys vs replica keys; the captured artifact decrypts with the tfstate passphrase to the exact bytes talosctl wrote and not with a wrong one; retention at 33/30 (the 3 oldest, never the newest), 29/30, 30/30, 5/3, empty bucket.
  - `resolve-s3-cred.sh`: the CLI argument order every Taskfile `env: sh:` depends on; nothing on stdout on any refusal (seed-openbao relies on the empty answer).
- `scripts/dev/test-seed-openbao.sh` (44 assertions): stub `kubectl` plays `bao` behind `kubectl exec`. Fresh cluster writes nine paths with the resolved keys and the convention bucket; a re-run leaves `backup/restic` and `zitadel/db` **alone**; the S3 keys, root token and generated passwords never appear in the output; every refusal (no keys, refused write with bao's reason, no recovery Secret, missing endpoint, missing tfvars) names its cause and writes nothing.
- Both wired into `task test-scripts` (reachability gate).

**Mutation-tested**: each fix reverted in turn → harness red (retention: 56 removals instead of 0; swapped args: `P-SK` printed; grep tfvar: 27 failures) → restored → green.

## Rung reached: mocked

- `task lint` — green (after removing a stale local worktree that `clea coverage` was scanning; not a tree change)
- `task test-scripts` — green, including the two new harnesses
- `task test` — 61/61
- `task render-check`, `task validate ROOT=cluster`, `task validate ROOT=talos-image` — green
- `checkov` 32/0, `test-checkov-custom-checks.sh` 6/0, `check-gitleaks-rules.sh` green; `gitleaks git -c .gitleaks-envdata.toml` on `origin/main..HEAD` (the CI command) — no leaks; `gitleaks dir` reports one hit in a **gitignored** local feint `terraform.tfstate.backup`, not in the tree
- IPv4 literals in the diff: `10.0.1.x` (RFC 1918 fixtures) and `127.0.0.1` only

**Not run: emulated, real cloud.** The retention fix changes what an `aws s3 rm` loop deletes on a real bucket; the harness proves the key selection, not the provider's listing semantics.

## Left out

- `seed-openbao.sh` builds the backups bucket name without `bucket_suffix` while `lib/common.sh`'s `oa_project` includes it — #166, not touched here.

Assisted-by: Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_