### PR TITLE
fix(dev): feint.sh retries `running` after a restart instead of checking once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`feint.sh` checked whether the emulator had restarted exactly once, with
+  no retry (#169).** `feint start` returning — even after printing its own
+  "listening on ..." line — does not guarantee `feint status` already
+  answers. `reset_emulator` (used before every apply/record lane) and the
+  `start` command hit this on a GitHub-hosted runner: CI's "Feint Evidence
+  (outscale)" job on PR #168 failed with "the emulator did not come back",
+  then passed on an unmodified re-run of the same commit. Both now poll for
+  up to `FEINT_RESTART_TIMEOUT` (default 10s, integer sleep only — feint also
+  ships Darwin binaries and BSD `sleep` rejects a fractional argument) before
+  failing, and the failure path prints the emulator's own log (previously
+  only `require_emulator` did). New `scripts/dev/test-feint-restart.sh`: a
+  stub `feint` puts the startup delay under control; `FEINT_RESTART_TIMEOUT=0`
+  reproduces the exact pre-fix behavior through the real code path, not a
+  diff revert.
 - **`seed-openbao.sh` named a backups bucket that did not exist on any
   cluster deployed under a `bucket_suffix` (#166).** It rebuilt
   `s3-<project>-<provider>-backups-<env>` by hand from `cluster_name`'s first

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -429,6 +429,12 @@ tasks:
       # (#132) — proves a malformed rev-range fails loud instead of reading
       # as zero commits, none of them tool-authored.
       - ./scripts/dev/test-commit-authors.sh
+      # feint.sh checked `running` once, immediately after `feint start`
+      # returned, with no retry — raced on a GitHub-hosted runner and failed
+      # CI once with no code change (#169). A stub feint puts the startup
+      # delay under our control; FEINT_RESTART_TIMEOUT=0 reproduces the exact
+      # pre-fix behavior through the real code path.
+      - ./scripts/dev/test-feint-restart.sh
       # Offline self-test of check-required-checks.sh's diff logic (#122):
       # against canned fixtures, proves it flags a required check that a
       # ruleset never declares (CodeQL-shaped) AND refuses an empty rulesets

--- a/scripts/dev/feint.sh
+++ b/scripts/dev/feint.sh
@@ -66,15 +66,38 @@ require_emulator() {
   # The one thing that could explain it, the emulator's own log, was discarded.
   # Observed 2026-08-17: the outscale leg planned successfully, then found no
   # emulator at the apply, and nothing in the run said why.
+  emulator_log_hint
+  exit 1
+}
+
+# emulator_log_hint prints the emulator's own log so "why" survives past the
+# process that could have answered it directly. Shared by require_emulator and
+# reset_emulator's failure path.
+emulator_log_hint() {
   local log="${XDG_RUNTIME_DIR:-/tmp}/feint/${FEINT_ENDPOINT#http://}/feint.log"
   log="${log//:/_}"
   if [ -r "$log" ]; then
-    echo "  it was started and is gone. Last lines of ${log}:" >&2
+    echo "  Last lines of ${log}:" >&2
     tail -20 "$log" | sed 's/^/    /' >&2
   else
     echo "  no log at ${log} either — if it never started, run 'task feint-up' first." >&2
   fi
-  exit 1
+}
+
+# poll_running waits up to FEINT_RESTART_TIMEOUT seconds for the emulator to
+# actually answer `status`. `feint start` returning — even after its own
+# "listening on ..." line — does not mean the status endpoint is already up:
+# a restart inside reset_emulator raced this on a GitHub-hosted runner and
+# failed CI once with no code change involved, passing again on an unmodified
+# re-run (#169). Integer sleep only: feint also ships Darwin binaries, and
+# BSD sleep does not accept a fractional argument.
+FEINT_RESTART_TIMEOUT="${FEINT_RESTART_TIMEOUT:-10}"
+poll_running() {
+  local deadline=$((SECONDS + FEINT_RESTART_TIMEOUT))
+  until running; do
+    [ "$SECONDS" -lt "$deadline" ] || return 1
+    sleep 1
+  done
 }
 
 # reset_emulator empties the store, which only a restart does: the store is in
@@ -87,7 +110,11 @@ reset_emulator() {
   [ -n "$FEINT_VM" ] && vm_args=(--vm "$FEINT_VM")
   feint_cli stop >/dev/null 2>&1 || true
   feint_cli start --addr "$(addr_of "$FEINT_ENDPOINT")" "${vm_args[@]}" >/dev/null
-  running || { echo "✗ the emulator did not come back on $FEINT_ENDPOINT" >&2; exit 1; }
+  poll_running || {
+    echo "✗ the emulator did not come back on $FEINT_ENDPOINT within ${FEINT_RESTART_TIMEOUT}s" >&2
+    emulator_log_hint
+    exit 1
+  }
 }
 
 # emulated_env clears every credential a provider could pick up on its own.
@@ -448,8 +475,14 @@ case "${1:-}" in
     # Matched on the output, not the exit code: `feint status` exits 0 either
     # way, so keying off it silently skipped the start and left every later
     # step running against nothing.
-    running || feint_cli start --addr "$(addr_of "$FEINT_ENDPOINT")" "${vm_args[@]}"
-    running || { echo "✗ the emulator did not come up on $FEINT_ENDPOINT" >&2; exit 1; }
+    if ! running; then
+      feint_cli start --addr "$(addr_of "$FEINT_ENDPOINT")" "${vm_args[@]}"
+      poll_running || {
+        echo "✗ the emulator did not come up on $FEINT_ENDPOINT within ${FEINT_RESTART_TIMEOUT}s" >&2
+        emulator_log_hint
+        exit 1
+      }
+    fi
     feint_cli status
     ;;
   stop)

