### PR TITLE
feat(dev): resolve flux-install.yaml's image tags to their ghcr digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ in git. 0.1.0 is the first entry describing something proven.
 
 ## [Unreleased]
 
+### Added
+
+- **`task check-flux-digests`: the network half of #119.** `flux-install.yaml`
+  pins its seven controller images by tag only — a tag force-moved upstream
+  changes not one byte of the committed YAML, so `task render-check` sees
+  nothing, Cléa has no `# renovate:` anchor on these lines, and Trivy skips
+  the file. `scripts/dev/check-flux-image-digests.sh` resolves each tag to
+  the digest ghcr.io serves today (an anonymous token, same as `docker pull`)
+  and compares it to `flux-image-digests.lock`, recorded alongside
+  `upstream-artifacts.lock`. Needs the network but never a cloud account, so
+  it stays out of `task lint`. Proven by mutating one recorded digest: the
+  check went red naming the drift, then green again once restored.
+
 ### Fixed
 
 - **`install-shellcheck.sh` died extracting its own download on a bare box,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1312,6 +1312,14 @@ tasks:
       # This reads the EFFECTIVE settings the committed ConfigMap carries.
       - python3 scripts/ops/check-cilium-effective-config.py
 
+  check-flux-digests:
+    desc: >-
+      Resolve flux-install.yaml's 7 tag-pinned images to their ghcr.io digest and compare to
+      upstream-artifacts.lock's sibling (#119). Needs the network, never a cloud account — not part
+      of `task lint`, which must stay offline. Usage: task check-flux-digests [-- --write]
+    cmds:
+      - ./scripts/dev/check-flux-image-digests.sh {{.CLI_ARGS}}
+
   kubeconfig:
     desc: >-
       Retrieve kubeconfig/talosconfig from OpenTofu outputs (re-inits the backend, so this works from a cold

--- a/infrastructure/opentofu/cluster/bootstrap-manifests/flux-image-digests.lock
+++ b/infrastructure/opentofu/cluster/bootstrap-manifests/flux-image-digests.lock
@@ -1,0 +1,7 @@
+ghcr.io/fluxcd/helm-controller:v1.6.3 sha256:16ada99456385100698a5d7adf90aba8a2089d987ab541c9566b6d7b0e897038
+ghcr.io/fluxcd/image-automation-controller:v1.2.3 sha256:81128adfd127601530d3dffc1deaf7c9eeec5b9aa555b3ab80cab37fa5d909a4
+ghcr.io/fluxcd/image-reflector-controller:v1.2.3 sha256:a47e09e024a9ff2ea4f3878a1b90c2850134cfdc8b292ec52268dbc1e57e1a4c
+ghcr.io/fluxcd/kustomize-controller:v1.9.4 sha256:2b8bec54ffb6caf421bd2a6c005d27f567d5dd4db7feb55794fb51fcabd69b8f
+ghcr.io/fluxcd/notification-controller:v1.9.2 sha256:9ce503e7bcb8493fafe2aaef0c2ac4396df4f6890256acf9cd444a2dcd2a69ed
+ghcr.io/fluxcd/source-controller:v1.9.3 sha256:ff8f3c92f1bcb433e858c948040c3a3393fe73f5dd72048a4502bfaf0a4c26cd
+ghcr.io/fluxcd/source-watcher:v2.2.2 sha256:1d59f752ecf520d1dc56ca413749dfab507497dd363639b6fbaf5036850e05c7

--- a/scripts/dev/check-flux-image-digests.sh
+++ b/scripts/dev/check-flux-image-digests.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# flux-install.yaml pins its seven controller images by TAG only (#119) — a tag
+# force-moved upstream changes not one byte of the committed YAML, so nothing
+# in this repository would notice: `task render-check` re-renders from the
+# same pinned tag, Cléa has no `# renovate:` anchor on these lines, and Trivy
+# has this file in `skip-files`. This is the OTHER half of #119 (the offline
+# half — sha256 of the file itself — is upstream-artifacts.lock): resolve each
+# tag to the digest ghcr.io serves TODAY and compare it to the one recorded
+# below the last time this ran.
+#
+# Needs the network (an anonymous ghcr.io token, same as `docker pull` would
+# use) but never a cloud account — same rung distinction Cléa's probes draw.
+# Not part of `task lint`, which must stay fully offline.
+#
+# Usage:
+#   check-flux-image-digests.sh          # compare against the recorded lock
+#   check-flux-image-digests.sh --write  # resolve current digests and rewrite the lock
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="${ROOT}/infrastructure/opentofu/cluster/bootstrap-manifests/flux-install.yaml"
+LOCK="${ROOT}/infrastructure/opentofu/cluster/bootstrap-manifests/flux-image-digests.lock"
+WRITE=false
+[[ "${1:-}" == "--write" ]] && WRITE=true
+
+[ -f "$MANIFEST" ] || { echo "✗ ${MANIFEST} is missing" >&2; exit 1; }
+
+# ghcr.io/fluxcd/<name>:<tag> — every controller image flux-install.yaml pins,
+# in the order they appear. `sort -u` because two containers can share one image.
+mapfile -t REFS < <(grep -oE 'ghcr\.io/fluxcd/[a-z-]+:v[0-9.]+' "$MANIFEST" | sort -u)
+[ "${#REFS[@]}" -gt 0 ] || { echo "✗ no ghcr.io/fluxcd/* image ref found in ${MANIFEST}" >&2; exit 1; }
+
+resolve_digest() { # <image> <tag>
+  local image="$1" tag="$2" token
+  token="$(curl -fsS "https://ghcr.io/token?scope=repository:fluxcd/${image}:pull" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+  curl -fsS -D - -o /dev/null \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/fluxcd/${image}/manifests/${tag}" |
+    grep -i '^docker-content-digest:' | tr -d '\r' | awk '{print $2}'
+}
+
+if $WRITE; then
+  : >"$LOCK"
+  for ref in "${REFS[@]}"; do
+    image="${ref#ghcr.io/fluxcd/}"; image="${image%%:*}"; tag="${ref##*:}"
+    digest="$(resolve_digest "$image" "$tag")"
+    [ -n "$digest" ] || { echo "✗ ${ref} — ghcr.io returned no Docker-Content-Digest" >&2; exit 1; }
+    printf '%s %s\n' "$ref" "$digest" >>"$LOCK"
+    echo "  recorded ${ref} -> ${digest}"
+  done
+  echo "OK — ${LOCK} written."
+  exit 0
+fi
+
+[ -f "$LOCK" ] || { echo "✗ ${LOCK} is missing — run with --write to create it" >&2; exit 1; }
+declare -A RECORDED
+while read -r ref digest; do
+  [ -n "$ref" ] || continue
+  RECORDED["$ref"]="$digest"
+done <"$LOCK"
+
+FAIL=0
+for ref in "${REFS[@]}"; do
+  recorded="${RECORDED[$ref]:-}"
+  if [ -z "$recorded" ]; then
+    echo "✗ ${ref} — not in ${LOCK} (run --write)" >&2
+    FAIL=1
+    continue
+  fi
+  image="${ref#ghcr.io/fluxcd/}"; image="${image%%:*}"; tag="${ref##*:}"
+  live="$(resolve_digest "$image" "$tag")"
+  if [ -z "$live" ]; then
+    echo "✗ ${ref} — ghcr.io returned no Docker-Content-Digest" >&2
+    FAIL=1
+  elif [ "$live" != "$recorded" ]; then
+    echo "✗ ${ref} — tag now resolves to ${live}, recorded ${recorded} (re-run --write once you have verified the new digest)" >&2
+    FAIL=1
+  else
+    echo "  ✓ ${ref} — ${live}"
+  fi
+done
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "OK — every flux-install.yaml image tag still resolves to its recorded digest."
+fi
+exit "$FAIL"


### PR DESCRIPTION
Closes #119.

## What happened

`flux-install.yaml` pins its seven controller images by **tag only**:
`source-controller`, `kustomize-controller`, `helm-controller`,
`notification-controller`, `image-automation-controller`,
`image-reflector-controller`, `source-watcher`. A tag force-moved upstream
does not change one byte of the committed YAML, so nothing in this
repository would notice: `task render-check` re-renders from the same
pinned tag, Cléa has no `# renovate:` anchor on these lines, and Trivy has
this file in `skip-files`.

The offline half of #119 — `upstream-artifacts.lock`, the sha256 of the
committed file itself — already landed in #160. It catches the file
changing under a fixed tag; it cannot catch the *tag* silently starting to
resolve to different bits upstream, since the committed file would not
change at all.

## Fix

`scripts/dev/check-flux-image-digests.sh`: for each `ghcr.io/fluxcd/*`
image ref in `flux-install.yaml`, get an anonymous ghcr.io token (same as
`docker pull` would use), resolve the tag's current `Docker-Content-Digest`,
and compare it to `flux-image-digests.lock` (recorded alongside
`upstream-artifacts.lock`, same idiom). A mismatch fails loud, naming both
digests.

This needs the network but never a cloud account — the same rung
distinction Cléa's own probes draw — so it does not belong in `task lint`,
which must stay fully offline. Wired as its own `task check-flux-digests`
target instead; wiring it into Cléa's daily scheduled lane
(`.github/workflows/clea.yml`) is left out on purpose, since this routine
never touches `.github/**`.

## Proof

Ran the check for real against ghcr.io (all 7 images resolved and matched
on first run, seeding the lock). Then proved the failure mode the repo's
way — mutated one recorded digest and watched it go red naming the drift,
restored it and watched it go green again:

```
✗ ghcr.io/fluxcd/source-controller:v1.9.3 — tag now resolves to
  sha256:ff8f3c92..., recorded sha256:0000...0000
  (re-run --write once you have verified the new digest)
```

```
OK — every flux-install.yaml image tag still resolves to its recorded digest.
```

## Rung reached: mocked + live network (never real cloud)

- `task lint` (16/16), `task test-scripts`, `task test` 61/61, `task
  render-check`, `task validate ROOT=cluster` / `ROOT=talos-image` — green
- `checkov` 32/0 (direct run — `trivy` is not installed in this sandbox,
  a known environment limit; relies on CI), `test-checkov-custom-checks.sh`
  6/0, `check-gitleaks-rules.sh`, `gitleaks dir` (dir scan) and `gitleaks
  git -c .gitleaks-envdata.toml` on `origin/main..HEAD` — all clean
- `shellcheck -S error` and `bash -n` on the new script — clean
- The new check itself was run live against ghcr.io four times in this
  session (initial resolve, clean pass, induced failure, restored pass) —
  this is the proof that matters for a check whose whole job is talking to
  a real registry
- No IPv4 literal in the diff

**Not run here**: wiring `task check-flux-digests` into a scheduled
workflow — left for a human decision, since that touches `.github/**`.

---
Assisted-by: Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FvN18eTRXsy5Fsuazaae)_