### PR TITLE
chore(deps): bump plumber to v0.4.51

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,7 +95,7 @@ jobs:
       # wired live, see that script's header for why.
       - name: Plumber
         # renovate: datasource=github-releases depName=getplumber/plumber
-        uses: getplumber/plumber@3feac69e925e9771f8a495f4177af754d568c1ad  # v0.4.48
+        uses: getplumber/plumber@e815e0bff47f9170e8e0a056df0a851124634ae2  # v0.4.51
         with:
           # Publishing the score sends this repository's name to a hosted badge
           # service. That is a decision to take on purpose, not a CI default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -538,6 +538,30 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Changed
 
+- **`getplumber/plumber` v0.4.48 → v0.4.51** in `.github/workflows/security.yml`
+  and `scripts/internal/install-plumber.sh`, bumped by hand rather than by
+  Cléa: the `security.yml` anchor is `action-sha`-pinned
+  (`uses: getplumber/plumber@<sha> # vX.Y.Z`), and `clea bump` refuses to
+  rewrite only the trailing comment there since it cannot also move the SHA —
+  doing so would claim a version the pinned commit does not carry. Both sites
+  were not yet probed by Cléa (issue #91), so this bump carries its own
+  evidence in place of a probe: the release notes for v0.4.49 → v0.4.51 show
+  no breaking change (GitLab-platform-mode features and an additive
+  report-schema field only); the pinned SHA was checksum-verified against
+  `getplumber/plumber`'s own `checksums.txt` via `install-plumber.sh`; and a
+  real `plumber analyze` run against this tree on v0.4.51 was diffed against
+  the same run on v0.4.48 — identical 24-control set, identical
+  `dataCollectionDegraded: true` (this sandbox's GitHub session is
+  repository-scoped, so `branchProtectionResult` and the action-CVE lookups
+  can't resolve — the same limitation the v0.4.48 baseline hits, not a
+  regression), and every real policy control (`actionPinningResult`,
+  `excessivePermissionsResult`, `permissionsResult`, `dangerousTriggersResult`,
+  `checkoutCredentialsResult`, …) passing on both. `task lint` (including
+  `check-version-drift.sh`'s pin-agreement check), `task test-scripts`,
+  `task validate` (both roots), `task test`, checkov (32/0) + custom checks,
+  and a default-rules gitleaks dir scan all green. `task security`'s `trivy`
+  step could not run in this sandbox (no network) — relies on CI.
+
 - **`yamllint` 1.35.1 → 1.38.0** in `.github/workflows/ci.yml`, probed green
   by Cléa (issue #91). `task lint`, `task test-scripts`, `task validate`
   (both roots), `task test`, checkov (32/0) + custom checks, and a default-rules

--- a/scripts/internal/install-plumber.sh
+++ b/scripts/internal/install-plumber.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 # renovate: datasource=github-releases depName=getplumber/plumber extractVersion=^v(?<version>.*)$
-PLUMBER_VERSION="0.4.48"
+PLUMBER_VERSION="0.4.51"
 
 # shellcheck source=scripts/lib/common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"


### PR DESCRIPTION
## What

Unblocks what `clea bump` correctly refuses to do on its own: the
`security.yml` anchor is `action-sha` pinned
(`uses: getplumber/plumber@<sha> # vX.Y.Z`), and rewriting only the
trailing comment would claim a version the pinned commit does not carry.
Bumped by hand instead — SHA and comment moved together — plus the
sibling non-SHA pin in `install-plumber.sh` so both anchors keep
agreeing (`check-version-drift.sh` checks exactly this).

| dependency | old → new | where |
|---|---|---|
| `getplumber/plumber` | `v0.4.48` → `v0.4.51` | `.github/workflows/security.yml:98` (action-sha) |
| `getplumber/plumber` | `0.4.48` → `0.4.51` | `scripts/internal/install-plumber.sh:21` |

New SHA: `e815e0bff47f9170e8e0a056df0a851124634ae2` (resolved from the
upstream `v0.4.51` tag via `git ls-remote`).

## Why by hand, and the evidence in place of a probe

Neither anchor had been probed green by Cléa yet (issue #91 lists both
`not probed`), and `clea bump` never gets the chance to try the
`security.yml` one — its own safety check refuses any rewrite that
would move the label without moving the SHA. So this carries its own
evidence instead of a probe:

- **Release notes, v0.4.49 → v0.4.51**: no breaking change — GitLab
  platform-mode features/fixes and an additive `plumber-report.json`
  field (control name + category metadata alongside the existing keys).
  No CLI flag changes in range.
- **Checksum-verified install**: `install-plumber.sh` downloaded the
  `v0.4.51` binary and verified it against upstream's own
  `checksums.txt`.
- **Real `plumber analyze` run against this tree**, v0.4.51 vs. v0.4.48,
  diffed side by side:
  - identical 24-control set, no controls added/removed/renamed;
  - identical `dataCollectionDegraded: true` on both — this sandbox's
    GitHub session is repository-scoped, so `branchProtectionResult`
    and the per-action CVE/archived-repo lookups can't resolve; this is
    the same limitation the v0.4.48 baseline already hits here, not
    something v0.4.51 introduced (a real CI token has the access this
    sandbox doesn't);
  - every real policy control (`actionPinningResult`,
    `excessivePermissionsResult`, `permissionsResult`,
    `dangerousTriggersResult`, `checkoutCredentialsResult`, …) passes on
    both versions, no new findings.

## Gates run (this sandbox has no network for `trivy` — relies on CI for that one)

- `task lint` — green (includes `check-version-drift.sh`: `plumber
  0.4.51: install-plumber.sh and security.yml agree`)
- `task test-scripts` — green
- `task validate ROOT=cluster` / `ROOT=talos-image` — green
- `task test` — 61/61 passed
- `checkov -d infrastructure/opentofu` — 32/0
- `./scripts/dev/test-checkov-custom-checks.sh` — 6/0
- `gitleaks dir` (default rules, matching `task security`'s own
  invocation) — no leaks
- `./scripts/dev/check-gitleaks-rules.sh` — green
- `trivy` — **not run**, no network access in this sandbox; CI's own
  Trivy step is what verifies this

Mocked rung — a CI tool-version pin bump, no provider/cloud surface.

Assisted-by: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbJHzE7FcDKZQqSMFKfzqV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbJHzE7FcDKZQqSMFKfzqV)_