--- a/scripts/dev/test-feint-restart.sh
+++ b/scripts/dev/test-feint-restart.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# feint.sh's start/restart path checked `running` exactly once, immediately
+# after `feint start` returned. `feint start` returning — even printing its
+# own "listening on ..." line — does not guarantee the status endpoint
+# already answers: this raced on a GitHub-hosted runner and failed CI once
+# (PR #168, "Feint Evidence (outscale)"), passing again on an unmodified
+# re-run of the same commit (#169).
+#
+# A stub `feint` puts the delay under our control: `status` reports
+# "running on ..." only OA_STUB_DELAY seconds after `start` was called.
+# FEINT_RESTART_TIMEOUT=0 reproduces the EXACT pre-fix behavior — a single
+# immediate check, no retry — through the real code path, not a diff revert.
+#
+# Offline: no cloud, no account, no real feint process, no Incus.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+SB="$(mktemp -d)"; LOG="$SB/calls.log"; STATE="$SB/state"
+trap 'rm -rf "$SB"' EXIT
+
+# start: records when it was called. status: "running on ..." only once
+# OA_STUB_DELAY seconds have elapsed since — or never, if OA_STUB_NEVER_READY.
+cat >"$SB/feint" <<'STUB'
+#!/usr/bin/env bash
+printf 'feint:%s\n' "$*" >>"$OA_STUB_LOG"
+case "$1" in
+  version) printf 'v0.12.0\n'; exit 0 ;;
+  start) date +%s >"$OA_STUB_STATE"; exit 0 ;;
+  stop)  rm -f "$OA_STUB_STATE"; exit 0 ;;
+  status)
+    if [ "${OA_STUB_NEVER_READY:-0}" = 1 ] || [ ! -f "$OA_STUB_STATE" ]; then
+      echo "not running"; exit 0
+    fi
+    started="$(cat "$OA_STUB_STATE")"; now="$(date +%s)"
+    if [ $((now - started)) -ge "${OA_STUB_DELAY:-0}" ]; then
+      echo "running on 127.0.0.1:4599 (pid 1, since $(date -u +%FT%TZ))"
+    else
+      echo "not running yet"
+    fi
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$SB/feint"
+
+run() { # <FEINT_RESTART_TIMEOUT> <OA_STUB_DELAY> [OA_STUB_NEVER_READY]
+  : >"$LOG"; rm -f "$STATE"
+  env -i PATH="$SB:$PATH" HOME="$SB" \
+      OA_STUB_LOG="$LOG" OA_STUB_STATE="$STATE" OA_STUB_DELAY="$2" OA_STUB_NEVER_READY="${3:-0}" \
+      FEINT_RESTART_TIMEOUT="$1" FEINT_ENDPOINT="http://127.0.0.1:4599" \
+      ./scripts/dev/feint.sh start </dev/null 2>&1
+}
+calls() { grep -c "^feint:$1" "$LOG"; }
+
+echo "--- status is slow to catch up, well within the timeout: succeeds ---"
+START="$(date +%s)"
+OUT="$(run 5 2)"; RC=$?
+ELAPSED=$(( $(date +%s) - START ))
+[ "$RC" -eq 0 ] && ok "start succeeds once status catches up (rc=$RC)" || bad "start failed: $OUT"
+[ "$ELAPSED" -ge 2 ] && ok "it actually kept checking (${ELAPSED}s elapsed, delay was 2s)" \
+                     || bad "returned too fast (${ELAPSED}s) — is poll_running retrying at all?"
+grep -q "^running on" <<<"$OUT" && ok "the final status line is printed" || bad "no status line: $OUT"
+
+echo "--- FEINT_RESTART_TIMEOUT=0 reproduces the exact pre-fix bug: one check, no retry ---"
+OUT="$(run 0 2)"; RC=$?
+[ "$RC" -ne 0 ] && ok "fails immediately, same as before this fix (rc=$RC)" \
+                || bad "rc=0 with zero retry budget — poll_running is not actually being exercised above"
+grep -qi "did not come up" <<<"$OUT" && ok "and names what happened" || bad "$OUT"
+
+echo "--- the emulator never becomes ready: fails within the timeout, not hung ---"
+START="$(date +%s)"
+OUT="$(run 2 999 1)"; RC=$?
+ELAPSED=$(( $(date +%s) - START ))
+[ "$RC" -ne 0 ] && ok "fails (rc=$RC)" || bad "rc=0 with an emulator that never came up"
+[ "$ELAPSED" -le 4 ] && ok "bounded by the timeout, not hung (${ELAPSED}s)" || bad "took ${ELAPSED}s — no upper bound?"
+grep -qi "did not come up" <<<"$OUT" && ok "names the failure" || bad "$OUT"
+grep -qi "no log at\|Last lines of" <<<"$OUT" && ok "and points at the emulator's own log" || bad "$OUT"
+
+echo "--- already running: no restart is attempted at all ---"
+: >"$LOG"; date +%s >"$STATE"
+OUT="$(env -i PATH="$SB:$PATH" HOME="$SB" OA_STUB_LOG="$LOG" OA_STUB_STATE="$STATE" OA_STUB_DELAY=0 \
+       FEINT_RESTART_TIMEOUT=5 FEINT_ENDPOINT="http://127.0.0.1:4599" \
+       ./scripts/dev/feint.sh start </dev/null 2>&1)"; RC=$?
+[ "$RC" -eq 0 ] && ok "start on an already-running emulator succeeds" || bad "$OUT"
+[ "$(calls start)" = 0 ] && ok "…and 'feint start' was never called" || bad "feint start was called: $(grep '^feint:start' "$LOG")"
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$PASS" -gt 0 ] && [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
⚠ This PR modifies the repository's own gates/scripts — read the diff before running anything on this branch.

