### PR TITLE
fix(internal): install-shellcheck.sh installs xz-utils when xz is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ### Fixed
 
+- **`install-shellcheck.sh` died extracting its own download on a bare box,
+  which Cléa's probe misreported as a `fluxcd/flux2` bump failure (#174).**
+  ShellCheck's release asset is a `.tar.xz`; a bare `ubuntu:24.04` (Cléa's
+  probe image) has no `xz`, so `curl` and the checksum both succeeded and
+  `tar -xJf` then died with "xz: Cannot exec: No such file or directory" —
+  after which `setup.sh` carried on, `flux` never got installed either, and
+  the probe blamed flux2 for an environment gap that had nothing to do with
+  it. Same shape `install-tflint.sh` already hit and fixed for `unzip`:
+  install `xz-utils` when `xz` is missing and apt is available, refuse
+  by name otherwise. Reproduced the exact failure in a bare `ubuntu:24.04`
+  container (red without the fix, green with it, idempotent on a second run).
 - **`feint.sh` checked whether the emulator had restarted exactly once, with
   no retry (#169).** `feint start` returning — even after printing its own
   "listening on ..." line — does not guarantee `feint status` already

--- a/scripts/dev/check-tool-pins.sh
+++ b/scripts/dev/check-tool-pins.sh
@@ -31,6 +31,7 @@ cd "$ROOT" || exit 1
 
 declare -A ALLOW=(
   [unzip]="generic OS utility (unpacks vendored downloads) — no meaningful version to track"
+  [xz-utils]="generic OS utility (unpacks vendored downloads, e.g. shellcheck's .tar.xz) — no meaningful version to track"
   [zstd]="generic OS utility (talos image build)"
   [qemu-utils]="generic OS utility (talos image build)"
   [gnupg]="generic OS utility (backup encryption, Zabbly key verification)"

--- a/scripts/internal/install-shellcheck.sh
+++ b/scripts/internal/install-shellcheck.sh
@@ -50,6 +50,20 @@ case "$(uname -s)-$(uname -m)" in
   *) echo "✗ no published shellcheck binary for $(uname -s)-$(uname -m)" >&2; exit 1 ;;
 esac
 
+# ShellCheck ships a .tar.xz, and a bare ubuntu:24.04 has no xz — same gap
+# install-tflint.sh already hit and fixed for unzip (#174): the extract died
+# with "tar (child): xz: Cannot exec: No such file or directory" after the
+# download and checksum had both already succeeded, which read as a bump
+# failure in Cléa's probe when the actual cause was never reached.
+if ! command -v xz >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    $SUDO apt-get update -qq && $SUDO apt-get install -y -qq xz-utils
+  else
+    echo "✗ xz is required to extract shellcheck's release archive, and I cannot install it here" >&2
+    exit 1
+  fi
+fi
+
 base="https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
Closes #174.

## What happened

ShellCheck's release asset is a `.tar.xz`. A bare `ubuntu:24.04` — Cléa's own probe image (`scripts/clea/probe.sh`'s `start_box()`, which deliberately installs only `curl ca-certificates` and treats anything else the installer needs as a finding, not a prerequisite to paper over) — has no `xz`. `curl` and the checksum both succeed; `tar -xJf` then dies with `xz: Cannot exec: No such file or directory`. `setup.sh` doesn't stop there, so it carries on toward installing flux2, which then also comes up missing (`flux: command not found`) — and the probe reports the *flux2* bump as failed, permanently, for a reason that has nothing to do with flux2.

## Fix

`scripts/internal/install-shellcheck.sh`: same shape `install-tflint.sh` already hit and fixed for `unzip` — check for `xz`, install `xz-utils` via apt when missing, refuse by name if apt isn't available. `scripts/dev/check-tool-pins.sh`'s `ALLOW` list gets the same generic-OS-utility entry `unzip` already has, so the new unpinned `apt-get install xz-utils` doesn't trip `task lint`.

## Proof

Reproduced the exact failure in a bare `ubuntu:24.04` container — the same image Cléa's probe uses — rather than trusting the diagnosis:

```
# pre-fix install-shellcheck.sh in a bare ubuntu:24.04:
/tmp/tmp.cIn0tYf3f8/shellcheck-v0.11.0.linux.x86_64.tar.xz: OK
tar (child): xz: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
RC=2

# post-fix, same image:
Setting up xz-utils (5.6.1+really5.4.5-1ubuntu0.3) ...
/tmp/tmp.4yPy2pT7co/shellcheck-v0.11.0.linux.x86_64.tar.xz: OK
installed shellcheck 0.11.0 → /tmp/bin/shellcheck
RC=0
ShellCheck - shell script analysis tool
version: 0.11.0
```

Also confirmed idempotent: a second run with `xz-utils` already present still exits 0.

## Rung reached: mocked

- `task lint` (including the new `check-tool-pins.sh` entry), `task test-scripts`, `task test` 61/61, `task render-check`, `task validate ROOT=cluster` / `ROOT=talos-image` — green
- `checkov` 32/0, `test-checkov-custom-checks.sh` 6/0, `check-gitleaks-rules.sh` green, `gitleaks git -c .gitleaks-envdata.toml` on `origin/main..HEAD` — no leaks
- `shellcheck -S error` and `bash -n` on the changed script — clean
- No IPv4 literal in the diff

**Not run here**: Cléa's own scheduled `fluxcd/flux2` probe against the real image — the reproduction above uses the same base image and the same install path, but the live confirmation ("does flux2 v2.9.5 now probe green, or fail on something that's actually about flux2") happens on Cléa's next scheduled run against `main`.

Assisted-by: Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_