### PR TITLE
fix(ops): seed-openbao derives the backups bucket through oa_project, suffix included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`seed-openbao.sh` named a backups bucket that did not exist on any
+  cluster deployed under a `bucket_suffix` (#166).** It rebuilt
+  `s3-<project>-<provider>-backups-<env>` by hand from `cluster_name`'s first
+  segment, while `cluster/backup.tf` and every other shell caller append the
+  suffix through `oa_project`; restic and Loki were seeded with the wrong
+  name and the seeder printed ✓. It now derives the name through the new
+  `oa_backup_bucket()` in `lib/common.sh`, and `test-bucket-names.sh` runs the
+  seeder against a stub kubectl and reads the bucket it announces — the
+  seventh derivation, compared with the six it already covered.
 - **Building a Talos image for one cluster could silently delete the image
   another cluster's tfvars still pinned (#93).** talos-image's root tracks
   exactly one image per provider (`backend.tf`: `key=talos-image.tfstate`, not

--- a/scripts/dev/test-bucket-names.sh
+++ b/scripts/dev/test-bucket-names.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Six places build a bucket name. They must agree, or the backend points at a
+# Seven places build a bucket name. They must agree, or the backend points at a
 # bucket nothing created and the apply dies after the network exists.
 #
 # The derivations live in two languages that cannot import each other:
-#   shell  — oa_project / oa_state_bucket / oa_artifact_bucket (lib/common.sh),
-#            used by tf-backend.sh, ensure-buckets.sh, infra-verify.sh,
-#            restore-artifacts.sh and talos-image.sh, all of which run BEFORE or
-#            AROUND OpenTofu;
+#   shell  — oa_project / oa_state_bucket / oa_artifact_bucket / oa_backup_bucket
+#            (lib/common.sh), used by tf-backend.sh, ensure-buckets.sh,
+#            infra-verify.sh, restore-artifacts.sh, talos-image.sh and
+#            seed-openbao.sh, all of which run BEFORE or AROUND OpenTofu;
 #   HCL    — local.backup_project in cluster/backup.tf, which names the same
 #            buckets from inside the apply.
 # Nothing but this file compares them.
@@ -19,7 +19,7 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=../lib/common.sh
 source "$ROOT/scripts/lib/common.sh"
-oa_require_fn oa_state_bucket oa_artifact_bucket oa_project || exit 1
+oa_require_fn oa_state_bucket oa_artifact_bucket oa_backup_bucket oa_project || exit 1
 
 PASS=0
 FAIL=0
@@ -41,6 +41,7 @@ echo "=== the full bucket names ==="
 eq "state, no suffix"    "$(oa_state_bucket "$(oa_project example)" scaleway dev)"        "s3-example-scaleway-tfstate-dev"
 eq "state, suffix"       "$(oa_state_bucket "$(oa_project example a1b2c3)" scaleway dev)" "s3-example-a1b2c3-scaleway-tfstate-dev"
 eq "artifact, suffix"    "$(oa_artifact_bucket "$(oa_project example a1b2c3)" ovh management prod)" "s3-example-a1b2c3-ovh-management-prod"
+eq "backups, suffix"     "$(oa_backup_bucket "$(oa_project example a1b2c3)" outscale prod)" "s3-example-a1b2c3-outscale-backups-prod"
 
 echo "=== HCL and shell derive the SAME namespace ==="
 # `join("-", compact([...]))` in backup.tf against oa_project here. Reproduced
@@ -66,6 +67,11 @@ if grep -qF 'backup_project        = join("-", compact([split("-", var.cluster_n
   ok "backup.tf:local.backup_project is the expression mirrored above"
 else
   bad "backup.tf:local.backup_project changed — update hcl_project() here, then re-check every caller"
+fi
+if grep -qF 'backup_data_bucket = "${local.backup_bucket_prefix}-backups-${var.environment}"' "$BT"; then
+  ok "backup.tf:local.backup_data_bucket is <prefix>-backups-<env>, what oa_backup_bucket() prints"
+else
+  bad "backup.tf:local.backup_data_bucket changed — oa_backup_bucket() and seed-openbao.sh now name a different bucket"
 fi
 
 echo "=== every name is legal on all three providers ==="
@@ -117,6 +123,22 @@ for kind in primary replica; do
          sed -nE 's#.*s3://([a-z0-9-]+)/backups/.*#\1#p' | head -1)"
   eq "restore --from $kind targets the suffixed bucket" "$got" "$want"
 done
+
+echo "=== the Day-1 seeder names the SAME backups bucket backup.tf publishes ==="
+# Same shape: RUN seed-openbao.sh against a stub kubectl (every path reads as
+# already set, so nothing is written) and read the bucket it announces. It was
+# the seventh place building the name and the only one dropping the suffix, so
+# restic and Loki were seeded with a bucket backup.tf never created (#166).
+cat >"$SB/kubectl" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in "get secret openbao-recovery"*) printf 'stub-token' | base64 ;; "exec "*" secrets list") printf 'secret/\n' ;; esac
+exit 0
+STUB
+chmod +x "$SB/kubectl"; printf 'apiVersion: v1\n' >"$SB/kubeconfig"
+WANT_SEED="$(oa_backup_bucket "$(oa_project "$CNAME" "$SUF")" scaleway "$ENVV")"
+got="$(PATH="$SB:$PATH" KUBECONFIG="$SB/kubeconfig" OPENBAO_WAIT=0 SCW_AWS_ACCESS_KEY_ID=k SCW_AWS_SECRET_ACCESS_KEY=k \
+       ./scripts/ops/seed-openbao.sh scaleway oatest 2>&1 | sed -nE 's/.*bucket ([a-z0-9-]+)\).*/\1/p' | head -1)"
+eq "seed-openbao announces the suffixed backups bucket" "$got" "$WANT_SEED"
 
 
 echo "--- the state lock is claimed only where the store honours it ---"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -185,6 +185,7 @@ oa_project() { # <cluster_name> [bucket_suffix] — the bucket namespace
 }
 oa_state_bucket() { printf 's3-%s-%s-tfstate-%s' "$1" "$2" "$3"; }            # project provider env
 oa_artifact_bucket() { printf 's3-%s-%s-%s-%s' "$1" "$2" "$3" "$4"; }         # project provider role env