Closes #169.

## What

`reset_emulator` and the `start` command in `scripts/dev/feint.sh` both called `feint start` then checked `running` **exactly once**, with no retry. `feint start` returning — even after printing its own `listening on ...` line — does not guarantee the status endpoint already answers.

This raced on a GitHub-hosted runner: PR #168's "Feint Evidence (outscale)" job failed with `✗ the emulator did not come back on http://127.0.0.1:4599`, right after `feint start` had printed `listening`. A re-run of the same job on the same commit, no code change, passed.

Checked feint's own v0.12.1 release first — an internal coverage-inventory correction, explicitly "no user-facing changes to observed behavior," nothing about start/stop/status timing. Not a feint bug; this is ours.

## Fix

- New shared `poll_running()`: retries `running` for up to `FEINT_RESTART_TIMEOUT` (default 10s). Integer `sleep` only — feint also ships Darwin binaries, and BSD `sleep` rejects a fractional argument.
- Used by both `reset_emulator` (the path that actually failed) and the `start` command (same bug shape, same fix).
- New shared `emulator_log_hint()`: the emulator's own log on failure, previously only printed by `require_emulator`. Now both restart-failure paths get it.

## Proof

- `scripts/dev/test-feint-restart.sh` (11 assertions, wired into `task test-scripts`): a stub `feint` puts the startup delay under control — `status` reports "running" only N seconds after `start` was called.
  - Status slow but within budget (delay 2s, timeout 5s): succeeds, and actually took ≥2s (proves it's polling, not vacuously passing).
  - **`FEINT_RESTART_TIMEOUT=0` reproduces the exact pre-fix bug** — one check, no retry — through the real code path, not a diff revert: fails immediately, same as before this fix.
  - Emulator that never comes up: fails, bounded by the timeout (not hung).
  - Already running: no restart attempted at all, `feint start` never called.
- `bash -n`, `shellcheck -S error` (the exact severity `task lint` uses) — clean.
- **Proven at the emulated rung itself**, not just mocked: `task feint-test` — `feint-up`, plan + apply/destroy on both scaleway and outscale, `feint-down` — green end to end through the patched `start`/`reset_emulator` path. This is the same lane that failed in CI.
- `task lint`, `task test-scripts` (all green, including the new file), `task test` 61/61, `task render-check`, `task validate ROOT=cluster` / `ROOT=talos-image` — green.
- `checkov` 32/0, `test-checkov-custom-checks.sh` 6/0, `check-gitleaks-rules.sh` green, `gitleaks git -c .gitleaks-envdata.toml` on `origin/main..HEAD` (the CI command) — no leaks; `gitleaks dir` reports the one known hit in a gitignored local feint `terraform.tfstate.backup`, not in the tree.
- IPv4 literals in the diff: `127.0.0.1` only (already used throughout this file).

**Not run: real cloud** — not applicable, this only touches the local emulator driver.

Assisted-by: Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_