+oa_backup_bucket() { printf 's3-%s-%s-backups-%s' "$1" "$2" "$3"; }           # project provider env (restic, Longhorn)
 
 # --- Local port block for the per-node Talos API tunnels (CPs 50000+off+i,
 # workers 50100+off+i). The ports were fixed, which meant one cluster at a time

--- a/scripts/ops/seed-openbao.sh
+++ b/scripts/ops/seed-openbao.sh
@@ -27,6 +27,8 @@ set -euo pipefail
 PROVIDER="${1:?usage: seed-openbao.sh <provider> [role]}"
 ROLE="${2:-management}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$ROOT/scripts/lib/common.sh"   # oa_project / oa_backup_bucket
 CLUSTER="$ROOT/infrastructure/opentofu/cluster"
 TFVARS="$CLUSTER/envs/${ROLE}-${PROVIDER}.tfvars"
 
@@ -137,18 +139,11 @@ REPLICA_EP="$(tfvar s3_replica_endpoint)"
 [ -n "$PRIMARY_EP" ] || fail "s3_primary_endpoint is not set in $TFVARS"
 [ -n "$REPLICA_EP" ] || REPLICA_EP="$PRIMARY_EP"
 
-# Application-backup bucket, same convention as cluster/backup.tf:
-#   s3-<project>-<provider-short>-backups-<environment>
-CLUSTER_NAME="$(tfvar cluster_name)"
-ENVIRONMENT="$(tfvar environment)"
-PROJECT="${CLUSTER_NAME%%-*}"
-case "$PROVIDER" in
-  scaleway) SHORT=scaleway ;;
-  ovh) SHORT=ovh ;;
-  outscale) SHORT=outscale ;;
-  *) SHORT="$PROVIDER" ;;
-esac
-BUCKET="s3-${PROJECT}-${SHORT}-backups-${ENVIRONMENT}"
+# Application-backup bucket, through the SAME derivation as cluster/backup.tf
+# and every other shell caller — this was the one place that rebuilt the name
+# by hand and dropped bucket_suffix, so a suffixed cluster's restic and Loki
+# were pointed at a bucket nothing created (#166). bucket_suffix is optional.
+BUCKET="$(oa_backup_bucket "$(oa_project "$(tfvar cluster_name)" "$(tfvar bucket_suffix || true)")" "$PROVIDER" "$(tfvar environment)")"
 
 # Alerting endpoints are real in production and arbitrary on a throwaway cluster,
 # which admin-access.md says explicitly. Take them from the environment when set,


### PR DESCRIPTION
⚠ This PR modifies the repository's own gates/scripts — read the diff before running anything on this branch.

Closes #166.

## What

`scripts/ops/seed-openbao.sh` rebuilt `s3-<project>-<provider>-backups-<env>` by hand from `cluster_name`'s first segment, while `cluster/backup.tf` (`local.backup_data_bucket`) and every other shell caller append `bucket_suffix` through `oa_project`. On a cluster deployed under a suffix, `backup/s3-primary`, `backup/s3-replica` and `observability/loki-s3` were seeded with a bucket nothing created, and the seeder printed ✓.

- `scripts/lib/common.sh`: `oa_backup_bucket()` next to `oa_state_bucket` / `oa_artifact_bucket`, mirroring backup.tf's expression.
- `scripts/ops/seed-openbao.sh`: sources `lib/common.sh` and derives the name through it (`bucket_suffix` optional, absent by default).
- `scripts/dev/test-bucket-names.sh`: the seventh derivation, compared the way the restore path already is — **runs** `seed-openbao.sh` against a stub kubectl on the suffixed fixture and reads the bucket it announces; plus the backups name itself with a suffix, and a guard that backup.tf's `backup_data_bucket` expression is still the one mirrored.

## Rung reached: mocked

- `task lint`, `task test-scripts` (24/24 in `test-bucket-names.sh`), `task test` 61/61, `task render-check`, `task validate ROOT=cluster` / `ROOT=talos-image` — green
- `checkov` 32/0, `test-checkov-custom-checks.sh` 6/0, `check-gitleaks-rules.sh` green, `gitleaks git -c .gitleaks-envdata.toml` on `origin/main..HEAD` (the CI command) — no leaks
- No IPv4 literal in the diff
- **Mutation-tested**: with the previous hand-built derivation restored, the new assertion goes red (`s3-…-scaleway-backups-dev` announced instead of `s3-…-a1b2c3-scaleway-backups-dev`); with the fix, green.

**Not run: emulated, real cloud** — #68 (a deploy under a suffix reaching `cluster-verify`) stays the real-cloud proof; this removes one reason it would not have worked.

## Expected trivial conflict

#167 touches `seed-openbao.sh` (its `tfvar()` reader, a different hunk) and adds a `CHANGELOG.md` bullet under the same heading. Both resolve by keeping both sides. Once #167 lands, `test-seed-openbao.sh` can gain a suffixed-fixture case; the assertion here already proves the derivation.

Assisted-by: Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_